### PR TITLE
refactor(nav): Settings-Einträge aus Nav entfernen (jetzt im Hub)

### DIFF
--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -1,7 +1,7 @@
 import { lazy, type LazyExoticComponent, type ComponentType } from "react"
 import {
   Bot, FolderKanban, MessageCircle, Workflow, MoonStar, Sparkles, Server,
-  Puzzle, Globe, Cpu, Package, Boxes, Users, Key, BrainCircuit,
+  Puzzle, Globe, Cpu, Package, Boxes, Users, Key,
   SlidersHorizontal, Database, Network, type LucideIcon,
 } from "lucide-react"
 
@@ -35,9 +35,8 @@ const AgentSubMenu = lazy(() => import("./detail/AgentSubMenu").then((m) => ({ d
 const ProjectSettings = lazy(() => import("./detail/ProjectSettings").then((m) => ({ default: m.ProjectSettings })))
 const ProjectSubMenu = lazy(() => import("./detail/ProjectSubMenu").then((m) => ({ default: m.ProjectSubMenu })))
 
-// Noch nicht ins Schema migriert (Vollbild via EmbedFrame): MCP, Memory, Butler.
+// Noch nicht ins Schema migriert (Vollbild via EmbedFrame): MCP, Butler.
 const McpPage = lazy(() => import("@/features/mcp/McpPage").then((m) => ({ default: m.McpPage })))
-const MemoryPage = lazy(() => import("@/features/memory/MemoryPage").then((m) => ({ default: m.MemoryPage })))
 const ButlerPage = lazy(() => import("@/features/butler/ButlerPage").then((m) => ({ default: m.ButlerPage })))
 
 /**
@@ -115,8 +114,7 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
     tabs: ["Provider & Modelle"], route: "/llm", component: LlmPage },
   { id: "credentials", label: "Zugangsdaten", icon: Key, hasSubmenu: false,
     tabs: ["Credentials"], route: "/credentials", component: CredentialsPage },
-  { id: "memory", label: "Gedächtnis", icon: BrainCircuit, hasSubmenu: false,
-    tabs: ["Einträge"], route: "/memory", component: MemoryPage, fullscreen: true },
+
   { id: "extensions", label: "Erweiterungen", icon: Package, hasSubmenu: false,
     tabs: ["Installiert"], route: "/extensions", component: ExtensionsPage, adminOnly: true },
   { id: "modules", label: "Module", icon: Boxes, hasSubmenu: false,

--- a/frontend/src/shared/nav-config.ts
+++ b/frontend/src/shared/nav-config.ts
@@ -1,6 +1,6 @@
 import { BrainCircuit,
-  BookOpen, Bot, Box, Boxes, Cpu, Film, FolderKanban, Globe, HardDrive, Heart, Key, LayoutDashboard,
-  MessageCircle, MessageSquare, MessagesSquare, MoonStar, Package, Pickaxe, Puzzle, Server, Settings, Sparkles, Users, Workflow,
+  BookOpen, Bot, Box, Film, FolderKanban, Globe, HardDrive, Heart, LayoutDashboard,
+  MessageCircle, MessageSquare, MessagesSquare, MoonStar, Pickaxe, Puzzle, Server, Sparkles, Workflow,
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 import { moduleNav } from "@/modules/index.generated"
@@ -57,14 +57,12 @@ export const NAV_ITEMS: NavItem[] = [
   { path: "/federation",  icon: Globe,           labelKey: "federation",  group: "infrastructure" },
   { path: "/streaming",   icon: Film,            labelKey: "streaming",   group: "infrastructure" },
   { path: "/datamining",  icon: Pickaxe,         labelKey: "datamining",  group: "infrastructure" },
-  // Einstellungen
-  { path: "/llm",         icon: Cpu,             labelKey: "llm",         group: "settings" },
-  { path: "/credentials", icon: Key,             labelKey: "credentials", group: "settings" },
-  { path: "/memory",      icon: BrainCircuit,    labelKey: "memory",      group: "settings" },
-  { path: "/extensions",  icon: Package,         labelKey: "extensions",  group: "settings", roles: ["admin"] },
-  { path: "/modules",     icon: Boxes,           labelKey: "modules",     group: "settings", roles: ["admin"] },
-  { path: "/users",       icon: Users,           labelKey: "users",       group: "settings", roles: ["admin"] },
-  { path: "/system",      icon: Settings,        labelKey: "system",      group: "settings" },
+  // Gedächtnis = Auswertung (kein Setting) → bei den Infrastruktur-/Analyse-Tools.
+  { path: "/memory",      icon: BrainCircuit,    labelKey: "memory",      group: "infrastructure" },
+
+  // Einstellungen: LLM/Credentials/Extensions/Module/Benutzer/System sind jetzt
+  // alle gebündelt im zentralen Settings-Hub (Zahnrad → /settings) erreichbar,
+  // daher hier KEINE Einzeleinträge mehr. Nur Hilfe bleibt.
   { path: "/help",        icon: BookOpen,        labelKey: "help",        group: "settings" },
 ]
 


### PR DESCRIPTION
LLM/Credentials/Extensions/Module/Benutzer/System raus aus der Nav (im Settings-Hub gebündelt, Routen bleiben). Gedächtnis aus Hub raus (Auswertung) → Infrastruktur-Gruppe. tsc+build grün.