### PR TITLE
feat(settings): echte Agentenliste im Submenü (Farben, sortiert)

### DIFF
--- a/frontend/src/features/settings/SettingsHubPage.tsx
+++ b/frontend/src/features/settings/SettingsHubPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react"
+import { Suspense, useState } from "react"
+import { Loader2 } from "lucide-react"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { SETTINGS_GROUPS, type SettingsGroup } from "./registry"
 import { GroupList } from "./GroupList"
@@ -40,12 +41,26 @@ export function SettingsHubPage() {
           <ContentArea group={active} subItem={subItem} />
         </div>
 
-        {/* Rechts: Submenü — nur wenn die Gruppe eins braucht */}
-        {active.hasSubmenu && (
-          <div className="w-56 shrink-0 border-l border-white/8 bg-zinc-950/50">
-            <SubMenu group={active} activeItem={subItem} onSelect={setSubItem} />
-          </div>
-        )}
+        {/* Rechts: Submenü — nur wenn die Gruppe eins braucht. Eigene
+            submenuComponent (z.B. Agentenliste mit Farben) hat Vorrang. */}
+        {active.hasSubmenu && (() => {
+          const Custom = active.submenuComponent
+          return (
+            <div className="w-64 shrink-0 border-l border-white/8 bg-zinc-950/50">
+              {Custom ? (
+                <Suspense fallback={
+                  <div className="flex h-full items-center justify-center">
+                    <Loader2 size={18} className="animate-spin text-zinc-500" />
+                  </div>
+                }>
+                  <Custom activeItem={subItem} onSelect={setSubItem} />
+                </Suspense>
+              ) : (
+                <SubMenu group={active} activeItem={subItem} onSelect={setSubItem} />
+              )}
+            </div>
+          )
+        })()}
       </div>
     </div>
   )

--- a/frontend/src/features/settings/detail/AgentSettings.tsx
+++ b/frontend/src/features/settings/detail/AgentSettings.tsx
@@ -53,15 +53,13 @@ export function AgentSettings({ itemId }: { itemId: string | null }) {
   }
 
   return (
-    <div className="max-w-3xl">
-      <AgentForm
-        agent={agent}
-        models={models}
-        catalog={catalog}
-        tools={tools}
-        onSaved={setAgent}
-        onDeleted={() => setAgent(null)}
-      />
-    </div>
+    <AgentForm
+      agent={agent}
+      models={models}
+      catalog={catalog}
+      tools={tools}
+      onSaved={setAgent}
+      onDeleted={() => setAgent(null)}
+    />
   )
 }

