### PR TITLE
feat(cards): Card-Store + DDL [Proaktiver Recall v1, Task 3]

### DIFF
--- a/core/src/hydrahive/db/_mirror_cards.py
+++ b/core/src/hydrahive/db/_mirror_cards.py
@@ -1,0 +1,112 @@
+"""Mirror — Card-Store: abgeleitete, recompute-safe Gist-Cards, getrennt vom
+kuratierten Memory. Tabelle/Embedding-Spalte siehe `_mirror_ddl` (cards in
+DDL_TABLES + ensure_embed_col(table="cards")). Listing/Suche für Recall A+C
+folgen in eigenen Funktionen (Tasks 5/6)."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from hydrahive.db._mirror_cards_model import Card
+from hydrahive.db._mirror_search import _dt, _pool
+
+logger = logging.getLogger(__name__)
+
+_COLS = (
+    "card_id, session_id, gist, valence, salience, groundedness, topics, "
+    "agent_id, agent_name, username, created_at, source, confidence, "
+    "superseded_by, supersedes, schema_version, computed_at, consolidation_model, "
+    "embedding, embedding_model, embedded_at"
+)
+
+# Felder ohne embedding — embedding (großer Vektor) wird beim Lesen nicht gebraucht.
+_READ_COLS = (
+    "card_id, session_id, gist, valence, salience, groundedness, topics, "
+    "agent_id, agent_name, username, created_at, source, confidence, "
+    "superseded_by, supersedes, schema_version, computed_at, consolidation_model"
+)
+
+
+def _vec_str(embedding: list[float] | None) -> str | None:
+    """pgvector-Literal wie in _mirror_embed/_mirror_search ('[a,b,c]' → $::text::vector)."""
+    if not embedding:
+        return None
+    return "[" + ",".join(str(x) for x in embedding) + "]"
+
+
+async def upsert_card(card: Card, embedding: list[float] | None = None) -> None:
+    """Schreibt/aktualisiert eine Card idempotent (ON CONFLICT card_id).
+    recompute-safe: derselbe card_id → genau eine Zeile, überschrieben."""
+    pool = _pool()
+    if not pool:
+        return
+    vec = _vec_str(embedding)
+    embed_model: str | None = None
+    if vec is not None:
+        from hydrahive.llm._config import load_config
+        embed_model = load_config().get("embed_model", "") or None
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO cards ({_COLS})
+                VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,$9,$10,$11,$12::jsonb,$13,
+                        $14::jsonb,$15::jsonb,$16,now(),$17,
+                        $18::text::vector,$19,
+                        CASE WHEN $18::text IS NULL THEN NULL ELSE now() END)
+                ON CONFLICT (card_id) DO UPDATE SET
+                    session_id=EXCLUDED.session_id, gist=EXCLUDED.gist,
+                    valence=EXCLUDED.valence, salience=EXCLUDED.salience,
+                    groundedness=EXCLUDED.groundedness, topics=EXCLUDED.topics,
+                    agent_id=EXCLUDED.agent_id, agent_name=EXCLUDED.agent_name,
+                    username=EXCLUDED.username, created_at=EXCLUDED.created_at,
+                    source=EXCLUDED.source, confidence=EXCLUDED.confidence,
+                    superseded_by=EXCLUDED.superseded_by, supersedes=EXCLUDED.supersedes,
+                    schema_version=EXCLUDED.schema_version, computed_at=EXCLUDED.computed_at,
+                    consolidation_model=EXCLUDED.consolidation_model,
+                    embedding=EXCLUDED.embedding, embedding_model=EXCLUDED.embedding_model,
+                    embedded_at=EXCLUDED.embedded_at
+                """,
+                card.card_id, card.session_id, card.gist, card.valence, card.salience,
+                card.groundedness, json.dumps(card.topics or []), card.agent_id,
+                card.agent_name, card.username,
+                _dt(card.created_at) if card.created_at else None,
+                json.dumps(card.source) if card.source is not None else None,
+                card.confidence, json.dumps(card.superseded_by or []),
+                json.dumps(card.supersedes or []), card.schema_version,
+                card.consolidation_model, vec, embed_model,
+            )
+    except Exception as e:
+        logger.warning("upsert_card(%s) fehlgeschlagen: %s", card.card_id, e)
+
+
+async def get_card(card_id: str) -> dict[str, Any] | None:
+    pool = _pool()
+    if not pool:
+        return None
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_READ_COLS} FROM cards WHERE card_id = $1", card_id
+            )
+        return dict(row) if row else None
+    except Exception as e:
+        logger.warning("get_card(%s) fehlgeschlagen: %s", card_id, e)
+        return None
+
+
+async def wipe_cards() -> int:
+    """Löscht alle Cards (für wipe-and-rebuild der abgeleiteten Schicht).
+    Berührt NUR die cards-Tabelle, nie das kuratierte Memory."""
+    pool = _pool()
+    if not pool:
+        return 0
+    try:
+        async with pool.acquire() as conn:
+            status = await conn.execute("DELETE FROM cards")
+        tail = status.split()[-1] if status else ""
+        return int(tail) if tail.isdigit() else 0
+    except Exception as e:
+        logger.warning("wipe_cards fehlgeschlagen: %s", e)
+        return 0

