### PR TITLE
feat(settings): zentrale Einstellungsseite (Gerüst, 3-Spalten)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { SkillsPage } from "@/features/skills/SkillsPage"
 import { CredentialsPage } from "@/features/credentials/CredentialsPage"
 import { SystemPage } from "@/features/system/SystemPage"
 import { SettingsPage } from "@/features/system/SettingsPage"
+import { SettingsHubPage } from "@/features/settings/SettingsHubPage"
 import { UsersPage } from "@/features/users/UsersPage"
 import { ProfilePage } from "@/features/profile/ProfilePage"
 import { PluginsPage } from "@/features/plugins/PluginsPage"
@@ -90,6 +91,7 @@ export default function App() {
           <Route path="mcp" element={<McpPage />} />
           <Route path="skills" element={<SkillsPage />} />
           <Route path="credentials" element={<CredentialsPage />} />
+          <Route path="settings" element={<SettingsHubPage />} />
           <Route path="system" element={<SystemPage />} />
           <Route path="system/settings" element={<AdminGuard><SettingsPage /></AdminGuard>} />
           <Route path="users" element={<AdminGuard><UsersPage /></AdminGuard>} />

--- a/frontend/src/features/settings/ContentArea.tsx
+++ b/frontend/src/features/settings/ContentArea.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react"
+import { Link } from "react-router-dom"
+import { ExternalLink } from "lucide-react"
+import type { SettingsGroup } from "./registry"
+
+interface Props {
+  group: SettingsGroup
+}
+
+/**
+ * Mittlerer Bereich: Karteikarten-Tabs oben + Inhalt darunter.
+ * Gerüst-Phase: der eigentliche Inhalt wird etappenweise migriert. Bis dahin
+ * zeigt jeder Tab einen Platzhalter + (falls vorhanden) einen Link zur
+ * bestehenden Seite, damit nichts unerreichbar ist.
+ */
+export function ContentArea({ group }: Props) {
+  const [tab, setTab] = useState(group.tabs[0] ?? "")
+
+  // Beim Gruppenwechsel auf den ersten Tab zurück.
+  useEffect(() => { setTab(group.tabs[0] ?? "") }, [group.id, group.tabs])
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Karteikarten */}
+      <div className="flex items-center gap-1 border-b border-white/8 px-4 pt-3">
+        {group.tabs.map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`rounded-t-lg px-3.5 py-2 text-sm transition-colors ${
+              tab === t
+                ? "bg-[#104E8B]/20 text-sky-200 border-b-2 border-sky-400"
+                : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[4%]"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {/* Inhalt */}
+      <div className="flex-1 overflow-y-auto p-5">
+        <div className="mx-auto max-w-3xl">
+          <div className="rounded-xl border border-white/8 bg-zinc-900/40 p-6">
+            <h3 className="text-base font-semibold text-zinc-100">{group.label} · {tab}</h3>
+            <p className="mt-2 text-sm text-zinc-400">
+              Dieser Bereich wird hierher umgezogen. Die Struktur steht — der
+              Inhalt folgt Schritt für Schritt.
+            </p>
+            {group.route && (
+              <Link
+                to={group.route}
+                className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#104E8B]/30 px-3.5 py-2 text-sm text-sky-200 ring-1 ring-inset ring-[#104E8B]/50 hover:bg-[#104E8B]/40 transition-colors"
+              >
+                <ExternalLink size={14} />
+                Aktuelle Seite öffnen
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/GroupList.tsx
+++ b/frontend/src/features/settings/GroupList.tsx
@@ -1,0 +1,41 @@
+import { SETTINGS_GROUPS, type SettingsGroup } from "./registry"
+
+interface Props {
+  role: string
+  activeId: string
+  onSelect: (g: SettingsGroup) => void
+}
+
+/** Linke Spalte: alle Settings-Hauptgruppen, logisch geordnet. */
+export function GroupList({ role, activeId, onSelect }: Props) {
+  const groups = SETTINGS_GROUPS.filter((g) => !g.adminOnly || role === "admin")
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="border-b border-white/8 px-4 py-3">
+        <h2 className="text-sm font-semibold text-zinc-200">Einstellungen</h2>
+        <p className="text-[11px] text-zinc-500">Gruppe wählen</p>
+      </div>
+      <nav className="flex-1 space-y-0.5 p-2">
+        {groups.map((g) => {
+          const Icon = g.icon
+          const active = g.id === activeId
+          return (
+            <button
+              key={g.id}
+              onClick={() => onSelect(g)}
+              className={`flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                active
+                  ? "bg-[#104E8B]/25 text-sky-200 ring-1 ring-inset ring-[#104E8B]/50"
+                  : "text-zinc-300 hover:bg-white/[5%]"
+              }`}
+            >
+              <Icon size={15} className="shrink-0" />
+              <span className="truncate">{g.label}</span>
+            </button>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/SettingsHubPage.tsx
+++ b/frontend/src/features/settings/SettingsHubPage.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { SETTINGS_GROUPS, type SettingsGroup } from "./registry"
+import { GroupList } from "./GroupList"
+import { ContentArea } from "./ContentArea"
+import { SubMenu } from "./SubMenu"
+
+/**
+ * Zentrale Einstellungsseite (unterm Zahnrad). 3-Spalten Master-Detail nach
+ * Tills Blueprint-Board, im Werkbank-Look (blauer Rahmen #104E8B):
+ *   links   = Hauptgruppen (Auswahl)
+ *   mitte   = Inhalt mit Karteikarten-Tabs
+ *   rechts  = kontextabhängiges Submenü (nur wenn group.hasSubmenu)
+ */
+export function SettingsHubPage() {
+  const role = useAuthStore((s) => s.role) ?? "user"
+  const groups = SETTINGS_GROUPS.filter((g) => !g.adminOnly || role === "admin")
+  const [active, setActive] = useState<SettingsGroup>(groups[0])
+  const [subItem, setSubItem] = useState<string | null>(null)
+
+  const selectGroup = (g: SettingsGroup) => {
+    setActive(g)
+    setSubItem(null)
+  }
+
+  return (
+    <div className="flex flex-col p-3 md:p-4 h-full">
+      <div
+        className="relative flex flex-1 overflow-hidden rounded-[28px] border border-[#104E8B]/70 shadow-2xl shadow-[0_0_50px_-12px_rgba(16,78,139,0.6)] backdrop-blur"
+      >
+        <div className="pointer-events-none absolute inset-0 rounded-[28px] ring-1 ring-inset ring-[#104E8B]/30" />
+
+        {/* Links: Hauptgruppen */}
+        <div className="w-56 shrink-0 border-r border-white/8 bg-zinc-950/50">
+          <GroupList role={role} activeId={active.id} onSelect={selectGroup} />
+        </div>
+
+        {/* Mitte: Inhalt mit Tabs */}
+        <div className="flex-1 min-w-0 bg-zinc-950/20">
+          <ContentArea group={active} />
+        </div>
+
+        {/* Rechts: Submenü — nur wenn die Gruppe eins braucht */}
+        {active.hasSubmenu && (
+          <div className="w-56 shrink-0 border-l border-white/8 bg-zinc-950/50">
+            <SubMenu group={active} activeItem={subItem} onSelect={setSubItem} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/SubMenu.tsx
+++ b/frontend/src/features/settings/SubMenu.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react"
+import { api } from "@/shared/api-client"
+import type { SettingsGroup } from "./registry"
+
+interface Props {
+  group: SettingsGroup
+  activeItem: string | null
+  onSelect: (id: string) => void
+}
+
+interface Entry { id: string; name: string }
+
+/**
+ * Rechte Spalte: kontextabhängiges Submenü. Bei "agenten" die Agenten, bei
+ * "projekte" die Projekte. Wird nur gerendert, wenn group.hasSubmenu — sonst
+ * blendet die Page diese Spalte komplett aus (Tills Vorgabe).
+ */
+export function SubMenu({ group, activeItem, onSelect }: Props) {
+  const [items, setItems] = useState<Entry[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    setLoading(true)
+    const url = group.id === "agents" ? "/agents"
+      : group.id === "projects" ? "/projects"
+      : null
+    if (!url) { setItems([]); setLoading(false); return }
+    api.get<Array<{ id: string; name?: string; config?: { identity?: string } }>>(url)
+      .then((res) => setItems((res || []).map((x) => ({
+        id: x.id,
+        name: x.config?.identity ? String(x.config.identity).slice(0, 28) : (x.name || x.id),
+      }))))
+      .catch(() => setItems([]))
+      .finally(() => setLoading(false))
+  }, [group.id])
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="border-b border-white/8 px-4 py-3">
+        <h2 className="text-sm font-semibold text-zinc-200">{group.submenuLabel ?? group.label}</h2>
+      </div>
+      <div className="flex-1 space-y-0.5 p-2">
+        {loading ? (
+          <div className="h-20 rounded-lg bg-zinc-900/50 animate-pulse" />
+        ) : items.length === 0 ? (
+          <p className="px-3 py-3 text-xs text-zinc-600">Keine Einträge.</p>
+        ) : (
+          items.map((it) => (
+            <button
+              key={it.id}
+              onClick={() => onSelect(it.id)}
+              className={`w-full truncate rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                activeItem === it.id
+                  ? "bg-[#104E8B]/25 text-sky-200"
+                  : "text-zinc-300 hover:bg-white/[5%]"
+              }`}
+            >
+              {it.name}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -1,0 +1,72 @@
+import {
+  Bot, FolderKanban, MessageCircle, Workflow, MoonStar, Sparkles, Server,
+  Puzzle, Globe, Cpu, Package, Boxes, Users, Key, BrainCircuit,
+  SlidersHorizontal, Database, Network, type LucideIcon,
+} from "lucide-react"
+
+/**
+ * Settings-Gruppen-Registry (SSOT für die linke Auswahl-Spalte).
+ *
+ * Entstanden aus Tills Blueprint-Board "einstellungsseite": EINE zentrale
+ * Settings-Seite, links die Hauptgruppen (logisch geordnet), Mitte der Inhalt
+ * mit Karteikarten, rechts ein kontextabhängiges Submenü (das z.B. bei
+ * "agenten" die Agenten listet) — wird ausgeblendet, wenn die Gruppe keins
+ * braucht (hasSubmenu=false).
+ *
+ * WICHTIG (Tills Vorgabe): hier NUR Einstellungen — Auswertungen/Statistiken
+ * bleiben auf den eigenen Feature-Seiten (z.B. Zahnfee-Auswertung getrennt vom
+ * Zahnfee-Setting).
+ *
+ * `tabs` = die Karteikarten oben im Inhaltsbereich. `route` (optional) verlinkt
+ * vorerst auf die bestehende Seite, solange der Inhalt noch nicht migriert ist
+ * (Gerüst-Ansatz: Struktur steht, Inhalt zieht etappenweise nach).
+ */
+export interface SettingsGroup {
+  id: string
+  label: string
+  icon: LucideIcon
+  hasSubmenu: boolean
+  submenuLabel?: string
+  tabs: string[]
+  route?: string          // bestehende Seite (Fallback, bis migriert)
+  adminOnly?: boolean
+}
+
+export const SETTINGS_GROUPS: SettingsGroup[] = [
+  { id: "agents", label: "Agenten", icon: Bot, hasSubmenu: true,
+    submenuLabel: "Agenten", tabs: ["Einstellungen", "Tools", "Mail"], route: "/agents" },
+  { id: "projects", label: "Projekte", icon: FolderKanban, hasSubmenu: true,
+    submenuLabel: "Projekte", tabs: ["Einstellungen"], route: "/projects" },
+  { id: "communication", label: "Kommunikation", icon: MessageCircle, hasSubmenu: false,
+    tabs: ["Discord", "WhatsApp", "Mail"], route: "/communication" },
+  { id: "butler", label: "Butler", icon: Workflow, hasSubmenu: false,
+    tabs: ["Flows"], route: "/butler" },
+  { id: "zahnfee", label: "Zahnfee", icon: MoonStar, hasSubmenu: false,
+    tabs: ["Einstellungen"], route: "/zahnfee", adminOnly: true },
+  { id: "skills", label: "Skills", icon: Sparkles, hasSubmenu: false,
+    tabs: ["Bibliothek"], route: "/skills" },
+  { id: "mcp", label: "MCP", icon: Server, hasSubmenu: false,
+    tabs: ["Server"], route: "/mcp" },
+  { id: "plugins", label: "Plugins", icon: Puzzle, hasSubmenu: false,
+    tabs: ["Installiert"], route: "/plugins", adminOnly: true },
+  { id: "federation", label: "Föderation", icon: Globe, hasSubmenu: false,
+    tabs: ["Instanzen"], route: "/federation" },
+  { id: "llm", label: "KI-Modelle", icon: Cpu, hasSubmenu: false,
+    tabs: ["Provider", "Modelle"], route: "/llm" },
+  { id: "credentials", label: "Zugangsdaten", icon: Key, hasSubmenu: false,
+    tabs: ["Credentials"], route: "/credentials" },
+  { id: "memory", label: "Gedächtnis", icon: BrainCircuit, hasSubmenu: false,
+    tabs: ["Einträge"], route: "/memory" },
+  { id: "extensions", label: "Erweiterungen", icon: Package, hasSubmenu: false,
+    tabs: ["Installiert"], route: "/extensions", adminOnly: true },
+  { id: "modules", label: "Module", icon: Boxes, hasSubmenu: false,
+    tabs: ["Verfügbar"], route: "/modules", adminOnly: true },
+  { id: "connections", label: "Verbindungen", icon: Network, hasSubmenu: false,
+    tabs: ["Mail", "Tailscale", "AgentLink", "Samba"], route: "/system" },
+  { id: "system", label: "System", icon: SlidersHorizontal, hasSubmenu: false,
+    tabs: ["Allgemein", "Backup", "Status"], route: "/system", adminOnly: true },
+  { id: "settings_values", label: "Globale Settings", icon: Database, hasSubmenu: false,
+    tabs: ["Werte"], route: "/system/settings", adminOnly: true },
+  { id: "users", label: "Benutzer", icon: Users, hasSubmenu: false,
+    tabs: ["Verwaltung"], route: "/users", adminOnly: true },
+]

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -84,19 +84,17 @@ export function Layout() {
           })}
         </nav>
 
-        {role === "admin" && (
-          <Link
-            to="/system/settings"
-            className={`p-1.5 rounded-md transition-colors ${
-              pathname.startsWith("/system/settings")
-                ? "text-violet-300 bg-violet-500/15"
-                : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
-            }`}
-            title={t("settings.gear_tooltip", { ns: "system", defaultValue: "Einstellungen" })}
-          >
-            <Settings size={16} />
-          </Link>
-        )}
+        <Link
+          to="/settings"
+          className={`p-1.5 rounded-md transition-colors ${
+            pathname.startsWith("/settings")
+              ? "text-violet-300 bg-violet-500/15"
+              : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+          }`}
+          title={t("settings.gear_tooltip", { ns: "system", defaultValue: "Einstellungen" })}
+        >
+          <Settings size={16} />
+        </Link>
 
         <button
           onClick={() => setBentoOpen((o) => !o)}


### PR DESCRIPTION
Eine Settings-Seite unterm Zahnrad nach Tills Blueprint-Board. 3-Spalten Master-Detail im Werkbank-Look: links Hauptgruppen, Mitte Inhalt mit Karteikarten-Tabs, rechts kontextabhängiges Submenü (ausblendbar). Gerüst-Phase — Struktur steht, Inhalt zieht etappenweise nach, bis dahin Link zur bestehenden Seite. tsc + build grün.