### PR TITLE
fix(modules): Hub-Cache heilt sich bei divergierter History selbst

### DIFF
--- a/core/src/hydrahive/modules/hub_client.py
+++ b/core/src/hydrahive/modules/hub_client.py
@@ -58,7 +58,12 @@ def _refresh_one(cache: Path, url: str) -> None:
     if (cache / ".git").exists():
         result = _run_git(["pull", "--ff-only"], cwd=cache)
         if result.returncode != 0:
-            raise HubError(f"git pull failed: {result.stderr.strip()}")
+            # ff-only schlägt fehl, wenn die Hub-History divergiert (z.B. nach
+            # einem force-push/History-Rewrite im Hub-Repo). Der Cache ist eine
+            # REINE Spiegelung ohne lokale Commits — es gibt nichts zu verlieren.
+            # Statt das Update für den Nutzer zu blockieren (der keine Shell hat),
+            # hart auf den Remote-Stand re-synchronisieren. Selbstheilend.
+            _resync_hard(cache, result.stderr.strip())
         return
     if cache.exists():
         import shutil
@@ -66,6 +71,22 @@ def _refresh_one(cache: Path, url: str) -> None:
     result = _run_git(["clone", "--depth=1", "--filter=blob:none", url, str(cache)])
     if result.returncode != 0:
         raise HubError(f"git clone failed: {result.stderr.strip()}")
+
+
+def _resync_hard(cache: Path, pull_error: str) -> None:
+    """Hub-Cache hart auf den Remote-Stand zwingen (Fallback bei divergierter
+    History). Sicher, weil der Cache nur gespiegelt wird — keine lokale Arbeit.
+
+    Ermittelt den aktuellen Branch des Caches und setzt ihn auf origin/<branch>.
+    """
+    logger.warning("Hub pull --ff-only fehlgeschlagen, re-sync hart auf Remote: %s", pull_error)
+    fetched = _run_git(["fetch", "origin"], cwd=cache)
+    if fetched.returncode != 0:
+        raise HubError(f"git fetch failed: {fetched.stderr.strip()}")
+    head = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cache).stdout.strip() or "main"
+    reset = _run_git(["reset", "--hard", f"origin/{head}"], cwd=cache)
+    if reset.returncode != 0:
+        raise HubError(f"git reset failed: {reset.stderr.strip()}")
 
 
 def refresh() -> None:

--- a/core/tests/test_module_hub.py
+++ b/core/tests/test_module_hub.py
@@ -189,3 +189,96 @@ def test_installer_cache_path_for_uses_hub(mod_env, monkeypatch):
     )
     (extra / "rom").mkdir()
     assert installer._cache_path_for("rom") == (extra / "rom").resolve()
