### PR TITLE
feat(settings): Deeplinks + Agenten/Projekte nur noch im Hub

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,8 +10,7 @@ const appModuleRoutes = moduleRoutes as ModuleRoute[]
 import { DashboardPage } from "@/features/dashboard/DashboardPage"
 import { SessionDetailPage } from "@/features/analytics/SessionDetailPage"
 import { ChatPage } from "@/features/chat/ChatPage"
-import { AgentsPage } from "@/features/agents/AgentsPage"
-import { ProjectsPage } from "@/features/projects/ProjectsPage"
+
 import { LlmPage } from "@/features/llm/LlmPage"
 import { CatalogPage } from "@/features/llm/CatalogPage"
 import { McpPage } from "@/features/mcp/McpPage"
@@ -74,8 +73,9 @@ export default function App() {
           <Route path="werkstatt" element={<ChatPage />} />
           <Route path="werkstatt/:sid" element={<ChatPage />} />
           <Route path="devchat" element={<Navigate to="/werkstatt" replace />} />
-          <Route path="agents" element={<AgentsPage />} />
-          <Route path="projects" element={<ProjectsPage />} />
+          {/* Agenten & Projekte leben jetzt im Settings-Hub (eine Config-Stelle). */}
+          <Route path="agents" element={<Navigate to="/settings/agents" replace />} />
+          <Route path="projects" element={<Navigate to="/settings/projects" replace />} />
           <Route path="communication" element={<CommunicationPage />} />
           <Route path="teamchat" element={<TeamchatPage />} />
           <Route path="vms" element={<VMsPage />} />
@@ -92,6 +92,7 @@ export default function App() {
           <Route path="skills" element={<SkillsPage />} />
           <Route path="credentials" element={<CredentialsPage />} />
           <Route path="settings" element={<SettingsHubPage />} />
+          <Route path="settings/:groupId" element={<SettingsHubPage />} />
           <Route path="system" element={<SystemPage />} />
           <Route path="system/settings" element={<AdminGuard><SettingsPage /></AdminGuard>} />
           <Route path="users" element={<AdminGuard><UsersPage /></AdminGuard>} />

--- a/frontend/src/features/settings/SettingsHubPage.tsx
+++ b/frontend/src/features/settings/SettingsHubPage.tsx
@@ -1,4 +1,5 @@
-import { Suspense, useState } from "react"
+import { Suspense, useEffect, useState } from "react"
+import { useParams, useNavigate } from "react-router-dom"
 import { Loader2 } from "lucide-react"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { SETTINGS_GROUPS, type SettingsGroup } from "./registry"
@@ -15,13 +16,19 @@ import { SubMenu } from "./SubMenu"
  */
 export function SettingsHubPage() {
   const role = useAuthStore((s) => s.role) ?? "user"
+  const navigate = useNavigate()
+  const { groupId } = useParams<{ groupId?: string }>()
   const groups = SETTINGS_GROUPS.filter((g) => !g.adminOnly || role === "admin")
-  const [active, setActive] = useState<SettingsGroup>(groups[0])
+
+  // Aktive Gruppe aus der URL (/settings/:groupId), Fallback erste Gruppe.
+  const active = groups.find((g) => g.id === groupId) ?? groups[0]
   const [subItem, setSubItem] = useState<string | null>(null)
 
+  // Submenü-Auswahl zurücksetzen, wenn die Gruppe wechselt (auch via Deeplink).
+  useEffect(() => { setSubItem(null) }, [active.id])
+
   const selectGroup = (g: SettingsGroup) => {
-    setActive(g)
-    setSubItem(null)
+    navigate(`/settings/${g.id}`)
   }
 
   return (

--- a/frontend/src/shared/nav-config.ts
+++ b/frontend/src/shared/nav-config.ts
@@ -41,8 +41,8 @@ export const NAV_ITEMS: NavItem[] = [
   // Arbeiten
   { path: "/",            icon: Heart,           labelKey: "buddy",       group: "working" },
   { path: "/werkstatt",   icon: MessageSquare,   labelKey: "werkstatt",   group: "working" },
-  { path: "/agents",      icon: Bot,             labelKey: "agents",      group: "working" },
-  { path: "/projects",    icon: FolderKanban,    labelKey: "projects",    group: "working" },
+  { path: "/settings/agents",   icon: Bot,          labelKey: "agents",   group: "working" },
+  { path: "/settings/projects", icon: FolderKanban, labelKey: "projects", group: "working" },
   { path: "/communication", icon: MessageCircle, labelKey: "communication", group: "working" },
   { path: "/teamchat",    icon: MessagesSquare,  labelKey: "teamchat",    group: "working" },
   // Automatisierung
@@ -66,7 +66,7 @@ export const NAV_ITEMS: NavItem[] = [
   { path: "/help",        icon: BookOpen,        labelKey: "help",        group: "settings" },
 ]
 
-export const QUICK_LINK_PATHS = ["/dashboard", "/werkstatt", "/agents", "/projects"]
+export const QUICK_LINK_PATHS = ["/dashboard", "/werkstatt", "/settings/agents", "/settings/projects"]
 
 const MODULE_NAV_ITEMS: NavItem[] = (moduleNav as ModuleNavEntry[]).map((n) => ({
   path: n.path,


### PR DESCRIPTION
Settings-Hub URL-gesteuert (/settings/:groupId). Nav + Header-Quicklinks 'Agenten'/'Projekte' zeigen in den Hub. Alte /agents+/projects → Redirect. Eine Config-Stelle. tsc+build grün.