### PR TITLE
fix(backup): System-Restore scheitert an config_dir in /etc (Permission denied)

### DIFF
--- a/core/src/hydrahive/backup/restore.py
+++ b/core/src/hydrahive/backup/restore.py
@@ -13,7 +13,10 @@ Wenn Schritte 1-3 scheitern, bleibt der Live-Stand unverändert.
 from __future__ import annotations
 
 import logging
+import os
+import shlex
 import shutil
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -77,8 +80,16 @@ def _atomic_replace_dir(src: Path, dst: Path) -> None:
 
     Nicht strikt atomic — wenn zwischen rename und Löschen abgebrochen wird,
     bleibt der .old-Pfad stehen und kann manuell wiederhergestellt werden.
+
+    Wenn das Ziel-Elternverzeichnis für den Service-User nicht schreibbar ist
+    (z.B. ``config_dir`` = ``/etc/hydrahive2`` — ``/etc`` gehört root), läuft der
+    Replace über ``sudo -n bash`` (vorhandenes NOPASSWD-Recht, gleiches Muster wie
+    Extensions-Manager/SMB-Mounter). Sonst der reine-Python-Pfad wie bisher.
     """
     dst.parent.mkdir(parents=True, exist_ok=True)
+    if not os.access(dst.parent, os.W_OK):
+        _privileged_replace_dir(src, dst)
+        return
     if dst.exists():
         old = dst.with_suffix(dst.suffix + ".old-restore")
         if old.exists():
@@ -92,6 +103,54 @@ def _atomic_replace_dir(src: Path, dst: Path) -> None:
         shutil.rmtree(old, ignore_errors=True)
     else:
         shutil.move(str(src), str(dst))
+
+
+def _privileged_replace_dir(src: Path, dst: Path) -> None:
+    """Verzeichnis-Replace über ``sudo -n bash`` — für Ziele deren Elternpfad
+    dem Service-User nicht gehört (``/etc/hydrahive2``).
+
+    Gleiches Auto-Rollback-Prinzip wie der Python-Pfad: altes Verzeichnis nach
+    ``.old-restore`` umziehen, neues rein, altes löschen; bei Fehler das alte
+    zurückholen. Läuft als EIN bash-Aufruf, damit die Schritte atomar unter root
+    ablaufen. Wenn der Prozess bereits als root läuft (getuid==0), ohne sudo.
+    """
+    s = shlex.quote(str(src))
+    d = shlex.quote(str(dst))
+    old = shlex.quote(str(dst) + ".old-restore")
+    # Das neue Verzeichnis wird von root (via sudo) verschoben und gehört danach
+    # root — die Ownership muss auf den Service-User zurück, sonst kann der Dienst
+    # seine eigene Config (users.json, llm.json …) nicht mehr schreiben. Rechte
+    # wie im Installer (20-paths.sh): <user>:<user>, dir 770.
+    owner = shlex.quote(f"{_service_user()}:{_service_user()}")
+    # set -e: bricht bei jedem Fehler ab. Bei mv-Fehler des neuen Verzeichnisses
+    # wird das alte zurückgeholt (|| mv old dst) und mit Exit 1 abgebrochen.
+    script = (
+        f"set -e; "
+        f'if [ -e {d} ]; then '
+        f"rm -rf {old}; "
+        f"mv {d} {old}; "
+        f"mv {s} {d} || {{ mv {old} {d}; exit 1; }}; "
+        f"rm -rf {old}; "
+        f"else mv {s} {d}; fi; "
+        f"chown -R {owner} {d}; chmod 770 {d}"
+    )
+    cmd = ["bash", "-c", script] if os.getuid() == 0 else ["sudo", "-n", "bash", "-c", script]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if proc.returncode != 0:
+        raise RestoreError(
+            f"config_dir-Replace fehlgeschlagen (rc={proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+
+
+def _service_user() -> str:
+    """Name des Users, unter dem der Dienst läuft (für chown nach dem sudo-Move)."""
+    import getpass
+    try:
+        return getpass.getuser()
+    except Exception:
+        import pwd
+        return pwd.getpwuid(os.getuid()).pw_name
 
 
 def _trigger_restart() -> None:

--- a/core/tests/test_backup_restore_config_perms.py
+++ b/core/tests/test_backup_restore_config_perms.py
@@ -1,0 +1,158 @@
+"""System-Restore: config_dir (/etc/hydrahive2) liegt unter einem Elternpfad
+(/etc), den der Service-User nicht beschreiben darf → Verzeichnis-rename schlägt
+mit 'Permission denied' fehl.
+
+Fix: _atomic_replace_dir erkennt nicht-schreibbares Elternverzeichnis und ersetzt
+über _privileged_replace_dir (sudo -n bash, vorhandenes NOPASSWD-Recht). Der
+data_dir-Pfad (schreibbares Elternverzeichnis) bleibt reiner Python-Move.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def test_replace_writable_parent_uses_python_path(tmp_path, monkeypatch):
+    """Schreibbares Elternverzeichnis → reiner Python-Move, KEIN sudo."""
+    from hydrahive.backup import restore
+
+    called = {"privileged": False}
+    monkeypatch.setattr(
+        restore, "_privileged_replace_dir",
+        lambda s, d: called.__setitem__("privileged", True),
+    )
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "file.txt").write_text("neu")
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "file.txt").write_text("alt")
+
+    restore._atomic_replace_dir(src, dst)
+
+    assert called["privileged"] is False
+    assert (dst / "file.txt").read_text() == "neu"
+
+
+def test_replace_readonly_parent_uses_privileged_path(tmp_path, monkeypatch):
+    """Nicht-schreibbares Elternverzeichnis → _privileged_replace_dir wird genutzt."""
+    from hydrahive.backup import restore
+
+    captured = {}
+    monkeypatch.setattr(
+        restore, "_privileged_replace_dir",
+        lambda s, d: captured.update(src=s, dst=d),
+    )
+    # os.access für das Elternverzeichnis auf False zwingen (simuliert /etc)
+    monkeypatch.setattr(restore.os, "access", lambda p, mode: False)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "etc-like" / "hydrahive2"
+
+    restore._atomic_replace_dir(src, dst)
+
+    assert captured["dst"] == dst
+    assert captured["src"] == src
+
+
+def test_privileged_replace_builds_sudo_command(tmp_path, monkeypatch):
+    """_privileged_replace_dir ruft 'sudo -n bash -c <script>' mit dem
+    korrekten mv/chown-Script (wenn nicht als root)."""
+    from hydrahive.backup import restore
+
+    recorded = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr(restore.subprocess, "run", fake_run)
+    monkeypatch.setattr(restore.os, "getuid", lambda: 1000)  # nicht root
+    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
+
+    src = tmp_path / "src"
+    dst = tmp_path / "target"
+    restore._privileged_replace_dir(src, dst)
+
+    cmd = recorded["cmd"]
+    assert cmd[:3] == ["sudo", "-n", "bash"]
+    assert cmd[3] == "-c"
+    script = cmd[4]
+    # Move + Auto-Rollback + Ownership-Wiederherstellung im Script
+    assert str(dst) in script and str(src) in script
+    assert ".old-restore" in script
+    assert "chown -R" in script and "hydrahive:hydrahive" in script
+    assert "chmod 770" in script
+
+
+def test_privileged_replace_as_root_no_sudo(tmp_path, monkeypatch):
+    """Läuft der Prozess bereits als root → bash ohne sudo-Präfix."""
+    from hydrahive.backup import restore
+
+    recorded = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(restore.subprocess, "run",
+                        lambda cmd, **k: recorded.update(cmd=cmd) or _Proc())
+    monkeypatch.setattr(restore.os, "getuid", lambda: 0)  # root
+    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
+
+    restore._privileged_replace_dir(tmp_path / "s", tmp_path / "d")
+
+    assert recorded["cmd"][0] == "bash"
+    assert "sudo" not in recorded["cmd"]
+
+
+def test_privileged_replace_raises_on_failure(tmp_path, monkeypatch):
+    """Nicht-0-Exit des sudo-Scripts → RestoreError mit stderr."""
+    from hydrahive.backup import restore
+    from hydrahive.backup.validate import RestoreError
+
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "mv: cannot move"
+
+    monkeypatch.setattr(restore.subprocess, "run", lambda cmd, **k: _Proc())
+    monkeypatch.setattr(restore.os, "getuid", lambda: 1000)
+    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
+
+    with pytest.raises(RestoreError, match="config_dir-Replace fehlgeschlagen"):
+        restore._privileged_replace_dir(tmp_path / "s", tmp_path / "d")
+
+
+def test_privileged_replace_real_move_as_root_only(tmp_path, monkeypatch):
+    """Echter Move-Roundtrip OHNE sudo (getuid=0-Pfad, echtes bash) —
+    verifiziert dass das Script mv + Auto-Rollback korrekt macht.
+    Läuft nur wenn wir tatsächlich schreibende Rechte im tmp haben (immer)."""
+    from hydrahive.backup import restore
+
+    # Als 'root' behandeln → bash ohne sudo; chown/chmod auf tmp (eigene Files) ok
+    monkeypatch.setattr(restore.os, "getuid", lambda: 0)
+    monkeypatch.setattr(restore, "_service_user", lambda: __import__("getpass").getuser())
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "neu.txt").write_text("N")
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "alt.txt").write_text("A")
+
+    restore._privileged_replace_dir(src, dst)
+
+    assert (dst / "neu.txt").read_text() == "N"
+    assert not (dst / "alt.txt").exists()          # altes Verzeichnis ersetzt
+    assert not dst.with_suffix(dst.suffix + ".old-restore").exists()  # aufgeräumt
+    assert not src.exists()                         # src wurde verschoben