--- a/core/src/hydrahive/db/_mirror_ddl.py
+++ b/core/src/hydrahive/db/_mirror_ddl.py
@@ -130,6 +130,29 @@ CREATE INDEX IF NOT EXISTS errors_log_source   ON errors_log (source, created_at
 CREATE INDEX IF NOT EXISTS errors_log_severity ON errors_log (severity, created_at);
 CREATE INDEX IF NOT EXISTS errors_log_created  ON errors_log (created_at);
 CREATE INDEX IF NOT EXISTS errors_log_type     ON errors_log (error_type, created_at);
+CREATE TABLE IF NOT EXISTS cards (
+  card_id             TEXT PRIMARY KEY,
+  session_id          TEXT NOT NULL,
+  gist                TEXT,
+  valence             TEXT,
+  salience            TEXT,
+  groundedness        TEXT,
+  topics              JSONB,
+  agent_id            TEXT,
+  agent_name          TEXT,
+  username            TEXT,
+  created_at          TIMESTAMPTZ,
+  source              JSONB,
+  confidence          REAL NOT NULL DEFAULT 1.0,
+  superseded_by       JSONB,
+  supersedes          JSONB,
+  schema_version      INTEGER NOT NULL DEFAULT 1,
+  computed_at         TIMESTAMPTZ,
+  consolidation_model TEXT
+);
+CREATE INDEX IF NOT EXISTS cards_session          ON cards (session_id);
+CREATE INDEX IF NOT EXISTS cards_agent            ON cards (agent_id, created_at);
+CREATE INDEX IF NOT EXISTS cards_recency_salience ON cards (created_at DESC, salience);
 """
 
 # Separat, weil CREATE OR REPLACE VIEW Ownership der View erfordert.
@@ -181,8 +204,11 @@ LEFT JOIN (
 DDL_BASE = DDL_TABLES + DDL_VIEW
 
 
-async def ensure_embed_col(conn) -> None:
-    """Legt embedding-Spalte mit der richtigen Dimension an oder passt sie an."""
+async def ensure_embed_col(conn, table: str = "events") -> None:
+    """Legt die embedding-Spalte einer Tabelle mit der richtigen Dimension an
+    oder passt sie an. Generisch über `table` (events, cards) — dieselbe
+    Dim-Quelle (`embed_model`), damit beide im selben pgvector-Raum vergleichbar
+    sind. `table` ist intern/vertrauenswürdig (kein User-Input)."""
     from hydrahive.llm._config import load_config
     from hydrahive.llm.embed import dim_for_model
     model = load_config().get("embed_model", "")
@@ -190,36 +216,36 @@ async def ensure_embed_col(conn) -> None:
     if not dim:
         return
 
-    row = await conn.fetchrow("""
+    row = await conn.fetchrow(f"""
         SELECT format_type(atttypid, atttypmod) AS coltype
         FROM pg_attribute
-        WHERE attrelid = 'events'::regclass AND attname = 'embedding' AND attnum > 0
+        WHERE attrelid = '{table}'::regclass AND attname = 'embedding' AND attnum > 0
     """)
     if row:
         if row["coltype"] == f"vector({dim})":
             return
-        logger.info("Embedding-Dimension geändert (%s → vector(%d)) — Spalte neu anlegen", row["coltype"], dim)
-        await conn.execute("ALTER TABLE events DROP COLUMN IF EXISTS embedding")
-        await conn.execute("ALTER TABLE events DROP COLUMN IF EXISTS embedding_model")
-        await conn.execute("ALTER TABLE events DROP COLUMN IF EXISTS embedded_at")
+        logger.info("Embedding-Dimension geändert (%s → vector(%d)) auf %s — Spalte neu anlegen", row["coltype"], dim, table)
+        await conn.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS embedding")
+        await conn.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS embedding_model")
+        await conn.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS embedded_at")
 
-    await conn.execute(f"ALTER TABLE events ADD COLUMN IF NOT EXISTS embedding vector({dim})")
-    await conn.execute("ALTER TABLE events ADD COLUMN IF NOT EXISTS embedding_model TEXT")
-    await conn.execute("ALTER TABLE events ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMPTZ")
+    await conn.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS embedding vector({dim})")
+    await conn.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS embedding_model TEXT")
+    await conn.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMPTZ")
     try:
-        await conn.execute("""
-            CREATE INDEX IF NOT EXISTS events_embedding_hnsw
-            ON events USING hnsw (embedding vector_cosine_ops)
+        await conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {table}_embedding_hnsw
+            ON {table} USING hnsw (embedding vector_cosine_ops)
             WITH (m = 16, ef_construction = 64)
         """)
-        logger.info("Embedding-Spalte vector(%d) + HNSW-Index bereit", dim)
+        logger.info("Embedding-Spalte vector(%d) + HNSW-Index auf %s bereit", dim, table)
     except Exception:
         try:
-            await conn.execute("""
-                CREATE INDEX IF NOT EXISTS events_embedding_ivfflat
-                ON events USING ivfflat (embedding vector_cosine_ops)
+            await conn.execute(f"""
+                CREATE INDEX IF NOT EXISTS {table}_embedding_ivfflat
+                ON {table} USING ivfflat (embedding vector_cosine_ops)
                 WITH (lists = 100)
             """)
-            logger.info("Embedding-Spalte vector(%d) + IVFFlat-Index bereit (HNSW nicht unterstützt)", dim)
+            logger.info("Embedding-Spalte vector(%d) + IVFFlat-Index auf %s bereit (HNSW nicht unterstützt)", dim, table)
         except Exception as e:
-            logger.warning("Kein Vektor-Index angelegt (pgvector zu alt?): %s — Suche läuft per Seq-Scan", e)
+            logger.warning("Kein Vektor-Index auf %s angelegt (pgvector zu alt?): %s — Suche läuft per Seq-Scan", table, e)

--- a/core/src/hydrahive/db/mirror.py
+++ b/core/src/hydrahive/db/mirror.py
@@ -70,6 +70,10 @@ async def init() -> None:
                 await ensure_embed_col(conn)
             except Exception as ee:
                 logger.warning("PG-Mirror: Embedding-Spalte konnte nicht angepasst werden (Rechte?): %s", ee)
+            try:
+                await ensure_embed_col(conn, table="cards")
+            except Exception as ce:
+                logger.warning("PG-Mirror: cards-Embedding-Spalte konnte nicht angepasst werden (Rechte?): %s", ce)
         logger.info("PG-Mirror bereit")
     except Exception as e:
         logger.warning("PG-Mirror init fehlgeschlagen — Mirror deaktiviert: %s", e)

--- a/core/tests/test_mirror_cards.py
+++ b/core/tests/test_mirror_cards.py
@@ -1,0 +1,35 @@
+"""Lokal testbare Oberfläche von Task 3 (Card-Store).
+
+Die echten PG-Operationen (upsert/get/wipe gegen den Mirror) testet Till nach
+Deploy — hier nur Import-Smoke + DDL-/Signatur-Checks + der reine Vektor-Helfer,
+alles ohne PG.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def test_card_store_imports():
+    from hydrahive.db._mirror_cards import get_card, upsert_card, wipe_cards
+    assert callable(upsert_card) and callable(get_card) and callable(wipe_cards)
+
+
+def test_cards_table_in_ddl():
+    from hydrahive.db._mirror_ddl import DDL_TABLES
+    assert "CREATE TABLE IF NOT EXISTS cards" in DDL_TABLES
+    # recompute-safe braucht card_id als Konflikt-Anker (ON CONFLICT card_id)
+    assert "card_id             TEXT PRIMARY KEY" in DDL_TABLES
+
+
+def test_ensure_embed_col_is_table_generic():
+    from hydrahive.db._mirror_ddl import ensure_embed_col
+    params = inspect.signature(ensure_embed_col).parameters
+    assert "table" in params
+    assert params["table"].default == "events"  # events-Verhalten unverändert
+
+
+def test_vec_str_matches_mirror_embed_format():
+    from hydrahive.db._mirror_cards import _vec_str
+    assert _vec_str(None) is None
+    assert _vec_str([]) is None
+    assert _vec_str([1.0, 2.5, -3.0]) == "[1.0,2.5,-3.0]"


### PR DESCRIPTION
## Was
Task 3 des Plans `docs/superpowers/plans/2026-05-29-proactive-recall.md` — der **Card-Store** (L2/L3-Fundament) für Proaktiven Recall v1 (SPEC `56aaa82`).

## Dateien
- `db/_mirror_cards.py` (neu) — `upsert_card` (ON CONFLICT card_id, recompute-safe), `get_card`, `wipe_cards`.
- `db/_mirror_ddl.py` — `cards`-Tabelle in `DDL_TABLES`; `ensure_embed_col` auf `(conn, table="events")` generalisiert.
- `db/mirror.py` — `init()` ruft `ensure_embed_col(conn, table="cards")` (analog events).
- `tests/test_mirror_cards.py` (neu).

## Design-Entscheidungen (Abweichungen vom Plan, bewusst — bitte prüfen)
1. **`_pool()`-Konvention statt `pool`-Arg:** Store-Ops folgen `_mirror_sessions`/`_mirror_search` + Schmieds `event_type_counts(session_id)` — konsistenter als die Plan-Literal-Signaturen `(pool, …)`.
2. **`ensure_embed_col` generalisiert** (kein Duplikat, CLAUDE.md-Regel) — events-Verhalten unverändert (default `table="events"`); cards nutzt dieselbe Dim-Quelle → gleicher pgvector-Raum.
3. **`cards` in `DDL_TABLES`** (wie alle Tabellen, via `init`) → kein separates `ensure_cards_table`.
4. **`mirror.py init` angefasst** (im Plan-Datei-Listing für Task 3 nicht genannt) — nötig, damit die cards-Embedding-Spalte beim Start entsteht.
5. **recompute-safe = idempotenter `ON CONFLICT(card_id)`-Upsert + stabile deterministische Felder** — NICHT byte-identischer Inhalt (gist/valence vom LLM sind nicht-deterministisch). Die „wipe→rebuild identisch"-Akzeptanz meint gleiche card_ids/keine Dubletten + stabile Heuristik-Felder.

## Verifikation
- ✅ **9 Tests grün** auf `.23` (echte Umgebung, `pip install -e core`): 4 Card-Store + 5 Task-1-Groundedness. Nicht nur Syntax.
- ⏳ **PG-Ops** (upsert/get/wipe gegen echten Mirror) = Till nach Deploy. Bitte Review-Fokus auf die untestbaren PG-Stellen:
  - `$18::text::vector` NULL-Handling im Upsert (embedding optional)
  - JSONB-Casts (`$N::jsonb`) für topics/source/superseded
  - `embedding_model` aus `load_config()` beim Schreiben
  - `wipe_cards` Status-Parsing (`"DELETE n"`)
  - cards-Embedding-Dim == events-Dim via generalisiertem `ensure_embed_col`

Nächste Tasks (4 Writer, 5+6 Recall) bauen hierauf auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)