### PR TITLE
fix(backup): Restore config_dir — Bind-Mount-EBUSY + /etc-EPERM (Folge zu #238)

### DIFF
--- a/core/src/hydrahive/backup/restore.py
+++ b/core/src/hydrahive/backup/restore.py
@@ -14,9 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
-import shlex
 import shutil
-import subprocess
 import tarfile
 import tempfile
 import time
@@ -76,22 +74,31 @@ def _create_rollback_backup() -> Path:
 
 
 def _atomic_replace_dir(src: Path, dst: Path) -> None:
-    """Verzeichnis-Replace: alten Pfad nach .old umbenennen, neuen rein, alten löschen.
+    """Ersetzt das Zielverzeichnis durch ``src``.
 
-    Nicht strikt atomic — wenn zwischen rename und Löschen abgebrochen wird,
-    bleibt der .old-Pfad stehen und kann manuell wiederhergestellt werden.
+    Bevorzugt der schnelle, atomare Verzeichnis-rename (altes → ``.old-restore``,
+    neues rein, altes löschen). Der greift aber NICHT, wenn das Zielverzeichnis
+    selbst nicht umbenannt werden kann:
 
-    Wenn das Ziel-Elternverzeichnis für den Service-User nicht schreibbar ist
-    (z.B. ``config_dir`` = ``/etc/hydrahive2`` — ``/etc`` gehört root), läuft der
-    Replace über ``sudo -n bash`` (vorhandenes NOPASSWD-Recht, gleiches Muster wie
-    Extensions-Manager/SMB-Mounter). Sonst der reine-Python-Pfad wie bisher.
+    - ``config_dir`` = ``/etc/hydrahive2`` liegt in ``/etc`` (gehört root) → der
+      Service-User darf dort nicht umbenennen (EPERM), UND
+    - der systemd-Dienst richtet ``ReadWritePaths=/etc/hydrahive2 /var/lib/hydrahive2``
+      als Bind-Mounts im Service-Namespace ein → das Verzeichnis IST ein
+      Mount-Point und ``rename`` schlägt mit EBUSY fehl.
+
+    In beiden Fällen wird der INHALT in-place ersetzt (Dateien im bestehenden
+    Verzeichnis austauschen), statt das Verzeichnis selbst zu bewegen. Das umgeht
+    Permission UND Bind-Mount, ohne sudo — alle Operationen laufen im
+    user-eigenen Verzeichnis.
     """
     dst.parent.mkdir(parents=True, exist_ok=True)
-    if not os.access(dst.parent, os.W_OK):
-        _privileged_replace_dir(src, dst)
+    if not dst.exists():
+        shutil.move(str(src), str(dst))
         return
-    if dst.exists():
-        old = dst.with_suffix(dst.suffix + ".old-restore")
+
+    old = dst.with_suffix(dst.suffix + ".old-restore")
+    if _can_rename_dir(dst, old):
+        # Schneller Pfad: Verzeichnis atomar tauschen.
         if old.exists():
             shutil.rmtree(old, ignore_errors=True)
         dst.rename(old)
@@ -102,55 +109,97 @@ def _atomic_replace_dir(src: Path, dst: Path) -> None:
             raise
         shutil.rmtree(old, ignore_errors=True)
     else:
-        shutil.move(str(src), str(dst))
+        # Mount-Point / nicht umbenennbares Verzeichnis: Inhalt in-place ersetzen.
+        _replace_dir_contents(src, dst)
 
 
-def _privileged_replace_dir(src: Path, dst: Path) -> None:
-    """Verzeichnis-Replace über ``sudo -n bash`` — für Ziele deren Elternpfad
-    dem Service-User nicht gehört (``/etc/hydrahive2``).
-
-    Gleiches Auto-Rollback-Prinzip wie der Python-Pfad: altes Verzeichnis nach
-    ``.old-restore`` umziehen, neues rein, altes löschen; bei Fehler das alte
-    zurückholen. Läuft als EIN bash-Aufruf, damit die Schritte atomar unter root
-    ablaufen. Wenn der Prozess bereits als root läuft (getuid==0), ohne sudo.
-    """
-    s = shlex.quote(str(src))
-    d = shlex.quote(str(dst))
-    old = shlex.quote(str(dst) + ".old-restore")
-    # Das neue Verzeichnis wird von root (via sudo) verschoben und gehört danach
-    # root — die Ownership muss auf den Service-User zurück, sonst kann der Dienst
-    # seine eigene Config (users.json, llm.json …) nicht mehr schreiben. Rechte
-    # wie im Installer (20-paths.sh): <user>:<user>, dir 770.
-    owner = shlex.quote(f"{_service_user()}:{_service_user()}")
-    # set -e: bricht bei jedem Fehler ab. Bei mv-Fehler des neuen Verzeichnisses
-    # wird das alte zurückgeholt (|| mv old dst) und mit Exit 1 abgebrochen.
-    script = (
-        f"set -e; "
-        f'if [ -e {d} ]; then '
-        f"rm -rf {old}; "
-        f"mv {d} {old}; "
-        f"mv {s} {d} || {{ mv {old} {d}; exit 1; }}; "
-        f"rm -rf {old}; "
-        f"else mv {s} {d}; fi; "
-        f"chown -R {owner} {d}; chmod 770 {d}"
-    )
-    cmd = ["bash", "-c", script] if os.getuid() == 0 else ["sudo", "-n", "bash", "-c", script]
-    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    if proc.returncode != 0:
-        raise RestoreError(
-            f"config_dir-Replace fehlgeschlagen (rc={proc.returncode}): "
-            f"{proc.stderr.strip() or proc.stdout.strip()}"
-        )
-
-
-def _service_user() -> str:
-    """Name des Users, unter dem der Dienst läuft (für chown nach dem sudo-Move)."""
-    import getpass
+def _can_rename_dir(dst: Path, probe: Path) -> bool:
+    """Testet ohne Seiteneffekt, ob ``dst`` umbenannt werden kann (nicht Mount-
+    Point, Elternpfad schreibbar). Benennt kurz um und sofort zurück."""
+    if not os.access(dst.parent, os.W_OK):
+        return False
+    if probe.exists():
+        return False
     try:
-        return getpass.getuser()
+        dst.rename(probe)
+    except OSError:
+        return False
+    try:
+        probe.rename(dst)
+    except OSError:
+        # Rückbenennung scheiterte — extrem unwahrscheinlich; als nicht-renambar
+        # behandeln, damit der Inhalts-Pfad übernimmt (dst liegt noch als probe).
+        try:
+            probe.rename(dst)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def _replace_dir_contents(src: Path, dst: Path) -> None:
+    """Ersetzt den Inhalt von ``dst`` durch den von ``src`` — Datei für Datei,
+    ohne ``dst`` selbst zu bewegen (Mount-Point-/Permission-sicher).
+
+    Auto-Rollback: alter Inhalt wandert erst in ein ``.old-restore/`` UNTERHALB
+    von ``dst`` (gleiches Filesystem, umbenennbar), wird bei Erfolg gelöscht und
+    bei Fehler zurückgeholt. Einträge, die der User nicht bewegen kann (fremd-
+    owned wie root-eigene ``env``/``extensions``), werden übersprungen und bleiben
+    unverändert erhalten — die sind hostspezifisch, nicht Teil eines portablen
+    Restores (analog zum ``tls/``-Ausschluss im Backup)."""
+    backup = dst / ".old-restore"
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
+    backup.mkdir(parents=True, exist_ok=True)
+
+    backed_up: list[str] = []   # Namen, deren Original in backup/ liegt
+    added: list[str] = []        # Namen, die wir neu in dst eingebracht haben
+    skipped: list[str] = []
+    try:
+        # 1) bestehenden Inhalt (außer dem backup-Ordner) beiseite räumen
+        for entry in list(dst.iterdir()):
+            if entry == backup:
+                continue
+            try:
+                entry.rename(backup / entry.name)
+                backed_up.append(entry.name)
+            except OSError:
+                # Nicht bewegbar (fremd-owned, z.B. root:hydrahive env/extensions)
+                # → unverändert lassen. Hostspezifisch, gehört nicht in den Restore.
+                skipped.append(entry.name)
+
+        # 2) neuen Inhalt hineinbringen (skip, was wir übersprungen haben)
+        for entry in list(src.iterdir()):
+            if entry.name in skipped:
+                continue
+            shutil.move(str(entry), str(dst / entry.name))
+            added.append(entry.name)
+
+        # 3) Erfolg → alten Inhalt löschen
+        shutil.rmtree(backup, ignore_errors=True)
+        if skipped:
+            logger.warning(
+                "config-Restore: %d hostspezifische Einträge übersprungen "
+                "(fremd-owned, unverändert erhalten): %s",
+                len(skipped), ", ".join(sorted(skipped)),
+            )
     except Exception:
-        import pwd
-        return pwd.getpwuid(os.getuid()).pw_name
+        # Rollback: erst neu eingebrachte Einträge raus, dann Originale zurück.
+        for name in added:
+            live = dst / name
+            if live.is_dir():
+                shutil.rmtree(live, ignore_errors=True)
+            else:
+                live.unlink(missing_ok=True)
+        for name in backed_up:
+            src_bak = backup / name
+            if src_bak.exists():
+                try:
+                    src_bak.rename(dst / name)
+                except OSError:
+                    pass
+        shutil.rmtree(backup, ignore_errors=True)
+        raise
 
 
 def _trigger_restart() -> None:

--- a/core/tests/test_backup_restore_config_perms.py
+++ b/core/tests/test_backup_restore_config_perms.py
@@ -1,158 +1,164 @@
-"""System-Restore: config_dir (/etc/hydrahive2) liegt unter einem Elternpfad
-(/etc), den der Service-User nicht beschreiben darf → Verzeichnis-rename schlägt
-mit 'Permission denied' fehl.
+"""System-Restore: config_dir (/etc/hydrahive2) kann NICHT per Verzeichnis-rename
+ersetzt werden — zwei Gründe, die zusammen auftreten:
 
-Fix: _atomic_replace_dir erkennt nicht-schreibbares Elternverzeichnis und ersetzt
-über _privileged_replace_dir (sudo -n bash, vorhandenes NOPASSWD-Recht). Der
-data_dir-Pfad (schreibbares Elternverzeichnis) bleibt reiner Python-Move.
+1. /etc gehört root → Service-User (hydrahive) darf dort nicht umbenennen (EPERM).
+2. Die systemd-Unit setzt ReadWritePaths=/etc/hydrahive2 → das Verzeichnis ist im
+   Service-Namespace ein Bind-Mount → rename() gibt EBUSY.
+
+Fix: _atomic_replace_dir testet ob dst umbenennbar ist (_can_rename_dir). Wenn
+nicht, wird der INHALT in-place ersetzt (_replace_dir_contents) — Mount-Point-
+und Permission-sicher, ohne sudo. Fremd-owned Einträge (root:hydrahive env/
+extensions) werden übersprungen (hostspezifisch).
 """
 from __future__ import annotations
-
-import os
 
 import pytest
 
 
-def test_replace_writable_parent_uses_python_path(tmp_path, monkeypatch):
-    """Schreibbares Elternverzeichnis → reiner Python-Move, KEIN sudo."""
+def test_can_rename_normal_dir(tmp_path):
+    """Normales Verzeichnis mit schreibbarem Parent → umbenennbar."""
     from hydrahive.backup import restore
 
-    called = {"privileged": False}
-    monkeypatch.setattr(
-        restore, "_privileged_replace_dir",
-        lambda s, d: called.__setitem__("privileged", True),
-    )
-
-    src = tmp_path / "src"
-    src.mkdir()
-    (src / "file.txt").write_text("neu")
-    dst = tmp_path / "dst"
+    dst = tmp_path / "d"
     dst.mkdir()
-    (dst / "file.txt").write_text("alt")
+    (dst / "x").write_text("1")
+    assert restore._can_rename_dir(dst, tmp_path / "d.old") is True
+    # nach dem Probe-Test steht dst wieder am Platz, Inhalt intakt
+    assert (dst / "x").read_text() == "1"
+
+
+def test_can_rename_readonly_parent(tmp_path, monkeypatch):
+    """Nicht-schreibbares Elternverzeichnis (simuliert /etc) → nicht umbenennbar."""
+    from hydrahive.backup import restore
+
+    dst = tmp_path / "d"
+    dst.mkdir()
+    monkeypatch.setattr(restore.os, "access", lambda p, mode: False)
+    assert restore._can_rename_dir(dst, tmp_path / "d.old") is False
+
+
+def test_replace_dir_uses_rename_when_possible(tmp_path, monkeypatch):
+    """Umbenennbares Ziel → schneller rename-Pfad, KEIN Content-Replace."""
+    from hydrahive.backup import restore
+
+    called = {"contents": False}
+    monkeypatch.setattr(restore, "_replace_dir_contents",
+                        lambda s, d: called.__setitem__("contents", True))
+
+    src = tmp_path / "src"; src.mkdir(); (src / "neu").write_text("N")
+    dst = tmp_path / "dst"; dst.mkdir(); (dst / "alt").write_text("A")
 
     restore._atomic_replace_dir(src, dst)
+    assert called["contents"] is False
+    assert (dst / "neu").read_text() == "N"
+    assert not (dst / "alt").exists()
 
-    assert called["privileged"] is False
-    assert (dst / "file.txt").read_text() == "neu"
 
-
-def test_replace_readonly_parent_uses_privileged_path(tmp_path, monkeypatch):
-    """Nicht-schreibbares Elternverzeichnis → _privileged_replace_dir wird genutzt."""
+def test_replace_dir_falls_back_to_contents(tmp_path, monkeypatch):
+    """Nicht umbenennbares Ziel → Content-Replace-Pfad."""
     from hydrahive.backup import restore
 
     captured = {}
-    monkeypatch.setattr(
-        restore, "_privileged_replace_dir",
-        lambda s, d: captured.update(src=s, dst=d),
-    )
-    # os.access für das Elternverzeichnis auf False zwingen (simuliert /etc)
-    monkeypatch.setattr(restore.os, "access", lambda p, mode: False)
+    monkeypatch.setattr(restore, "_can_rename_dir", lambda d, p: False)
+    monkeypatch.setattr(restore, "_replace_dir_contents",
+                        lambda s, d: captured.update(src=s, dst=d))
 
-    src = tmp_path / "src"
-    src.mkdir()
-    dst = tmp_path / "etc-like" / "hydrahive2"
-
+    src = tmp_path / "src"; src.mkdir()
+    dst = tmp_path / "dst"; dst.mkdir()
     restore._atomic_replace_dir(src, dst)
-
-    assert captured["dst"] == dst
-    assert captured["src"] == src
+    assert captured == {"src": src, "dst": dst}
 
 
-def test_privileged_replace_builds_sudo_command(tmp_path, monkeypatch):
-    """_privileged_replace_dir ruft 'sudo -n bash -c <script>' mit dem
-    korrekten mv/chown-Script (wenn nicht als root)."""
+# ---------------------------------------------------------------- Content-Replace
+def test_replace_contents_swaps_files(tmp_path):
+    """In-place Content-Replace: dst behält seine Identität (Mount-Point-sicher),
+    Inhalt wird ausgetauscht, .old-restore aufgeräumt."""
     from hydrahive.backup import restore
 
-    recorded = {}
+    src = tmp_path / "src"; src.mkdir()
+    (src / "llm.json").write_text("neu")
+    (src / "sub").mkdir(); (src / "sub" / "a.txt").write_text("x")
 
-    class _Proc:
-        returncode = 0
-        stdout = ""
-        stderr = ""
+    dst = tmp_path / "dst"; dst.mkdir()
+    dst_inode = dst.stat().st_ino
+    (dst / "llm.json").write_text("alt")
+    (dst / "weg.json").write_text("weg")
 
-    def fake_run(cmd, **kwargs):
-        recorded["cmd"] = cmd
-        return _Proc()
+    restore._replace_dir_contents(src, dst)
 
-    monkeypatch.setattr(restore.subprocess, "run", fake_run)
-    monkeypatch.setattr(restore.os, "getuid", lambda: 1000)  # nicht root
-    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
-
-    src = tmp_path / "src"
-    dst = tmp_path / "target"
-    restore._privileged_replace_dir(src, dst)
-
-    cmd = recorded["cmd"]
-    assert cmd[:3] == ["sudo", "-n", "bash"]
-    assert cmd[3] == "-c"
-    script = cmd[4]
-    # Move + Auto-Rollback + Ownership-Wiederherstellung im Script
-    assert str(dst) in script and str(src) in script
-    assert ".old-restore" in script
-    assert "chown -R" in script and "hydrahive:hydrahive" in script
-    assert "chmod 770" in script
+    assert dst.stat().st_ino == dst_inode          # dst NICHT bewegt (Mount-safe)
+    assert (dst / "llm.json").read_text() == "neu"  # ersetzt
+    assert (dst / "sub" / "a.txt").read_text() == "x"  # neu rein
+    assert not (dst / "weg.json").exists()          # alter Inhalt weg
+    assert not (dst / ".old-restore").exists()       # Backup aufgeräumt
 
 
-def test_privileged_replace_as_root_no_sudo(tmp_path, monkeypatch):
-    """Läuft der Prozess bereits als root → bash ohne sudo-Präfix."""
+def test_replace_contents_skips_unmovable(tmp_path, monkeypatch):
+    """Fremd-owned Einträge (können nicht umbenannt werden) werden übersprungen
+    und bleiben unverändert erhalten — env/extensions bleiben vom Zielserver."""
     from hydrahive.backup import restore
 
-    recorded = {}
+    src = tmp_path / "src"; src.mkdir()
+    (src / "llm.json").write_text("neu")
+    (src / "env").write_text("SRC-ENV")  # käme aus Backup, soll NICHT übernommen werden
 
-    class _Proc:
-        returncode = 0
-        stdout = ""
-        stderr = ""
+    dst = tmp_path / "dst"; dst.mkdir()
+    (dst / "llm.json").write_text("alt")
+    (dst / "env").write_text("HOST-ENV")  # hostspezifisch, "fremd-owned"
 
-    monkeypatch.setattr(restore.subprocess, "run",
-                        lambda cmd, **k: recorded.update(cmd=cmd) or _Proc())
-    monkeypatch.setattr(restore.os, "getuid", lambda: 0)  # root
-    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
+    real_rename = restore.Path.rename
 
-    restore._privileged_replace_dir(tmp_path / "s", tmp_path / "d")
+    def guarded_rename(self, target):
+        # 'env' simuliert fremd-owned: rename ins Backup schlägt fehl
+        if self.name == "env" and ".old-restore" in str(target):
+            raise OSError("Operation not permitted")
+        return real_rename(self, target)
 
-    assert recorded["cmd"][0] == "bash"
-    assert "sudo" not in recorded["cmd"]
+    monkeypatch.setattr(restore.Path, "rename", guarded_rename)
 
+    restore._replace_dir_contents(src, dst)
 
-def test_privileged_replace_raises_on_failure(tmp_path, monkeypatch):
-    """Nicht-0-Exit des sudo-Scripts → RestoreError mit stderr."""
-    from hydrahive.backup import restore
-    from hydrahive.backup.validate import RestoreError
-
-    class _Proc:
-        returncode = 1
-        stdout = ""
-        stderr = "mv: cannot move"
-
-    monkeypatch.setattr(restore.subprocess, "run", lambda cmd, **k: _Proc())
-    monkeypatch.setattr(restore.os, "getuid", lambda: 1000)
-    monkeypatch.setattr(restore, "_service_user", lambda: "hydrahive")
-
-    with pytest.raises(RestoreError, match="config_dir-Replace fehlgeschlagen"):
-        restore._privileged_replace_dir(tmp_path / "s", tmp_path / "d")
+    assert (dst / "llm.json").read_text() == "neu"     # normal ersetzt
+    assert (dst / "env").read_text() == "HOST-ENV"      # übersprungen, Host-Wert bleibt
 
 
-def test_privileged_replace_real_move_as_root_only(tmp_path, monkeypatch):
-    """Echter Move-Roundtrip OHNE sudo (getuid=0-Pfad, echtes bash) —
-    verifiziert dass das Script mv + Auto-Rollback korrekt macht.
-    Läuft nur wenn wir tatsächlich schreibende Rechte im tmp haben (immer)."""
+def test_replace_contents_rollback_on_error(tmp_path, monkeypatch):
+    """Fehler beim Einbringen des neuen Inhalts → alter Inhalt wird zurückgeholt."""
     from hydrahive.backup import restore
 
-    # Als 'root' behandeln → bash ohne sudo; chown/chmod auf tmp (eigene Files) ok
-    monkeypatch.setattr(restore.os, "getuid", lambda: 0)
-    monkeypatch.setattr(restore, "_service_user", lambda: __import__("getpass").getuser())
+    src = tmp_path / "src"; src.mkdir()
+    (src / "a.json").write_text("A-neu")
+    (src / "b.json").write_text("B-neu")
 
-    src = tmp_path / "src"
-    src.mkdir()
-    (src / "neu.txt").write_text("N")
-    dst = tmp_path / "dst"
-    dst.mkdir()
-    (dst / "alt.txt").write_text("A")
+    dst = tmp_path / "dst"; dst.mkdir()
+    (dst / "a.json").write_text("A-alt")
+    (dst / "b.json").write_text("B-alt")
 
-    restore._privileged_replace_dir(src, dst)
+    real_move = restore.shutil.move
+    state = {"n": 0}
 
-    assert (dst / "neu.txt").read_text() == "N"
-    assert not (dst / "alt.txt").exists()          # altes Verzeichnis ersetzt
-    assert not dst.with_suffix(dst.suffix + ".old-restore").exists()  # aufgeräumt
-    assert not src.exists()                         # src wurde verschoben
+    def flaky_move(s, d):
+        state["n"] += 1
+        if state["n"] == 2:  # zweites Einbringen schlägt fehl
+            raise OSError("disk full")
+        return real_move(s, d)
+
+    monkeypatch.setattr(restore.shutil, "move", flaky_move)
+
+    with pytest.raises(OSError):
+        restore._replace_dir_contents(src, dst)
+
+    # Rollback: beide Originale wieder da, kein .old-restore-Rest
+    assert (dst / "a.json").read_text() == "A-alt"
+    assert (dst / "b.json").read_text() == "B-alt"
+    assert not (dst / ".old-restore").exists()
+
+
+def test_replace_dir_new_target_just_moves(tmp_path):
+    """Ziel existiert noch nicht → einfacher move."""
+    from hydrahive.backup import restore
+
+    src = tmp_path / "src"; src.mkdir(); (src / "x").write_text("1")
+    dst = tmp_path / "neu-dst"
+    restore._atomic_replace_dir(src, dst)
+    assert (dst / "x").read_text() == "1"


### PR DESCRIPTION
## Bug
Folgefehler nach #238. Restore bricht jetzt ab mit:
```
config_dir-Replace fehlgeschlagen (rc=1): mv: das Verschieben von
'/etc/hydrahive2' nach '/etc/hydrahive2.old-restore' ist nicht möglich:
Das Gerät oder die Ressource ist belegt   (EBUSY)
```

## Ursache (auf 192.168.178.121 read-only verifiziert)
Die systemd-Unit setzt `ReadWritePaths=/var/lib/hydrahive2 /etc/hydrahive2`. Dadurch richtet systemd diese Verzeichnisse als **Bind-Mounts im Mount-Namespace des Dienstes** ein — sichtbar in `/proc/<pid>/mounts`:
```
/dev/sda2 /etc/hydrahive2 ext4 rw,relatime 0 0
/dev/sda2 /var/lib/hydrahive2 ext4 rw,relatime 0 0
```
Ein Verzeichnis, das (im eigenen Namespace) ein **Mount-Point** ist, lässt sich **nicht per `rename()`/`mv` verschieben** → **EBUSY**. Das erklärt, warum der manuelle `mv` (außerhalb des Namespaces) ging, der Restore aber nicht.

Der sudo-Ansatz aus #238 löste zwar das `/etc`-Permission-Problem, **aber nicht das Bind-Mount-Problem** — `mv` scheitert auch als root am Mount-Point.

## Fix
**Nicht mehr das Verzeichnis umbenennen.** `_atomic_replace_dir` prüft per `_can_rename_dir` (Probe-rename + zurück), ob das Ziel umbenennbar ist. Wenn nicht (Mount-Point **oder** `/etc`-Parent nicht schreibbar), wird der **Inhalt in-place** ersetzt (`_replace_dir_contents`):
- bestehende Einträge → `dst/.old-restore/`, neue rein, alte löschen; bei Fehler Rollback
- `dst` behält seine Identität (Inode unverändert) → **Mount-Point- UND Permission-sicher, kein sudo**

Der komplette sudo-Pfad aus #238 **entfällt** (war unnötig komplex und löste EBUSY ohnehin nicht). `data_dir`-Subdirs + DB unverändert (rename-Pfad, keine Mount-Points).

Fremd-owned Einträge (`root:hydrahive` `env`/`extensions`, nicht umbenennbar) werden übersprungen und bleiben erhalten — hostspezifisch, kein Teil eines portablen Restores (analog `tls/`-Ausschluss).

## Verifikation
Im **echten Bind-Mount-Namespace** getestet (der Prozess läuft im Service-Kontext, `/etc/hydrahive2` ist dort Mount-Point): `rename` gibt EACCES/EBUSY, `_replace_dir_contents` läuft sauber durch (Inode unverändert, Inhalt getauscht, Rollback-Ordner aufgeräumt).
- 8 neue Tests (`_can_rename_dir`, rename-vs-content-Pfadwahl, Content-Swap, skip-unmovable, Rollback-on-error, new-target)
- bestehende Backup/Restore-Tests (symlink #182) grün — keine Regression