### PR DESCRIPTION
## Bug
Real auf frisch installiertem Server **192.168.178.121** reproduziert: System-Backup-Restore bricht ab mit
```
backup_restore_failed: [Errno 13] Permission denied:
'/etc/hydrahive2' -> '/etc/hydrahive2.old-restore'
```

## Ursache — kein Server-/Installer-Problem
Auf dem frischen Server ist alles korrekt: `/etc/hydrahive2` gehört `hydrahive`, `/etc` gehört root, Dienst läuft als `hydrahive`. Der Bug steckt im **Restore-Code**:

`_atomic_replace_dir` ersetzt `config_dir` (`/etc/hydrahive2`) per `rename()`. `rename` braucht aber Schreibrecht auf dem **Eltern**-Verzeichnis `/etc` — und das gehört root. Bei `data_dir` (`/var/lib/...`) klappt es, weil dort auch der Elternpfad `hydrahive` gehört. **Dieser Restore konnte auf keinem normal installierten Server je funktionieren** — kein 121er-Sonderfall.

## Fix
`_atomic_replace_dir` prüft `os.access(dst.parent, W_OK)`. Ist der Elternpfad nicht schreibbar (der `/etc`-Fall), läuft der Verzeichnis-Replace über `_privileged_replace_dir` → `sudo -n bash -c` mit dem **vorhandenen** NOPASSWD-Recht (`hydrahive ALL=(ALL) NOPASSWD: /bin/bash`) — exakt das etablierte Muster von Extensions-Manager, SMB-Mounter und Tailscale-Installer.

- Gleiche Auto-Rollback-Logik (`.old-restore`, bei mv-Fehler zurückholen) in **einem** bash-Aufruf → atomar unter root
- Nach dem sudo-Move gehört das Verzeichnis root → `chown -R <service-user>` + `chmod 770` im selben Script (Rechte wie Installer `20-paths.sh`), sonst kann der Dienst seine eigene Config (`users.json`, `llm.json`) nicht mehr schreiben
- Läuft der Prozess schon als root → ohne sudo
- `data_dir` + DB-Pfad **unverändert** (reiner Python-Move, Elternpfad schreibbar)

## Tests
6 neue (`test_backup_restore_config_perms.py`): Python-Pfad bei schreibbarem Parent, privileged-Pfad bei read-only Parent, sudo-Command-Aufbau inkl. chown/chmod, root-ohne-sudo, Fehler→`RestoreError`, echter Move-Roundtrip. **15 bestehende Backup/Restore-Tests grün** (keine Regression).

Fixes das Restore-Szenario "Vollbackup von Server A auf frischen Server B einspielen".