+
+
+# --- Selbstheilung bei divergierter Hub-History --------------------------
+
+def _fake_proc(returncode=0, stdout="", stderr=""):
+    """Minimaler CompletedProcess-Ersatz für gemockte _run_git-Aufrufe."""
+    from types import SimpleNamespace
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_refresh_one_ff_pull_erfolg_kein_reset(mod_env, tmp_path):
+    """Normaler Fall: pull --ff-only klappt → kein fetch/reset-Fallback."""
+    from hydrahive.modules import hub_client
+
+    cache = tmp_path / "hub"
+    (cache / ".git").mkdir(parents=True)
+    calls = []
+
+    def fake_git(args, cwd=None):
+        calls.append(args)
+        return _fake_proc(returncode=0)
+
+    with patch.object(hub_client, "_run_git", side_effect=fake_git):
+        hub_client._refresh_one(cache, "http://x/y.git")
+
+    assert calls == [["pull", "--ff-only"]]  # nur pull, kein reset
+
+
+def test_refresh_one_divergenz_heilt_per_reset(mod_env, tmp_path):
+    """ff-only schlägt fehl (divergierte History) → fetch + reset --hard origin/<branch>."""
+    from hydrahive.modules import hub_client
+
+    cache = tmp_path / "hub"
+    (cache / ".git").mkdir(parents=True)
+    calls = []
+
+    def fake_git(args, cwd=None):
+        calls.append(args)
+        if args[:2] == ["pull", "--ff-only"]:
+            return _fake_proc(returncode=1, stderr="Not possible to fast-forward")
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return _fake_proc(returncode=0, stdout="main\n")
+        return _fake_proc(returncode=0)
+
+    with patch.object(hub_client, "_run_git", side_effect=fake_git):
+        hub_client._refresh_one(cache, "http://x/y.git")  # darf NICHT werfen
+
+    assert ["pull", "--ff-only"] in calls
+    assert ["fetch", "origin"] in calls
+    assert ["reset", "--hard", "origin/main"] in calls
+
+
+def test_refresh_one_divergenz_nutzt_aktuellen_branch(mod_env, tmp_path):
+    """Der hart resyncte Branch folgt dem tatsächlichen HEAD des Caches."""
+    from hydrahive.modules import hub_client
+
+    cache = tmp_path / "hub"
+    (cache / ".git").mkdir(parents=True)
+    calls = []
+
+    def fake_git(args, cwd=None):
+        calls.append(args)
+        if args[:2] == ["pull", "--ff-only"]:
+            return _fake_proc(returncode=1, stderr="diverged")
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return _fake_proc(returncode=0, stdout="release\n")
+        return _fake_proc(returncode=0)
+
+    with patch.object(hub_client, "_run_git", side_effect=fake_git):
+        hub_client._refresh_one(cache, "http://x/y.git")
+
+    assert ["reset", "--hard", "origin/release"] in calls
+
+
+def test_refresh_one_reset_fehler_wirft(mod_env, tmp_path):
+    """Schlägt sogar der Reset fehl, wird ein HubError gemeldet (nicht still)."""
+    from hydrahive.modules import hub_client
+
+    cache = tmp_path / "hub"
+    (cache / ".git").mkdir(parents=True)
+
+    def fake_git(args, cwd=None):
+        if args[:2] == ["pull", "--ff-only"]:
+            return _fake_proc(returncode=1, stderr="diverged")
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return _fake_proc(returncode=0, stdout="main\n")
+        if args[0] == "reset":
+            return _fake_proc(returncode=1, stderr="reset boom")
+        return _fake_proc(returncode=0)
+
+    with patch.object(hub_client, "_run_git", side_effect=fake_git):
+        with pytest.raises(hub_client.HubError, match="git reset failed"):
+            hub_client._refresh_one(cache, "http://x/y.git")


### PR DESCRIPTION
## Problem

`git pull --ff-only` im Hub-Cache bricht hart ab (`HubError`), sobald die Hub-History divergiert — z.B. nach einem force-push/History-Rewrite im Modul-Repo. 

**Folge:** Modul-Updates schlagen für **alle bestehenden Installationen** fehl. Nutzer ohne Shell-Zugang können den Cache nicht manuell reparieren und sitzen mit einem kaputten Update-Button fest.

## Fix

Bei fehlgeschlagenem `ff-only` fällt `_refresh_one()` auf einen harten Re-Sync zurück: `fetch origin` + `reset --hard origin/<branch>`.

Das ist **sicher**, weil der Hub-Cache eine reine Spiegelung ohne lokale Commits ist — es gibt nichts zu verlieren. Updates heilen sich so beim nächsten Klick selbst, **ohne Shell-Eingriff**.

## Warum das wichtig ist

~40-50 Installationen ohne Shell-Kenntnisse. Ein kaputter Update-Mechanismus durch einen Hub-History-Eingriff darf sich nicht in manuelle Reparatur pro Nutzer übersetzen.

## Tests

+4 neue Tests:
- ff-Pull-Erfolg → kein Reset-Fallback
- Divergenz → heilt per fetch+reset
- Reset folgt dem tatsächlichen HEAD-Branch
- Reset-Fehler meldet HubError (nicht still)

18 passed. `hub_client.py` bleibt unter 200 Zeilen.