### PR TITLE
feat(settings): Vollbild-Gruppen einbetten (Agenten/Projekte/MCP/Memory/Butler/Mail)

### DIFF
--- a/frontend/src/features/settings/ContentArea.tsx
+++ b/frontend/src/features/settings/ContentArea.tsx
@@ -2,6 +2,7 @@ import { Suspense, useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 import { ExternalLink, Loader2 } from "lucide-react"
 import type { SettingsGroup } from "./registry"
+import { EmbedFrame } from "./EmbedFrame"
 
 interface Props {
   group: SettingsGroup
@@ -21,7 +22,10 @@ export function ContentArea({ group }: Props) {
   useEffect(() => { setTab(group.tabs[0] ?? "") }, [group.id, group.tabs])
 
   // Per-Tab-Komponente hat Vorrang, sonst die gruppenweite component.
-  const Embedded = group.tabComponents?.[tab] ?? group.component
+  const tabComp = group.tabComponents?.[tab]
+  const Embedded = tabComp ?? group.component
+  // EmbedFrame nur für gruppenweite Vollbild-Pages (nicht für Tab-Overrides).
+  const useFrame = !tabComp && Boolean(group.fullscreen)
 
   return (
     <div className="flex h-full flex-col">
@@ -44,7 +48,9 @@ export function ContentArea({ group }: Props) {
 
       {/* Inhalt */}
       <div className="flex-1 overflow-y-auto p-5">
-        {Embedded ? (
+        {Embedded && useFrame ? (
+          <EmbedFrame><Embedded /></EmbedFrame>
+        ) : Embedded ? (
           <Suspense fallback={
             <div className="flex h-40 items-center justify-center">
               <Loader2 size={20} className="animate-spin text-zinc-500" />

--- a/frontend/src/features/settings/EmbedFrame.tsx
+++ b/frontend/src/features/settings/EmbedFrame.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react"
+import { Loader2 } from "lucide-react"
+
+/**
+ * Bändigt Vollbild-Feature-Pages für die Einbettung im Settings-Hub.
+ *
+ * Diese Pages nutzen `-m-4 md:-m-6` (um das Outlet-Padding zu fressen) und
+ * `h-[calc(100dvh-3rem)]` (volle Viewport-Höhe). Im eingebetteten ContentArea
+ * würde das überlaufen. Dieser Frame:
+ *  - gibt eine feste, an den Hub-Bereich angepasste Höhe (relativ zum Viewport
+ *    minus Kopf/Tabs/Rahmen),
+ *  - gleicht den negativen Außen-Margin der Page mit gleichem Padding aus,
+ *  - kapselt das eigene Scrolling der Page.
+ */
+export function EmbedFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="h-[calc(100dvh-12rem)] overflow-hidden rounded-xl border border-white/8 bg-zinc-950/30">
+      {/* p-4/p-6 gleicht das -m-4/-m-6 der eingebetteten Page aus → netto 0,
+          aber die Page bekommt wieder ihren erwarteten Innenabstand. */}
+      <div className="h-full overflow-hidden p-4 md:p-6">
+        <Suspense fallback={
+          <div className="flex h-full items-center justify-center">
+            <Loader2 size={20} className="animate-spin text-zinc-500" />
+          </div>
+        }>
+          {children}
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -20,6 +20,7 @@ const FederationPage = lazy(() => import("@/features/federation/FederationPage")
 // Per-Tab-Inhalte für Multi-Tab-Gruppen (Kommunikation, Verbindungen, System).
 const CommDiscord = lazy(() => import("./tabs/CommunicationTabs").then((m) => ({ default: m.CommDiscord })))
 const CommWhatsApp = lazy(() => import("./tabs/CommunicationTabs").then((m) => ({ default: m.CommWhatsApp })))
+const CommMail = lazy(() => import("./tabs/CommunicationTabs").then((m) => ({ default: m.CommMail })))
 const ConnTailscale = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnTailscale })))
 const ConnAgentLink = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnAgentLink })))
 const ConnSamba = lazy(() => import("./tabs/ConnectionTabs").then((m) => ({ default: m.ConnSamba })))
@@ -27,6 +28,13 @@ const SysBackup = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default:
 const SysBridge = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysBridge })))
 const SysStatus = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysStatus })))
 const ZahnfeeConfig = lazy(() => import("@/features/zahnfee/ZahnfeeConfig").then((m) => ({ default: m.ZahnfeeConfig })))
