### PR TITLE
feat(settings): Multi-Tab-Gruppen mit echten Tab-Inhalten (Welle 3)

### DIFF
--- a/frontend/src/features/settings/ContentArea.tsx
+++ b/frontend/src/features/settings/ContentArea.tsx
@@ -20,7 +20,8 @@ export function ContentArea({ group }: Props) {
 
   useEffect(() => { setTab(group.tabs[0] ?? "") }, [group.id, group.tabs])
 
-  const Embedded = group.component
+  // Per-Tab-Komponente hat Vorrang, sonst die gruppenweite component.
+  const Embedded = group.tabComponents?.[tab] ?? group.component
 
   return (
     <div className="flex h-full flex-col">

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -17,6 +17,16 @@ const ExtensionsPage = lazy(() => import("@/features/extensions/ExtensionsPage")
 const PluginsPage = lazy(() => import("@/features/plugins/PluginsPage").then((m) => ({ default: m.PluginsPage })))
 const FederationPage = lazy(() => import("@/features/federation/FederationPage").then((m) => ({ default: m.FederationPage })))
 
+// Per-Tab-Inhalte für Multi-Tab-Gruppen (Kommunikation, Verbindungen, System).
+const CommDiscord = lazy(() => import("./tabs/CommunicationTabs").then((m) => ({ default: m.CommDiscord })))
+const CommWhatsApp = lazy(() => import("./tabs/CommunicationTabs").then((m) => ({ default: m.CommWhatsApp })))
+const ConnTailscale = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnTailscale })))
+const ConnAgentLink = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnAgentLink })))
+const ConnSamba = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnSamba })))
+const SysBackup = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysBackup })))
+const SysBridge = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysBridge })))
+const SysStatus = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysStatus })))
+
 /**
  * Settings-Gruppen-Registry (SSOT für die linke Auswahl-Spalte).
  *
@@ -45,6 +55,9 @@ export interface SettingsGroup {
   // Direkt eingebettete Komponente. Wenn gesetzt, rendert ContentArea sie
   // (in einem isolierten Scroll-Container) statt Platzhalter + Link.
   component?: LazyExoticComponent<ComponentType>
+  // Per-Tab-Komponenten (Tab-Name → Komponente) für Multi-Tab-Gruppen.
+  // Hat Vorrang vor `component` für den jeweils aktiven Tab.
+  tabComponents?: Record<string, LazyExoticComponent<ComponentType>>
   adminOnly?: boolean
 }
 
@@ -54,7 +67,8 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "projects", label: "Projekte", icon: FolderKanban, hasSubmenu: true,
     submenuLabel: "Projekte", tabs: ["Einstellungen"], route: "/projects" },
   { id: "communication", label: "Kommunikation", icon: MessageCircle, hasSubmenu: false,
-    tabs: ["Discord", "WhatsApp", "Mail"], route: "/communication" },
+    tabs: ["Discord", "WhatsApp", "Mail"], route: "/communication",
+    tabComponents: { Discord: CommDiscord, WhatsApp: CommWhatsApp } },
   { id: "butler", label: "Butler", icon: Workflow, hasSubmenu: false,
     tabs: ["Flows"], route: "/butler" },
   { id: "zahnfee", label: "Zahnfee", icon: MoonStar, hasSubmenu: false,
@@ -78,9 +92,11 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "modules", label: "Module", icon: Boxes, hasSubmenu: false,
     tabs: ["Verfügbar"], route: "/modules", component: ModulesPage, adminOnly: true },
   { id: "connections", label: "Verbindungen", icon: Network, hasSubmenu: false,
-    tabs: ["Mail", "Tailscale", "AgentLink", "Samba"], route: "/system" },
+    tabs: ["Tailscale", "AgentLink", "Samba"], route: "/system",
+    tabComponents: { Tailscale: ConnTailscale, AgentLink: ConnAgentLink, Samba: ConnSamba } },
   { id: "system", label: "System", icon: SlidersHorizontal, hasSubmenu: false,
-    tabs: ["Allgemein", "Backup", "Status"], route: "/system", adminOnly: true },
+    tabs: ["Status", "Backup", "Bridge"], route: "/system", adminOnly: true,
+    tabComponents: { Status: SysStatus, Backup: SysBackup, Bridge: SysBridge } },
   { id: "settings_values", label: "Globale Settings", icon: Database, hasSubmenu: false,
     tabs: ["Werte"], route: "/system/settings", component: SettingsPage, adminOnly: true },
   { id: "users", label: "Benutzer", icon: Users, hasSubmenu: false,

--- a/frontend/src/features/settings/tabs/CommunicationTabs.tsx
+++ b/frontend/src/features/settings/tabs/CommunicationTabs.tsx
@@ -1,0 +1,14 @@
+import { DiscordCard } from "@/features/communication/DiscordCard"
+import { WhatsAppCard } from "@/features/communication/WhatsAppCard"
+
+/**
+ * Tab-Inhalte der Gruppe "Kommunikation" — je Kanal eine Karteikarte.
+ * (Mail liegt in den globalen Settings-Werten, Gruppe "Mail".)
+ */
+export function CommDiscord() {
+  return <div className="space-y-4"><DiscordCard /></div>
+}
+
+export function CommWhatsApp() {
+  return <div className="space-y-4"><WhatsAppCard /></div>
+}

