### PR TITLE
feat(settings): Agenten nach Blueprint-Schema (Submenü + Settings)

### DIFF
--- a/frontend/src/features/settings/ContentArea.tsx
+++ b/frontend/src/features/settings/ContentArea.tsx
@@ -6,21 +6,24 @@ import { EmbedFrame } from "./EmbedFrame"
 
 interface Props {
   group: SettingsGroup
+  subItem?: string | null
 }
 
 /**
  * Mittlerer Bereich: Karteikarten-Tabs oben + Inhalt darunter.
  *
- * Wenn group.component gesetzt ist, wird die bestehende Feature-Page direkt
- * eingebettet (in einem isolierten, scrollbaren Container — neutralisiert
- * etwaiges Vollbild-Layout der Page). Sonst: Platzhalter + Link zur alten Seite
- * (Gerüst-Phase, Inhalt folgt etappenweise).
+ * Render-Priorität:
+ *  1. detailComponent (Gruppe mit Submenü) → bekommt die gewählte itemId.
+ *  2. tabComponents[tab] → Per-Tab-Inhalt.
+ *  3. component (+ fullscreen → EmbedFrame) → ganze Feature-Page.
+ *  4. Platzhalter + Link (noch nicht migriert).
  */
-export function ContentArea({ group }: Props) {
+export function ContentArea({ group, subItem = null }: Props) {
   const [tab, setTab] = useState(group.tabs[0] ?? "")
 
   useEffect(() => { setTab(group.tabs[0] ?? "") }, [group.id, group.tabs])
 
+  const Detail = group.detailComponent
   // Per-Tab-Komponente hat Vorrang, sonst die gruppenweite component.
   const tabComp = group.tabComponents?.[tab]
   const Embedded = tabComp ?? group.component
@@ -48,7 +51,15 @@ export function ContentArea({ group }: Props) {
 
       {/* Inhalt */}
       <div className="flex-1 overflow-y-auto p-5">
-        {Embedded && useFrame ? (
+        {Detail ? (
+          <Suspense fallback={
+            <div className="flex h-40 items-center justify-center">
+              <Loader2 size={20} className="animate-spin text-zinc-500" />
+            </div>
+          }>
+            <Detail itemId={subItem} />
+          </Suspense>
+        ) : Embedded && useFrame ? (
           <EmbedFrame><Embedded /></EmbedFrame>
         ) : Embedded ? (
           <Suspense fallback={

--- a/frontend/src/features/settings/SettingsHubPage.tsx
+++ b/frontend/src/features/settings/SettingsHubPage.tsx
@@ -37,7 +37,7 @@ export function SettingsHubPage() {
 
         {/* Mitte: Inhalt mit Tabs */}
         <div className="flex-1 min-w-0 bg-zinc-950/20">
-          <ContentArea group={active} />
+          <ContentArea group={active} subItem={subItem} />
         </div>
 
         {/* Rechts: Submenü — nur wenn die Gruppe eins braucht */}

--- a/frontend/src/features/settings/detail/AgentSettings.tsx
+++ b/frontend/src/features/settings/detail/AgentSettings.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react"
+import { Loader2 } from "lucide-react"
+import { agentsApi } from "@/features/agents/api"
+import { AgentForm } from "@/features/agents/AgentForm"
+import { llmModelsApi, type RegistryModel } from "@/features/llm/api"
+import type { Agent, ToolMeta } from "@/features/agents/types"
+
+/**
+ * Agenten-EINSTELLUNGEN für den Settings-Hub. Die Agentenliste rendert NICHT
+ * hier, sondern im Submenü rechts (Tills Schema: Submenü = die Agenten). Diese
+ * Komponente bekommt die gewählte agentId und zeigt nur dessen Settings-Form
+ * (Overview/Modell/Tools/Mail/Skills/Soul) — ohne die alte Vollbild-Liste.
+ */
+export function AgentSettings({ itemId }: { itemId: string | null }) {
+  const [agent, setAgent] = useState<Agent | null>(null)
+  const [tools, setTools] = useState<ToolMeta[]>([])
+  const [models, setModels] = useState<string[]>([])
+  const [catalog, setCatalog] = useState<RegistryModel[]>([])
+  const [loading, setLoading] = useState(false)
+
+  // Stammdaten (Tools/Modelle) einmalig.
+  useEffect(() => {
+    agentsApi.listTools().then(setTools).catch(() => {})
+    llmModelsApi.byModality("chat").then((res) => {
+      setModels(res.models.map((m) => m.id))
+      setCatalog(res.models)
+    }).catch(() => {})
+  }, [])
+
+  // Gewählten Agenten laden.
+  useEffect(() => {
+    if (!itemId) { setAgent(null); return }
+    setLoading(true)
+    agentsApi.list()
+      .then((list) => setAgent(list.find((a) => a.id === itemId) ?? null))
+      .catch(() => setAgent(null))
+      .finally(() => setLoading(false))
+  }, [itemId])
+
+  if (!itemId) {
+    return (
+      <p className="py-16 text-center text-sm text-zinc-500">
+        Rechts einen Agenten wählen, um seine Einstellungen zu bearbeiten.
+      </p>
+    )
+  }
+  if (loading || !agent) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 size={20} className="animate-spin text-zinc-500" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-3xl">
+      <AgentForm
+        agent={agent}
+        models={models}
+        catalog={catalog}
+        tools={tools}
+        onSaved={setAgent}
+        onDeleted={() => setAgent(null)}
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -29,8 +29,10 @@ const SysBridge = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default:
 const SysStatus = lazy(() => import("./tabs/SystemTabs").then((m) => ({ default: m.SysStatus })))
 const ZahnfeeConfig = lazy(() => import("@/features/zahnfee/ZahnfeeConfig").then((m) => ({ default: m.ZahnfeeConfig })))
 
-// Vollbild-Pages (werden in EmbedFrame gerendert, fullscreen: true).
-const AgentsPage = lazy(() => import("@/features/agents/AgentsPage").then((m) => ({ default: m.AgentsPage })))
+// Detail-Komponente (Submenü-Schema): Agenten — zeigt Settings des gewählten Agenten.
+const AgentSettings = lazy(() => import("./detail/AgentSettings").then((m) => ({ default: m.AgentSettings })))
+
+// Noch nicht ins Schema migriert (Vollbild via EmbedFrame): Projekte, MCP, Memory, Butler.
 const ProjectsPage = lazy(() => import("@/features/projects/ProjectsPage").then((m) => ({ default: m.ProjectsPage })))
 const McpPage = lazy(() => import("@/features/mcp/McpPage").then((m) => ({ default: m.McpPage })))
 const MemoryPage = lazy(() => import("@/features/memory/MemoryPage").then((m) => ({ default: m.MemoryPage })))
@@ -68,8 +70,13 @@ export interface SettingsGroup {
   // Hat Vorrang vor `component` für den jeweils aktiven Tab.
   tabComponents?: Record<string, LazyExoticComponent<ComponentType>>
   // Wenn true, wird die eingebettete component in einen EmbedFrame gepackt
-  // (für Vollbild-Pages mit -m-/h-calc-Layout: Agenten, Projekte, MCP, …).
+  // (für Vollbild-Pages mit -m-/h-calc-Layout: Projekte, MCP, … solange noch
+  // nicht ins Schema migriert).
   fullscreen?: boolean
+  // Detail-Komponente für Gruppen MIT Submenü: bekommt die im Submenü gewählte
+  // itemId und zeigt nur deren Einstellungen (Tills Schema). Hat Vorrang vor
+  // component, wenn hasSubmenu=true.
+  detailComponent?: LazyExoticComponent<ComponentType<{ itemId: string | null }>>
   adminOnly?: boolean
 }
 
@@ -78,8 +85,9 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   // — das ist bereits die ideale Settings-UI. Daher kein zusätzliches Submenü,
   // sondern ein klarer Verweis auf die vollwertige Seite (kein erzwungenes
   // Einbetten, das die bestehende Bedienung verschlechtern würde).
-  { id: "agents", label: "Agenten", icon: Bot, hasSubmenu: false,
-    tabs: ["Verwaltung"], route: "/agents", component: AgentsPage, fullscreen: true },
+  { id: "agents", label: "Agenten", icon: Bot, hasSubmenu: true,
+    submenuLabel: "Agenten", tabs: ["Einstellungen"], route: "/agents",
+    detailComponent: AgentSettings },
   { id: "projects", label: "Projekte", icon: FolderKanban, hasSubmenu: false,
     tabs: ["Verwaltung"], route: "/projects", component: ProjectsPage, fullscreen: true },
   { id: "communication", label: "Kommunikation", icon: MessageCircle, hasSubmenu: false,


### PR DESCRIPTION
Korrigiert den EmbedFrame-Shortcut. Agenten: Submenü rechts = Agentenliste, Mitte = nur Settings des gewählten Agenten. detailComponent-Mechanik in Registry/ContentArea. Referenz für die übrigen Submenü-Gruppen. tsc+build grün.