### PR TITLE
Claude Sonnet 5 zur Anthropic-Modellauswahl hinzufügen

### DIFF
--- a/core/src/hydrahive/llm/_anthropic.py
+++ b/core/src/hydrahive/llm/_anthropic.py
@@ -29,6 +29,7 @@ EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
 # Alle anderen (Claude 4.5/4.1/4.0/3.x, MiniMax) nutzen den Legacy-Pfad.
 EFFORT_PARAM_MODELS = (
     "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6",
+    "claude-sonnet-5",
 )
 
 # Legacy: Reasoning-Effort → extended_thinking budget_tokens (Claude 4.5/älter, MiniMax).

--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -27,8 +27,9 @@ PROVIDER_ENDPOINTS = {
 # Static-Listen für Provider ohne /v1/models-Endpoint.
 STATIC_MODELS = {
     "anthropic": [
-        "claude-sonnet-4-6", "claude-opus-4-8", "claude-opus-4-7", "claude-haiku-4-5",
-        "claude-sonnet-4-5", "claude-3-7-sonnet-20250219", "claude-3-5-haiku-20241022",
+        "claude-sonnet-5", "claude-sonnet-4-6", "claude-opus-4-8", "claude-opus-4-7",
+        "claude-haiku-4-5", "claude-sonnet-4-5", "claude-3-7-sonnet-20250219",
+        "claude-3-5-haiku-20241022",
     ],
     "minimax": [
         "MiniMax-Text-01", "MiniMax-M2", "MiniMax-M2.1", "MiniMax-M2.7", "MiniMax-M1",
@@ -58,6 +59,7 @@ PROVIDER_PREFIX = {
 # tool_use: True/False/None (None = ungetestet/unbekannt).
 METADATA: dict[str, dict[str, Any]] = {
     # Anthropic
+    "claude-sonnet-5":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-opus-4-8":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-opus-4-7":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-sonnet-4-6": {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},

--- a/core/src/hydrahive/llm/_pricing.py
+++ b/core/src/hydrahive/llm/_pricing.py
@@ -23,6 +23,8 @@ class Pricing(NamedTuple):
 # Anthropic Claude — $/1M tokens × 100 cents × 1000 micros / 1M tokens = $-Wert × 0.1 micros/token
 # Beispiel: Sonnet $3/1M input = 3 × 0.1 = 0.3 micros/token
 _ANTHROPIC: dict[str, Pricing] = {
+    # Sonnet 5: $2 / $10 / cache_read $0.20 / cache_write $2.50 (Intro-Preis, Stand 2026-07)
+    "claude-sonnet-5": Pricing(0.2, 1.0, 0.02, 0.25),
     # Sonnet 4.x (4-5, 4-6, 4-7): $3 / $15 / cache_read $0.30 / cache_write $3.75
     "claude-sonnet-4": Pricing(0.3, 1.5, 0.03, 0.375),
     # Opus 4.x (4-5, 4-6, 4-7): $15 / $75 / $1.50 / $18.75

--- a/frontend/src/features/chat/pricing.ts
+++ b/frontend/src/features/chat/pricing.ts
@@ -9,6 +9,7 @@ interface Pricing {
 
 const PRICING: { match: RegExp; price: Pricing }[] = [
   { match: /^claude-opus-4/i,             price: { input: 15.00, output: 75.00, cache_read: 1.50,  cache_write: 18.75 } },
+  { match: /^claude-sonnet-5/i,           price: { input: 2.00,  output: 10.00, cache_read: 0.20,  cache_write: 2.50  } },
   { match: /^claude-sonnet-4/i,           price: { input: 3.00,  output: 15.00, cache_read: 0.30,  cache_write: 3.75  } },
   { match: /^claude-haiku-4/i,            price: { input: 1.00,  output: 5.00,  cache_read: 0.10,  cache_write: 1.25  } },
   { match: /^claude-3-7-sonnet/i,         price: { input: 3.00,  output: 15.00, cache_read: 0.30,  cache_write: 3.75  } },


### PR DESCRIPTION
## Was
Claude **Sonnet 5** (Release 30.06.2026, Model-ID `claude-sonnet-5`) in die Anthropic-Modellauswahl aufgenommen. Major-Release → ID ohne Minor-Segment (anders als `claude-sonnet-4-6`). 1M Context, aktuell günstiger Intro-Preis $2/$10.

## Geänderte Stellen (4 Dateien — alle nötig)
| Datei | Änderung |
|-------|----------|
| `_catalog_data.py` | `claude-sonnet-5` in `STATIC_MODELS['anthropic']` (erste Position) + `METADATA` (1M context, tool_use, family anthropic) → erscheint in der Auswahl |
| `_anthropic.py` | in `EFFORT_PARAM_MODELS` → nutzt neuen `output_config.effort`-Pfad (Claude 4.6+), nicht den Legacy-`budget_tokens`-Pfad |
| `_pricing.py` | eigener Eintrag $2/$10. **Wichtig:** Prefix-Match — `claude-sonnet-5` fällt sonst *nicht* auf `claude-sonnet-4` zurück |
| `frontend/.../pricing.ts` | Regex-Eintrag **vor** `claude-sonnet-4` (spezifischer Match zuerst) |

## Verifikation
- ✅ 67 LLM-Tests grün (pricing/effort/catalog/anthropic/reasoning)
- ✅ Sonnet 5 wird in allen Pfaden korrekt erkannt — auch mit Datums-Suffix (`claude-sonnet-5-20260630`): eigenes Pricing $2/$10, neuer Effort-Pfad, Catalog-Metadata
- ✅ Routing greift automatisch (`client.py`: `startswith('claude-')`)
- ✅ TS-Typecheck grün (gegen echtes Frontend, read-only)

## Quellen
Anthropic Platform Docs (Model-IDs: `claude-sonnet-5`), anthropic.com/news/claude-sonnet-5, Pricing-Page ($2/$10 Intro).

Help-Docs (`i18n/help/*`) bewusst unverändert — die nennen `claude-sonnet-4-6` nur als Beispiel in Anleitungen, kein funktionaler Code.