### PR TITLE
fix(llm): temperature-deprecated-Retry auch im direkten LLM-Client-Pfad

### DIFF
--- a/core/src/hydrahive/llm/_anthropic.py
+++ b/core/src/hydrahive/llm/_anthropic.py
@@ -132,6 +132,17 @@ def _client(key: str):
     return _anthropic.AsyncAnthropic(api_key=key, timeout=300.0), False
 
 
+def _is_temperature_deprecated_error(exc: Exception) -> bool:
+    """True wenn Anthropic mit 'temperature is deprecated for this model' 400t.
+
+    Manche neueren Claude-Modelle (z.B. opus-4-7+, sonnet-5) akzeptieren keinen
+    temperature-Parameter mehr. Gilt für alle direkten Anthropic-SDK-Pfade
+    (complete/stream, OAuth/API-Key/MiniMax) — nicht nur den Runner-Pfad.
+    """
+    msg = str(exc).lower()
+    return "temperature" in msg and "deprecated" in msg
+
+
 async def anthropic_complete(
     key: str, messages: list[dict], model: str,
     temperature: float, max_tokens: int,
@@ -152,7 +163,15 @@ async def anthropic_complete(
     if system:
         kwargs["system"] = system
     from hydrahive.llm._oauth_usage import extract_rate_limit_headers
-    raw_resp = await client.messages.with_raw_response.create(**kwargs)
+    import anthropic as _anthropic
+
+    try:
+        raw_resp = await client.messages.with_raw_response.create(**kwargs)
+    except _anthropic.BadRequestError as e:
+        if not _is_temperature_deprecated_error(e):
+            raise
+        kwargs.pop("temperature", None)
+        raw_resp = await client.messages.with_raw_response.create(**kwargs)
     extract_rate_limit_headers(raw_resp.headers)
     resp = raw_resp.parse()
     return extract_text(resp.content)
@@ -169,12 +188,19 @@ async def minimax_complete(
         timeout=60.0,
         default_headers={"Authorization": f"Bearer {api_key}"},
     )
-    resp = await client.messages.create(
-        model=strip_provider_prefix(model),
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
+    kwargs: dict = {
+        "model": strip_provider_prefix(model),
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    try:
+        resp = await client.messages.create(**kwargs)
+    except _anthropic.BadRequestError as e:
+        if not _is_temperature_deprecated_error(e):
+            raise
+        kwargs.pop("temperature", None)
+        resp = await client.messages.create(**kwargs)
     return extract_text(resp.content)
 
 
@@ -189,20 +215,31 @@ async def minimax_stream(
         timeout=60.0,
         default_headers={"Authorization": f"Bearer {api_key}"},
     )
-    async with client.messages.stream(
-        model=strip_provider_prefix(model),
-        messages=messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-    ) as s:
-        async for text in s.text_stream:
-            yield text
+    kwargs: dict = {
+        "model": strip_provider_prefix(model),
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    try:
+        async with client.messages.stream(**kwargs) as s:
+            async for text in s.text_stream:
+                yield text
+    except _anthropic.BadRequestError as e:
+        if not _is_temperature_deprecated_error(e):
+            raise
+        kwargs.pop("temperature", None)
+        async with client.messages.stream(**kwargs) as s:
+            async for text in s.text_stream:
+                yield text
 
 
 async def anthropic_stream(
     key: str, messages: list[dict], model: str,
     temperature: float, max_tokens: int,
 ) -> AsyncIterator[str]:
+    import anthropic as _anthropic
+
     client, is_oauth = _client(key)
     kwargs: dict = {
         "model": strip_provider_prefix(model),
@@ -212,6 +249,14 @@ async def anthropic_stream(
     }
     if is_oauth:
         kwargs["system"] = _OAUTH_IDENTITY
-    async with client.messages.stream(**kwargs) as stream:
-        async for text in stream.text_stream:
-            yield text
+    try:
+        async with client.messages.stream(**kwargs) as stream:
+            async for text in stream.text_stream:
+                yield text
+    except _anthropic.BadRequestError as e:
+        if not _is_temperature_deprecated_error(e):
+            raise
+        kwargs.pop("temperature", None)
+        async with client.messages.stream(**kwargs) as stream:
+            async for text in stream.text_stream:
+                yield text

--- a/core/tests/test_llm_anthropic_temperature_retry.py
+++ b/core/tests/test_llm_anthropic_temperature_retry.py
@@ -1,0 +1,249 @@
+"""hydrahive.llm._anthropic: complete/stream retry'n ohne temperature, wenn das
+Modell sie ablehnt (BadRequestError 'temperature is deprecated for this model').
+
+Bug: test_stream_temperature_retry.py deckt bereits den Runner-Pfad
+(hydrahive.runner._stream_providers) ab — DIESER Pfad (hydrahive.llm._anthropic,
+genutzt von llm_client.complete()/stream(), u.a. vom Modell-Test-Button
+/api/llm/catalog/test) hatte den Retry NICHT. Neuere Claude-Modelle (opus-4-7+,
+sonnet-5) crashten dort mit einem rohen 400 statt zu funktionieren.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+
+def _bad_request_temperature():
+    import anthropic
+    resp = httpx.Response(400, request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"))
+    return anthropic.BadRequestError(
+        "temperature is deprecated for this model", response=resp, body=None
+    )
+
+
+def _other_bad_request():
+    import anthropic
+    resp = httpx.Response(400, request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"))
+    return anthropic.BadRequestError("invalid model xyz", response=resp, body=None)
+
+
+class _FakeRawResp:
+    def __init__(self, content: list, headers=None):
+        self.headers = headers or {}
+        self._content = content
+
+    def parse(self):
+        from types import SimpleNamespace
+        return SimpleNamespace(content=self._content)
+
+
+class _FakeTextBlock:
+    type = "text"
+    text = "OK"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------- anthropic_complete
+def test_anthropic_complete_retried_ohne_temperature(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeRawResponseNS:
+        async def create(self, **kwargs):
+            calls.append(kwargs)
+            if "temperature" in kwargs:
+                raise _bad_request_temperature()
+            return _FakeRawResp([_FakeTextBlock()])
+
+    class FakeMessages:
+        with_raw_response = FakeRawResponseNS()
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+    monkeypatch.setattr(
+        "hydrahive.llm._oauth_usage.extract_rate_limit_headers", lambda headers: None
+    )
+
+    from hydrahive.llm._anthropic import anthropic_complete
+    out = _run(anthropic_complete(
+        key="sk-ant-test", messages=[{"role": "user", "content": "hi"}],
+        model="claude-opus-4-8", temperature=1.0, max_tokens=1024,
+    ))
+
+    assert len(calls) == 2
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+    assert out == "OK"
+
+
+def test_anthropic_complete_ohne_fehler_kein_retry(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeRawResponseNS:
+        async def create(self, **kwargs):
+            calls.append(kwargs)
+            return _FakeRawResp([_FakeTextBlock()])
+
+    class FakeMessages:
+        with_raw_response = FakeRawResponseNS()
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+    monkeypatch.setattr(
+        "hydrahive.llm._oauth_usage.extract_rate_limit_headers", lambda headers: None
+    )
+
+    from hydrahive.llm._anthropic import anthropic_complete
+    out = _run(anthropic_complete(
+        key="sk-ant-test", messages=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-4-6", temperature=0.7, max_tokens=1024,
+    ))
+
+    assert len(calls) == 1
+    assert out == "OK"
+
+
+def test_anthropic_complete_anderer_bad_request_durchgereicht(monkeypatch):
+    class FakeRawResponseNS:
+        async def create(self, **kwargs):
+            raise _other_bad_request()
+
+    class FakeMessages:
+        with_raw_response = FakeRawResponseNS()
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+
+    from hydrahive.llm._anthropic import anthropic_complete
+    with pytest.raises(anthropic.BadRequestError):
+        _run(anthropic_complete(
+            key="sk-ant-test", messages=[{"role": "user", "content": "hi"}],
+            model="claude-opus-4-8", temperature=1.0, max_tokens=1024,
+        ))
+
+
+# ---------------------------------------------------------------- minimax_complete
+def test_minimax_complete_retried_ohne_temperature(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            calls.append(kwargs)
+            if "temperature" in kwargs:
+                raise _bad_request_temperature()
+            from types import SimpleNamespace
+            return SimpleNamespace(content=[_FakeTextBlock()])
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+
+    from hydrahive.llm._anthropic import minimax_complete
+    out = _run(minimax_complete(
+        api_key="key", messages=[{"role": "user", "content": "hi"}],
+        model="MiniMax-M2", temperature=1.0, max_tokens=1024,
+    ))
+
+    assert len(calls) == 2 and "temperature" not in calls[1]
+    assert out == "OK"
+
+
+# ---------------------------------------------------------------- anthropic_stream / minimax_stream
+class _FakeStreamObj:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+    @property
+    def text_stream(self):
+        return self
+
+
+class _FakeManager:
+    def __init__(self, should_raise: bool):
+        self._should_raise = should_raise
+
+    async def __aenter__(self):
+        if self._should_raise:
+            raise _bad_request_temperature()
+        return _FakeStreamObj()
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _drain(agen):
+    async def _run_it():
+        return [x async for x in agen]
+    return asyncio.run(_run_it())
+
+
+def test_anthropic_stream_retried_ohne_temperature(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeMessages:
+        def stream(self, **kwargs):
+            calls.append(kwargs)
+            return _FakeManager(should_raise="temperature" in kwargs)
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+
+    from hydrahive.llm._anthropic import anthropic_stream
+    _drain(anthropic_stream(
+        key="sk-ant-test", messages=[{"role": "user", "content": "hi"}],
+        model="claude-opus-4-8", temperature=1.0, max_tokens=1024,
+    ))
+
+    assert len(calls) == 2
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+
+
+def test_minimax_stream_retried_ohne_temperature(monkeypatch):
+    calls: list[dict] = []
+
+    class FakeMessages:
+        def stream(self, **kwargs):
+            calls.append(kwargs)
+            return _FakeManager(should_raise="temperature" in kwargs)
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.messages = FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", FakeClient)
+
+    from hydrahive.llm._anthropic import minimax_stream
+    _drain(minimax_stream(
+        api_key="key", messages=[{"role": "user", "content": "hi"}],
+        model="MiniMax-M2", temperature=1.0, max_tokens=1024,
+    ))
+
+    assert len(calls) == 2 and "temperature" not in calls[1]


### PR DESCRIPTION
## Bug
Gefunden auf Tills neuem Server (192.168.178.121, read-only bestätigt — keine Server-Änderung vorgenommen): `default_model=claude-opus-4-8` + LLM-Test-Button →
```
Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': '`temperature` is deprecated for this model.'}}
```

## Ursache
Neuere Claude-Modelle (opus-4-7+, sonnet-5) akzeptieren keinen `temperature`-Parameter mehr. Es gibt dafür schon einen Retry-Mechanismus — aber **nur im Runner-Pfad** (`hydrahive.runner._stream_providers`, siehe `test_stream_temperature_retry.py`).

`hydrahive.llm._anthropic` — genutzt von `llm_client.complete()`/`stream()`, u.a. vom **Modell-Test-Button** `/api/llm/catalog/test` — hatte den Retry **nicht**, obwohl der Docstring in `apply_effort()` genau das versprach (*"der deprecated-temperature-Retry im Call-Layer kümmert sich darum"*). Der Kommentar war schlicht nicht (mehr) wahr.

## Fix
Gleiches `try/except BadRequestError`-Muster wie im Runner, jetzt in allen vier direkten Anthropic-SDK-Pfaden:
- `anthropic_complete`
- `anthropic_stream`
- `minimax_complete`
- `minimax_stream`

Bei den Stream-Varianten liegt der eigentliche Request im `__aenter__` des Context-Managers — der `try/except` muss den ganzen `async with`-Block umschließen, nicht nur den Aufruf (gleiche Bugklasse wie in `_stream_providers.py` bereits gelöst, dort im Kommentar sogar explizit als "Der Bug" dokumentiert).

## Verifikation
- ✅ 6 neue Tests (`test_llm_anthropic_temperature_retry.py`): complete + stream, Anthropic + MiniMax, jeweils Retry / kein Retry nötig / anderer Fehler wird durchgereicht
- ✅ 58 Tests der breiteren Anthropic/Effort/Reasoning-Suite weiterhin grün
- ✅ Auf 192.168.178.121 read-only bestätigt: identischer Bug-Stand (Commit `edfdbd42`, `default_model=claude-opus-4-8`) — keine Änderung am Server vorgenommen, Fix läuft über den normalen Update-Weg