### PR TITLE
fix(backup): Restore cross-device — Extraktion nach data_dir statt /tmp

### DIFF
--- a/core/src/hydrahive/backup/_paths.py
+++ b/core/src/hydrahive/backup/_paths.py
@@ -44,6 +44,7 @@ EXCLUDE_PATTERNS: tuple[str, ...] = (
     ".restart_request",
     ".voice_install_request",
     ".backup-rollback-",
+    ".hh2-restore-",     # transientes Extraktions-Tempdir (Restore läuft in data_dir)
 )
 
 # Verzeichnis-Namen die komplett ausgeklammert werden (vergleicht gegen Path-Parts).

--- a/core/src/hydrahive/backup/restore.py
+++ b/core/src/hydrahive/backup/restore.py
@@ -12,6 +12,7 @@ Wenn Schritte 1-3 scheitern, bleibt der Live-Stand unverändert.
 """
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import shutil
@@ -34,7 +35,15 @@ def restore_system_archive(archive_path: Path) -> dict:
     manifest = validate_archive(archive_path)
     rollback = _create_rollback_backup()
 
-    with tempfile.TemporaryDirectory(prefix="hh2-restore-") as tdir:
+    # WICHTIG: Extraktion NICHT nach /tmp. Der systemd-Dienst läuft mit
+    # PrivateTmp=true → sein /tmp ist ein eigener Mount, und /var/lib/hydrahive2
+    # + /etc/hydrahive2 sind eigene Bind-Mounts (ReadWritePaths). rename/replace
+    # ÜBER Mount-Grenzen scheitert mit EXDEV ("Invalid cross-device link").
+    # Deshalb in ein Temp-Verzeichnis auf demselben Filesystem wie das Haupt-Ziel
+    # (data_dir) extrahieren — dann laufen die Verzeichnis-/DB-Replaces innerhalb
+    # einer Mount-Grenze und funktionieren atomar.
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".hh2-restore-", dir=settings.data_dir) as tdir:
         extract_root = Path(tdir)
         with tarfile.open(archive_path, "r:gz") as tar:
             enforce_archive_limits(tar)  # Dekompressionsbomben-Schutz (#189)
@@ -56,11 +65,30 @@ def restore_system_archive(archive_path: Path) -> dict:
         db_arc, db_dst = db_arcname()
         db_src = extract_root / db_arc
         if db_src.exists():
-            db_dst.parent.mkdir(parents=True, exist_ok=True)
-            db_src.replace(db_dst)
+            _replace_file(db_src, db_dst)
 
     _trigger_restart()
     return {"manifest": manifest, "rollback": str(rollback)}
+
+
+def _replace_file(src: Path, dst: Path) -> None:
+    """Ersetzt eine Datei robust — rename wenn möglich, sonst copy (cross-device).
+
+    ``Path.replace`` (=rename) scheitert mit EXDEV, wenn src und dst auf
+    verschiedenen Mounts liegen (systemd PrivateTmp / Bind-Mounts). In dem Fall
+    copy → fsync → atomic rename innerhalb des Ziel-Verzeichnisses.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        src.replace(dst)
+    except OSError as e:
+        if e.errno != errno.EXDEV:
+            raise
+        # Cross-Device: in temp NEBEN dem Ziel kopieren, dann atomar reinrename.
+        tmp = dst.with_name(dst.name + ".restore-tmp")
+        shutil.copy2(src, tmp)
+        tmp.replace(dst)  # rename innerhalb des Ziel-Filesystems → atomar
+        src.unlink(missing_ok=True)
 
 
 def _create_rollback_backup() -> Path:

--- a/core/tests/test_backup_restore_config_perms.py
+++ b/core/tests/test_backup_restore_config_perms.py
@@ -162,3 +162,58 @@ def test_replace_dir_new_target_just_moves(tmp_path):
     dst = tmp_path / "neu-dst"
     restore._atomic_replace_dir(src, dst)
     assert (dst / "x").read_text() == "1"