--- a/frontend/src/features/settings/tabs/ConnectionTabs.tsx
+++ b/frontend/src/features/settings/tabs/ConnectionTabs.tsx
@@ -1,0 +1,20 @@
+import { AgentLinkCard } from "@/features/system/AgentLinkCard"
+import { TailscaleCard } from "@/features/system/TailscaleCard"
+import { SambaCard } from "@/features/system/SambaCard"
+
+/**
+ * Tab-Inhalte der Gruppe "Verbindungen". Jede Karteikarte zeigt genau die
+ * thematisch passende(n) System-Card(s) — props-frei, daher direkt platzierbar.
+ * (Mail-Settings liegen in den globalen Settings-Werten, Gruppe "Mail".)
+ */
+export function ConnTailscale() {
+  return <div className="space-y-4"><TailscaleCard /></div>
+}
+
+export function ConnAgentLink() {
+  return <div className="space-y-4"><AgentLinkCard /></div>
+}
+
+export function ConnSamba() {
+  return <div className="space-y-4"><SambaCard /></div>
+}

--- a/frontend/src/features/settings/tabs/SystemTabs.tsx
+++ b/frontend/src/features/settings/tabs/SystemTabs.tsx
@@ -1,0 +1,37 @@
+import { Link } from "react-router-dom"
+import { ExternalLink } from "lucide-react"
+import { BackupCard } from "@/features/system/BackupCard"
+import { BridgeCard } from "@/features/system/BridgeCard"
+
+/** Tab-Inhalte der Gruppe "System". */
+export function SysBackup() {
+  return <div className="space-y-4"><BackupCard /></div>
+}
+
+export function SysBridge() {
+  return <div className="space-y-4"><BridgeCard /></div>
+}
+
+/**
+ * Status/Allgemein (Stats, Uptime, Pfade, Health) lebt von Live-Daten, die die
+ * SystemPage als Ganzes lädt — als Übersicht am Stück sinnvoller. Daher hier ein
+ * klarer Verweis statt halber Einbettung.
+ */
+export function SysStatus() {
+  return (
+    <div className="rounded-xl border border-white/8 bg-zinc-900/40 p-6">
+      <h3 className="text-base font-semibold text-zinc-100">System-Status & Übersicht</h3>
+      <p className="mt-2 text-sm text-zinc-400">
+        Live-Statistiken, Uptime, Speicher und Health-Checks gibt es gebündelt auf
+        der System-Übersicht.
+      </p>
+      <Link
+        to="/system"
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#104E8B]/30 px-3.5 py-2 text-sm text-sky-200 ring-1 ring-inset ring-[#104E8B]/50 hover:bg-[#104E8B]/40 transition-colors"
+      >
+        <ExternalLink size={14} />
+        System-Übersicht öffnen
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
Kommunikation (Discord/WhatsApp-Cards), Verbindungen (Tailscale/AgentLink/Samba), System (Status-Verweis/Backup/Bridge) — pro Karteikarte die passende bestehende Card. tabComponents-Map in der Registry. tsc + build grün.