### PR TITLE
feat(settings): erste Gruppen mit echtem Inhalt einbetten

### DIFF
--- a/frontend/src/features/settings/ContentArea.tsx
+++ b/frontend/src/features/settings/ContentArea.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react"
+import { Suspense, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, Loader2 } from "lucide-react"
 import type { SettingsGroup } from "./registry"
 
 interface Props {
@@ -9,55 +9,68 @@ interface Props {
 
 /**
  * Mittlerer Bereich: Karteikarten-Tabs oben + Inhalt darunter.
- * Gerüst-Phase: der eigentliche Inhalt wird etappenweise migriert. Bis dahin
- * zeigt jeder Tab einen Platzhalter + (falls vorhanden) einen Link zur
- * bestehenden Seite, damit nichts unerreichbar ist.
+ *
+ * Wenn group.component gesetzt ist, wird die bestehende Feature-Page direkt
+ * eingebettet (in einem isolierten, scrollbaren Container — neutralisiert
+ * etwaiges Vollbild-Layout der Page). Sonst: Platzhalter + Link zur alten Seite
+ * (Gerüst-Phase, Inhalt folgt etappenweise).
  */
 export function ContentArea({ group }: Props) {
   const [tab, setTab] = useState(group.tabs[0] ?? "")
 
-  // Beim Gruppenwechsel auf den ersten Tab zurück.
   useEffect(() => { setTab(group.tabs[0] ?? "") }, [group.id, group.tabs])
+
+  const Embedded = group.component
 
   return (
     <div className="flex h-full flex-col">
       {/* Karteikarten */}
       <div className="flex items-center gap-1 border-b border-white/8 px-4 pt-3">
-        {group.tabs.map((t) => (
+        {group.tabs.map((tName) => (
           <button
-            key={t}
-            onClick={() => setTab(t)}
+            key={tName}
+            onClick={() => setTab(tName)}
             className={`rounded-t-lg px-3.5 py-2 text-sm transition-colors ${
-              tab === t
+              tab === tName
                 ? "bg-[#104E8B]/20 text-sky-200 border-b-2 border-sky-400"
                 : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[4%]"
             }`}
           >
-            {t}
+            {tName}
           </button>
         ))}
       </div>
 
       {/* Inhalt */}
       <div className="flex-1 overflow-y-auto p-5">
-        <div className="mx-auto max-w-3xl">
-          <div className="rounded-xl border border-white/8 bg-zinc-900/40 p-6">
-            <h3 className="text-base font-semibold text-zinc-100">{group.label} · {tab}</h3>
-            <p className="mt-2 text-sm text-zinc-400">
-              Dieser Bereich wird hierher umgezogen. Die Struktur steht — der
-              Inhalt folgt Schritt für Schritt.
-            </p>
-            {group.route && (
-              <Link
-                to={group.route}
-                className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#104E8B]/30 px-3.5 py-2 text-sm text-sky-200 ring-1 ring-inset ring-[#104E8B]/50 hover:bg-[#104E8B]/40 transition-colors"
-              >
-                <ExternalLink size={14} />
-                Aktuelle Seite öffnen
-              </Link>
-            )}
+        {Embedded ? (
+          <Suspense fallback={
+            <div className="flex h-40 items-center justify-center">
+              <Loader2 size={20} className="animate-spin text-zinc-500" />
+            </div>
+          }>
+            <Embedded />
+          </Suspense>
+        ) : (
+          <div className="mx-auto max-w-3xl">
+            <div className="rounded-xl border border-white/8 bg-zinc-900/40 p-6">
+              <h3 className="text-base font-semibold text-zinc-100">{group.label} · {tab}</h3>
+              <p className="mt-2 text-sm text-zinc-400">
+                Dieser Bereich wird hierher umgezogen. Die Struktur steht — der
+                Inhalt folgt Schritt für Schritt.
+              </p>
+              {group.route && (
+                <Link
+                  to={group.route}
+                  className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#104E8B]/30 px-3.5 py-2 text-sm text-sky-200 ring-1 ring-inset ring-[#104E8B]/50 hover:bg-[#104E8B]/40 transition-colors"
+                >
+                  <ExternalLink size={14} />
+                  Aktuelle Seite öffnen
+                </Link>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -1,8 +1,17 @@
+import { lazy, type LazyExoticComponent, type ComponentType } from "react"
 import {
   Bot, FolderKanban, MessageCircle, Workflow, MoonStar, Sparkles, Server,
   Puzzle, Globe, Cpu, Package, Boxes, Users, Key, BrainCircuit,
   SlidersHorizontal, Database, Network, type LucideIcon,
 } from "lucide-react"
+
+// Lazy-geladene bestehende Feature-Pages, die direkt eingebettet werden.
+// Code-split: nur geladen, wenn die Gruppe geöffnet wird.
+const LlmPage = lazy(() => import("@/features/llm/LlmPage").then((m) => ({ default: m.LlmPage })))
+const CredentialsPage = lazy(() => import("@/features/credentials/CredentialsPage").then((m) => ({ default: m.CredentialsPage })))
+const SkillsPage = lazy(() => import("@/features/skills/SkillsPage").then((m) => ({ default: m.SkillsPage })))
+const UsersPage = lazy(() => import("@/features/users/UsersPage").then((m) => ({ default: m.UsersPage })))
+const SettingsPage = lazy(() => import("@/features/system/SettingsPage").then((m) => ({ default: m.SettingsPage })))
 
 /**
  * Settings-Gruppen-Registry (SSOT für die linke Auswahl-Spalte).
@@ -28,7 +37,10 @@ export interface SettingsGroup {
   hasSubmenu: boolean
   submenuLabel?: string
   tabs: string[]
-  route?: string          // bestehende Seite (Fallback, bis migriert)
+  route?: string          // bestehende Seite (Fallback-Link, bis eingebettet)
+  // Direkt eingebettete Komponente. Wenn gesetzt, rendert ContentArea sie
+  // (in einem isolierten Scroll-Container) statt Platzhalter + Link.
+  component?: LazyExoticComponent<ComponentType>
   adminOnly?: boolean
 }
 
@@ -44,7 +56,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "zahnfee", label: "Zahnfee", icon: MoonStar, hasSubmenu: false,
     tabs: ["Einstellungen"], route: "/zahnfee", adminOnly: true },
   { id: "skills", label: "Skills", icon: Sparkles, hasSubmenu: false,
-    tabs: ["Bibliothek"], route: "/skills" },
+    tabs: ["Bibliothek"], route: "/skills", component: SkillsPage },
   { id: "mcp", label: "MCP", icon: Server, hasSubmenu: false,
     tabs: ["Server"], route: "/mcp" },
   { id: "plugins", label: "Plugins", icon: Puzzle, hasSubmenu: false,
@@ -52,9 +64,9 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "federation", label: "Föderation", icon: Globe, hasSubmenu: false,
     tabs: ["Instanzen"], route: "/federation" },
   { id: "llm", label: "KI-Modelle", icon: Cpu, hasSubmenu: false,
-    tabs: ["Provider", "Modelle"], route: "/llm" },
+    tabs: ["Provider & Modelle"], route: "/llm", component: LlmPage },
   { id: "credentials", label: "Zugangsdaten", icon: Key, hasSubmenu: false,
-    tabs: ["Credentials"], route: "/credentials" },
+    tabs: ["Credentials"], route: "/credentials", component: CredentialsPage },
   { id: "memory", label: "Gedächtnis", icon: BrainCircuit, hasSubmenu: false,
     tabs: ["Einträge"], route: "/memory" },
   { id: "extensions", label: "Erweiterungen", icon: Package, hasSubmenu: false,
@@ -66,7 +78,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "system", label: "System", icon: SlidersHorizontal, hasSubmenu: false,
     tabs: ["Allgemein", "Backup", "Status"], route: "/system", adminOnly: true },
   { id: "settings_values", label: "Globale Settings", icon: Database, hasSubmenu: false,
-    tabs: ["Werte"], route: "/system/settings", adminOnly: true },
+    tabs: ["Werte"], route: "/system/settings", component: SettingsPage, adminOnly: true },
   { id: "users", label: "Benutzer", icon: Users, hasSubmenu: false,
-    tabs: ["Verwaltung"], route: "/users", adminOnly: true },
+    tabs: ["Verwaltung"], route: "/users", component: UsersPage, adminOnly: true },
 ]


### PR DESCRIPTION
Baut auf #221 (Settings-Hub-Gerüst) auf. ContentArea bettet jetzt bestehende Feature-Pages direkt ein (lazy) für: KI-Modelle, Zugangsdaten, Skills, Benutzer, Globale Settings. Rest behält vorerst Link. tsc + build grün.