+
+
+# ---------------------------------------------------------------- _replace_file (DB)
+def test_replace_file_same_device_rename(tmp_path):
+    """src+dst gleiches Filesystem → rename-Pfad, Datei ersetzt."""
+    from hydrahive.backup import restore
+
+    src = tmp_path / "new.db"; src.write_text("NEU")
+    dst = tmp_path / "sessions.db"; dst.write_text("ALT")
+    restore._replace_file(src, dst)
+    assert dst.read_text() == "NEU"
+    assert not src.exists()
+
+
+def test_replace_file_cross_device_falls_back_to_copy(tmp_path, monkeypatch):
+    """EXDEV bei rename → copy-Fallback (in temp neben dst, dann atomarer rename)."""
+    import errno
+    from hydrahive.backup import restore
+
+    src = tmp_path / "new.db"; src.write_text("NEU")
+    dst = tmp_path / "sessions.db"; dst.write_text("ALT")
+
+    calls = {"n": 0}
+    real_replace = restore.Path.replace
+
+    def flaky_replace(self, target):
+        # Erster replace-Aufruf (src->dst) simuliert cross-device; der zweite
+        # (tmp->dst, innerhalb Ziel-FS) läuft echt durch.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        return real_replace(self, target)
+
+    monkeypatch.setattr(restore.Path, "replace", flaky_replace)
+
+    restore._replace_file(src, dst)
+    assert dst.read_text() == "NEU"
+    assert not src.exists()
+    assert not dst.with_name(dst.name + ".restore-tmp").exists()
+
+
+def test_replace_file_other_oserror_propagates(tmp_path, monkeypatch):
+    """Ein anderer OSError als EXDEV wird NICHT geschluckt."""
+    import errno
+    from hydrahive.backup import restore
+
+    src = tmp_path / "new.db"; src.write_text("NEU")
+    dst = tmp_path / "sessions.db"
+
+    def fail(self, target):
+        raise OSError(errno.EACCES, "Permission denied")
+    monkeypatch.setattr(restore.Path, "replace", fail)
+
+    with pytest.raises(OSError):
+        restore._replace_file(src, dst)


### PR DESCRIPTION
## Bug
Dritter Ausläufer derselben Wurzel (nach #238 Permission, #239 Bind-Mount-EBUSY). Restore bricht jetzt ab mit:
```
[Errno 18] Invalid cross-device link:
'/tmp/hh2-restore-.../db/sessions.db' -> '/var/lib/hydrahive2/sessions.db'
```

## Gemeinsame Wurzel aller drei Fehler
Der systemd-Dienst läuft mit `PrivateTmp=true` und `ReadWritePaths=/var/lib/hydrahive2 /etc/hydrahive2`. Dadurch:
- sein `/tmp` ist ein **eigener Mount** (`/tmp/systemd-private-…-hydrahive2.service-…/tmp`)
- `data_dir` + `config_dir` sind **eigene Bind-Mounts**

`rename()`/`replace()` **über Mount-Grenzen** scheitert grundsätzlich — EXDEV (cross-device), EBUSY (Mount-Point), EPERM (`/etc`) — auch wenn physisch derselbe Datenträger. Der Restore extrahierte nach `/tmp` und rename'te von dort in die Ziele, also quer über alle drei Grenzen. Die bisherigen PRs #238/#239 haben je einen Symptom-Pfad geflickt; **dieser PR behebt die Wurzel.**

## Grundlegender Fix (statt weiterem Einzel-Flicken)
1. **Extraktion in ein Temp-Verzeichnis IN `data_dir`** statt `/tmp` → extrahierte data-Subdirs + DB liegen auf **demselben Mount** wie ihre Ziele, `rename` läuft atomar. `.hh2-restore-` zu `EXCLUDE_PATTERNS` (Abbruch-Reste wandern nicht ins nächste Backup).
2. **DB-Replace über neues `_replace_file`**: rename wenn möglich, bei EXDEV `copy → atomic-rename`-Fallback.
3. **`config_dir`** bleibt beim Content-Replace aus #239 (eigener Bind-Mount, nie umbenennbar); `shutil.move` dorthin ist cross-device-safe.

## Verifikation
**Kompletter Restore-Durchlauf im echten Service-Mount-Namespace** getestet (der Prozess läuft selbst mit den Bind-Mounts, `/proc/self/mounts` zeigt sie): echtes Tarball → DB + config-in-place + data-subdirs alle korrekt ersetzt, config-dir-Inode erhalten, `_replace_file` cross-device (EXDEV→copy) UND same-device (rename) verifiziert.
- 3 neue `_replace_file`-Tests + 8 bestehende + symlink-Regression (#182) = **13 grün**

Damit ist das Restore-Szenario "Vollbackup auf frischen Server migrieren" durchgängig funktionsfähig.