+
+// Vollbild-Pages (werden in EmbedFrame gerendert, fullscreen: true).
+const AgentsPage = lazy(() => import("@/features/agents/AgentsPage").then((m) => ({ default: m.AgentsPage })))
+const ProjectsPage = lazy(() => import("@/features/projects/ProjectsPage").then((m) => ({ default: m.ProjectsPage })))
+const McpPage = lazy(() => import("@/features/mcp/McpPage").then((m) => ({ default: m.McpPage })))
+const MemoryPage = lazy(() => import("@/features/memory/MemoryPage").then((m) => ({ default: m.MemoryPage })))
+const ButlerPage = lazy(() => import("@/features/butler/ButlerPage").then((m) => ({ default: m.ButlerPage })))
 
 /**
  * Settings-Gruppen-Registry (SSOT für die linke Auswahl-Spalte).
@@ -59,6 +67,9 @@ export interface SettingsGroup {
   // Per-Tab-Komponenten (Tab-Name → Komponente) für Multi-Tab-Gruppen.
   // Hat Vorrang vor `component` für den jeweils aktiven Tab.
   tabComponents?: Record<string, LazyExoticComponent<ComponentType>>
+  // Wenn true, wird die eingebettete component in einen EmbedFrame gepackt
+  // (für Vollbild-Pages mit -m-/h-calc-Layout: Agenten, Projekte, MCP, …).
+  fullscreen?: boolean
   adminOnly?: boolean
 }
 
@@ -68,20 +79,20 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   // sondern ein klarer Verweis auf die vollwertige Seite (kein erzwungenes
   // Einbetten, das die bestehende Bedienung verschlechtern würde).
   { id: "agents", label: "Agenten", icon: Bot, hasSubmenu: false,
-    tabs: ["Verwaltung"], route: "/agents" },
+    tabs: ["Verwaltung"], route: "/agents", component: AgentsPage, fullscreen: true },
   { id: "projects", label: "Projekte", icon: FolderKanban, hasSubmenu: false,
-    tabs: ["Verwaltung"], route: "/projects" },
+    tabs: ["Verwaltung"], route: "/projects", component: ProjectsPage, fullscreen: true },
   { id: "communication", label: "Kommunikation", icon: MessageCircle, hasSubmenu: false,
     tabs: ["Discord", "WhatsApp", "Mail"], route: "/communication",
-    tabComponents: { Discord: CommDiscord, WhatsApp: CommWhatsApp } },
+    tabComponents: { Discord: CommDiscord, WhatsApp: CommWhatsApp, Mail: CommMail } },
   { id: "butler", label: "Butler", icon: Workflow, hasSubmenu: false,
-    tabs: ["Flows"], route: "/butler" },
+    tabs: ["Flows"], route: "/butler", component: ButlerPage, fullscreen: true },
   { id: "zahnfee", label: "Zahnfee", icon: MoonStar, hasSubmenu: false,
     tabs: ["Einstellungen"], route: "/zahnfee", component: ZahnfeeConfig, adminOnly: true },
   { id: "skills", label: "Skills", icon: Sparkles, hasSubmenu: false,
     tabs: ["Bibliothek"], route: "/skills", component: SkillsPage },
   { id: "mcp", label: "MCP", icon: Server, hasSubmenu: false,
-    tabs: ["Server"], route: "/mcp" },
+    tabs: ["Server"], route: "/mcp", component: McpPage, fullscreen: true },
   { id: "plugins", label: "Plugins", icon: Puzzle, hasSubmenu: false,
     tabs: ["Installiert"], route: "/plugins", component: PluginsPage, adminOnly: true },
   { id: "federation", label: "Föderation", icon: Globe, hasSubmenu: false,
@@ -91,7 +102,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   { id: "credentials", label: "Zugangsdaten", icon: Key, hasSubmenu: false,
     tabs: ["Credentials"], route: "/credentials", component: CredentialsPage },
   { id: "memory", label: "Gedächtnis", icon: BrainCircuit, hasSubmenu: false,
-    tabs: ["Einträge"], route: "/memory" },
+    tabs: ["Einträge"], route: "/memory", component: MemoryPage, fullscreen: true },
   { id: "extensions", label: "Erweiterungen", icon: Package, hasSubmenu: false,
     tabs: ["Installiert"], route: "/extensions", component: ExtensionsPage, adminOnly: true },
   { id: "modules", label: "Module", icon: Boxes, hasSubmenu: false,

--- a/frontend/src/features/settings/tabs/CommunicationTabs.tsx
+++ b/frontend/src/features/settings/tabs/CommunicationTabs.tsx
@@ -1,9 +1,10 @@
+import { Link } from "react-router-dom"
+import { ExternalLink, Mail } from "lucide-react"
 import { DiscordCard } from "@/features/communication/DiscordCard"
 import { WhatsAppCard } from "@/features/communication/WhatsAppCard"
 
 /**
  * Tab-Inhalte der Gruppe "Kommunikation" — je Kanal eine Karteikarte.
- * (Mail liegt in den globalen Settings-Werten, Gruppe "Mail".)
  */
 export function CommDiscord() {
   return <div className="space-y-4"><DiscordCard /></div>
@@ -11,4 +12,30 @@ export function CommDiscord() {
 
 export function CommWhatsApp() {
   return <div className="space-y-4"><WhatsAppCard /></div>
+}
+
+/**
+ * Mail (SMTP/IMAP) sind globale Infrastruktur-Settings und liegen bei den
+ * globalen Settings-Werten (Gruppe "Mail"). Verweis statt Duplikat.
+ */
+export function CommMail() {
+  return (
+    <div className="rounded-xl border border-white/8 bg-zinc-900/40 p-6">
+      <div className="flex items-center gap-2 text-zinc-200">
+        <Mail size={16} />
+        <h3 className="text-base font-semibold">E-Mail (SMTP / IMAP)</h3>
+      </div>
+      <p className="mt-2 text-sm text-zinc-400">
+        Die Mail-Zugangsdaten (Versand &amp; Empfang) sind globale System-Settings.
+        Du findest sie unter „Globale Settings" in der Gruppe „Mail".
+      </p>
+      <Link
+        to="/settings"
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#104E8B]/30 px-3.5 py-2 text-sm text-sky-200 ring-1 ring-inset ring-[#104E8B]/50 hover:bg-[#104E8B]/40 transition-colors"
+      >
+        <ExternalLink size={14} />
+        Zu den globalen Settings
+      </Link>
+    </div>
+  )
 }


### PR DESCRIPTION
EmbedFrame bändigt Vollbild-Pages (feste Höhe, Margin-Ausgleich, eigenes Scrolling). Alle restlichen Settings-Gruppen haben jetzt Inhalt im Hub. Mail-Tab verweist auf globale Mail-Settings. tsc+build grün.