### PR TITLE
fix(ui): Modal-Overlays springen aus .box-Kacheln (Restore + Container-Shell)

### DIFF
--- a/frontend/src/features/containers/ContainerConsoleModal.tsx
+++ b/frontend/src/features/containers/ContainerConsoleModal.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react"
 import type { CSSProperties } from "react"
 import { rgbFor } from "@/shared/colors"
+import { ModalPortal } from "@/shared/ModalPortal"
 import type { Container } from "./types"
 import { ConsolePane } from "./ConsolePane"
 
@@ -11,6 +12,7 @@ interface Props {
 
 export function ContainerConsoleModal({ container, onClose }: Props) {
   return (
+    <ModalPortal>
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
       <div className="box box-static overflow-hidden w-full max-w-5xl flex flex-col"
@@ -25,5 +27,6 @@ export function ContainerConsoleModal({ container, onClose }: Props) {
         <ConsolePane containerId={container.container_id} className="flex-1" />
       </div>
     </div>
+    </ModalPortal>
   )
 }

--- a/frontend/src/features/system/BackupRestoreModal.tsx
+++ b/frontend/src/features/system/BackupRestoreModal.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react"
 import { AlertTriangle, Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { rgbFor } from "@/shared/colors"
+import { ModalPortal } from "@/shared/ModalPortal"
 
 export type RestoreState = "idle" | "confirm" | "uploading" | "waiting" | "done" | "failed"
 
@@ -14,8 +15,9 @@ export function BackupRestoreModal({ state, error, fileName, onConfirm, onClose 
 }) {
   const { t } = useTranslation("system")
   return (
+    <ModalPortal>
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
-      <div className="box overflow-hidden p-6 max-w-md w-full mx-4 space-y-4" style={{ "--c": rgbFor("/system") } as CSSProperties}>
+      <div className="box box-static overflow-hidden p-6 max-w-md w-full mx-4 space-y-4" style={{ "--c": rgbFor("/system") } as CSSProperties}>
         <div className="flex items-start gap-3">
           <AlertTriangle className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" />
           <div className="space-y-1">
@@ -51,5 +53,6 @@ export function BackupRestoreModal({ state, error, fileName, onConfirm, onClose 
         </div>
       </div>
     </div>
+    </ModalPortal>
   )
 }

--- a/frontend/src/shared/ModalPortal.tsx
+++ b/frontend/src/shared/ModalPortal.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react"
+import { createPortal } from "react-dom"
+
+/** Rendert Kinder via Portal an ``document.body``.
+ *
+ * Nötig für Overlays mit ``position: fixed``, die INNERHALB einer ``.box``
+ * (oder eines anderen Elements mit ``transform``/``filter``/``perspective``)
+ * gerendert werden: ein transformierter Vorfahr wird zum Containing-Block für
+ * ``fixed`` → das Overlay positioniert sich dann relativ zu diesem Element statt
+ * zum Viewport. Da ``.box:hover`` ein ``transform: translateY(-2px)`` setzt,
+ * „springt“ so ein Modal beim Mausbewegen zwischen Box- und Viewport-Bezug.
+ * Das Portal hängt das Overlay ans ``body`` — außerhalb jeder Box → stabil.
+ */
+export function ModalPortal({ children }: { children: ReactNode }) {
+  if (typeof document === "undefined") return null
+  return createPortal(children, document.body)
+}


### PR DESCRIPTION
## Bug (von Till gemeldet)
Beim Klick auf **Wiederherstellen** (System-Seite) bzw. **Shell** (Container) öffnet das Overlay-Fenster *in der unteren Box* statt zentriert — und **springt bei jeder Mausbewegung** zwischen Box und Seitenmitte hin und her. Man muss das Fenster "jagen" und kann nichts anklicken, nur mit Enter bestätigen.

## Ursache (eine Wurzel, zwei Symptome)
Beide Modals (`fixed inset-0`) werden **innerhalb einer `.box`** gerendert (`BackupCard` bzw. `ContainerCard`). Die `.box`-Klasse setzt bei `:hover` ein `transform: translateY(-2px)` (index.css).

Ein Vorfahr mit `transform` wird zum **Containing-Block für `position: fixed`** → das Overlay bezieht sich dann auf die Box statt auf den Viewport. Beim Mausbewegen togglet der `:hover`-Zustand (Maus mal über Box, mal über dem Overlay) → `transform` an/aus → das Overlay **springt** zwischen Box- und Viewport-Bezug.

## Fix
Neue geteilte Komponente **`ModalPortal`** (`createPortal` an `document.body`). Beide Overlays werden ans `body` gehängt — außerhalb jeder transformierten Box → stabil zentriert. `BackupRestoreModal`-Innenbox zusätzlich auf `box-static` (kein Hover-Lift, konsistent mit der Console-Box).

## Sorgfalt: nicht über-fixen
Alle **~20** `fixed inset-0`-Modals durchgegangen und ihre JSX-Verschachtelung geprüft: **nur diese zwei** liegen tatsächlich *in* einer Hover-`.box`. Die übrigen (EditVM, EditContainer, RestartModal, CredentialEditor, InstallModal, …) sind Geschwister auf Seitenebene → **nicht betroffen, bewusst nicht angefasst**.

## Verifikation
- TypeScript-Typecheck + `npm run build` grün (gegen echtes Frontend, read-only, danach zurückgesetzt)
- Reine Positionierungs-Änderung (Portal), keine Logik berührt

Der `ModalPortal`-Baustein steht für künftige Overlays-in-Boxen bereit.