--- a/frontend/src/features/settings/detail/AgentSubMenu.tsx
+++ b/frontend/src/features/settings/detail/AgentSubMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react"
+import { Crown, User, Wrench } from "lucide-react"
+import { agentsApi } from "@/features/agents/api"
+import type { Agent } from "@/features/agents/types"
+
+interface Props {
+  activeItem: string | null
+  onSelect: (id: string) => void
+}
+
+const TYPE_ICON = { master: Crown, project: User, specialist: Wrench }
+const TYPE_PILL: Record<string, string> = {
+  master: "bg-amber-500/[8%] border-amber-500/25 text-amber-300",
+  project: "bg-violet-500/[8%] border-violet-500/25 text-violet-300",
+  specialist: "bg-sky-500/[8%] border-sky-500/25 text-sky-300",
+}
+const TYPE_AVATAR: Record<string, string> = {
+  master: "/illustrations/agent-master.png",
+  project: "/illustrations/agent-project.png",
+  specialist: "/illustrations/agent-specialist.png",
+}
+// Sortier-Reihenfolge nach Typ: Master → Projekt-Agent → Spezialist, dann Name.
+const TYPE_ORDER: Record<string, number> = { master: 0, project: 1, specialist: 2 }
+
+/**
+ * Submenü der Agenten-Gruppe: die echte Agentenliste mit Farbmarkierungen
+ * (Master/Projekt/Spezialist), Avataren und off-Status — sortiert nach Typ und
+ * Name. Kein Button davor (Tills Vorgabe), Auswahl steuert den Mittelbereich.
+ */
+export function AgentSubMenu({ activeItem, onSelect }: Props) {
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    agentsApi.list()
+      .then((list) => {
+        const sorted = [...list].sort((a, b) => {
+          const o = (TYPE_ORDER[a.type] ?? 9) - (TYPE_ORDER[b.type] ?? 9)
+          return o !== 0 ? o : a.name.localeCompare(b.name)
+        })
+        setAgents(sorted)
+      })
+      .catch(() => setAgents([]))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-white/8 px-4 py-3">
+        <h2 className="text-sm font-semibold text-zinc-200">Agenten</h2>
+      </div>
+      <div className="flex-1 space-y-1 overflow-y-auto p-2">
+        {loading ? (
+          <div className="h-20 animate-pulse rounded-lg bg-zinc-900/50" />
+        ) : agents.length === 0 ? (
+          <p className="px-3 py-6 text-center text-xs text-zinc-600">Keine Agenten.</p>
+        ) : (
+          agents.map((a) => {
+            const Icon = TYPE_ICON[a.type] ?? Wrench
+            const active = a.id === activeItem
+            const dim = a.status !== "active"
+            return (
+              <div
+                key={a.id}
+                onClick={() => onSelect(a.id)}
+                className={`group flex cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 transition-all ${
+                  active
+                    ? "bg-gradient-to-r from-indigo-600/20 to-violet-600/10 border-l-2 border-violet-500"
+                    : "border-l-2 border-transparent hover:bg-white/[3%]"
+                } ${dim ? "opacity-50" : ""}`}
+              >
+                <img
+                  src={TYPE_AVATAR[a.type] ?? TYPE_AVATAR.specialist}
+                  alt=""
+                  className="h-8 w-8 shrink-0 object-contain drop-shadow-[0_0_5px_rgba(34,211,238,0.45)]"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span className={`flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] shrink-0 ${TYPE_PILL[a.type] ?? TYPE_PILL.specialist}`}>
+                      <Icon size={8} />
+                    </span>
+                    <p className={`truncate text-sm ${active ? "text-white" : "text-zinc-300"}`}>{a.name}</p>
+                  </div>
+                  <p className="mt-0.5 truncate font-mono text-[10px] text-zinc-600">{a.llm_model}</p>
+                </div>
+                {dim && (
+                  <span className="shrink-0 rounded-full border border-zinc-500/20 bg-zinc-500/[8%] px-1.5 py-0.5 text-[10px] text-zinc-500">off</span>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -31,6 +31,7 @@ const ZahnfeeConfig = lazy(() => import("@/features/zahnfee/ZahnfeeConfig").then
 
 // Detail-Komponente (Submenü-Schema): Agenten — zeigt Settings des gewählten Agenten.
 const AgentSettings = lazy(() => import("./detail/AgentSettings").then((m) => ({ default: m.AgentSettings })))
+const AgentSubMenu = lazy(() => import("./detail/AgentSubMenu").then((m) => ({ default: m.AgentSubMenu })))
 
 // Noch nicht ins Schema migriert (Vollbild via EmbedFrame): Projekte, MCP, Memory, Butler.
 const ProjectsPage = lazy(() => import("@/features/projects/ProjectsPage").then((m) => ({ default: m.ProjectsPage })))
@@ -77,6 +78,9 @@ export interface SettingsGroup {
   // itemId und zeigt nur deren Einstellungen (Tills Schema). Hat Vorrang vor
   // component, wenn hasSubmenu=true.
   detailComponent?: LazyExoticComponent<ComponentType<{ itemId: string | null }>>
+  // Eigene Submenü-Komponente (z.B. echte Agentenliste mit Farben) statt des
+  // generischen SubMenu. Bekommt activeItem + onSelect.
+  submenuComponent?: LazyExoticComponent<ComponentType<{ activeItem: string | null; onSelect: (id: string) => void }>>
   adminOnly?: boolean
 }
 
@@ -87,7 +91,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
   // Einbetten, das die bestehende Bedienung verschlechtern würde).
   { id: "agents", label: "Agenten", icon: Bot, hasSubmenu: true,
     submenuLabel: "Agenten", tabs: ["Einstellungen"], route: "/agents",
-    detailComponent: AgentSettings },
+    detailComponent: AgentSettings, submenuComponent: AgentSubMenu },
   { id: "projects", label: "Projekte", icon: FolderKanban, hasSubmenu: false,
     tabs: ["Verwaltung"], route: "/projects", component: ProjectsPage, fullscreen: true },
   { id: "communication", label: "Kommunikation", icon: MessageCircle, hasSubmenu: false,


### PR DESCRIPTION
AgentSubMenu mit echter Optik (Avatare, Farb-Pills Master/Projekt/Spezialist, off-Status), sortiert, ohne Button. max-w-Limit raus für mehr Breite. tsc+build grün.