### PR TITLE
feat(migration): Server-zu-Server Voll-Klon per rsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 node_modules/
 dist/
 .vite/
+.npm-cache/
 
 # Env
 .env

--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -16,6 +16,7 @@ from hydrahive.api.routes.workspace import router as workspace_router
 from hydrahive.api.routes.analytics import router as analytics_router
 from hydrahive.api.routes.auth import router as auth_router
 from hydrahive.api.routes.backup import router as backup_router
+from hydrahive.api.routes.migration import router as migration_router
 from hydrahive.api.routes.buddy import router as buddy_router
 from hydrahive.api.routes.butler import router as butler_router
 from hydrahive.api.routes.files import router as files_router
@@ -102,6 +103,7 @@ app.add_middleware(
 app.include_router(agentlink_router)
 app.include_router(auth_router)
 app.include_router(backup_router)
+app.include_router(migration_router)
 app.include_router(users_router)
 app.include_router(agents_router)
 app.include_router(agent_activity_router)

--- a/core/src/hydrahive/api/routes/migration.py
+++ b/core/src/hydrahive/api/routes/migration.py
@@ -1,0 +1,115 @@
+"""Server-zu-Server-Migration (Voll-Klon per rsync) — analog Bridge/Voice-Pattern.
+
+`POST /api/admin/migration/start` validiert die Ziel-Angaben, legt das SSH-Passwort
+in einer separaten 0600-Secret-Datei ab und schreibt einen Trigger-File. Ein
+systemd-Timer (hydrahive2-migration.timer) pollt den Trigger und startet
+hydrahive2-migration.service (oneshot, root), der `installer/migrate.sh` ausführt:
+rsync -aAX --delete über SSH zum Zielserver. Live-Log via `/api/admin/migration/log`.
+
+Das Passwort steht NIE in der Prozessliste (rsync/ssh lesen es via sshpass -f Datei)
+und NIE im Log. Der Core-Service selbst führt kein rsync/ssh aus (läuft als
+unprivilegierter `hydrahive`-User, kann root-owned Daten wie vms/ nicht lesen).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+
+from hydrahive.api.middleware.auth import require_admin
+from hydrahive.api.middleware.errors import coded
+from hydrahive.settings import settings
+
+router = APIRouter(prefix="/api/admin/migration", tags=["admin"])
+
+TRIGGER = settings.data_dir / ".migration_request"
+SECRET = settings.data_dir / ".migration_secret"
+DONE_MARKER = settings.data_dir / ".migration_done"
+
+# Hostname/IP: Buchstaben, Ziffern, Punkt, Bindestrich, Doppelpunkt (IPv6).
+_HOST_RE = re.compile(r"^[A-Za-z0-9._:-]{1,253}$")
+# SSH-User: konservativ, keine Shell-Metazeichen.
+_USER_RE = re.compile(r"^[A-Za-z0-9._-]{1,32}$")
+
+
+class MigrationStart(BaseModel):
+    host: str = Field(..., description="Ziel-Host oder IP")
+    port: int = Field(22, ge=1, le=65535)
+    ssh_user: str = Field("root", description="SSH-User auf dem Ziel")
+    password: str = Field(..., min_length=1, description="SSH-Passwort des Ziel-Users")
+    bwlimit_kbps: int = Field(0, ge=0, description="Bandbreiten-Limit in KB/s (0=aus)")
+
+
+def _is_running() -> bool:
+    """Läuft gerade eine Migration? Trigger existiert oder Service aktiv."""
+    return TRIGGER.exists() or SECRET.exists()
+
+
+@router.get("/status")
+def migration_status(_: Annotated[tuple[str, str], Depends(require_admin)]) -> dict:
+    running = _is_running()
+    done = None
+    if DONE_MARKER.exists():
+        try:
+            done = json.loads(DONE_MARKER.read_text())
+        except (OSError, ValueError):
+            done = None
+    return {"running": running, "last_result": done}
+
+
+@router.post("/start")
+def migration_start(
+    body: MigrationStart,
+    _: Annotated[tuple[str, str], Depends(require_admin)],
+) -> dict:
+    if _is_running():
+        raise coded(status.HTTP_409_CONFLICT, "migration_already_running")
+
+    host = body.host.strip()
+    if not _HOST_RE.match(host):
+        raise coded(status.HTTP_400_BAD_REQUEST, "migration_invalid_host")
+    if not _USER_RE.match(body.ssh_user):
+        raise coded(status.HTTP_400_BAD_REQUEST, "migration_invalid_user")
+
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    DONE_MARKER.unlink(missing_ok=True)
+
+    # Passwort in separate 0600-Datei — NICHT in den Klartext-Trigger, NICHT ins Log.
+    # umask-sicher: erst 0600 anlegen, dann schreiben.
+    fd = os.open(str(SECRET), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, body.password.encode())
+    finally:
+        os.close(fd)
+
+    request = {
+        "host": host,
+        "port": body.port,
+        "ssh_user": body.ssh_user,
+        "bwlimit_kbps": body.bwlimit_kbps,
+        "requested_at": int(time.time()),
+    }
+    TRIGGER.write_text(json.dumps(request))
+    return {"started": True}
+
+
+@router.get("/log")
+def migration_log(
+    _: Annotated[tuple[str, str], Depends(require_admin)],
+    tail: int = 500,
+) -> dict:
+    log_path: Path = settings.migration_log_path
+    if not log_path.exists():
+        return {"exists": False, "lines": [], "running": _is_running()}
+    lines = log_path.read_text(errors="replace").splitlines()[-tail:]
+    return {
+        "exists": True,
+        "lines": [line + "\n" for line in lines],
+        "running": _is_running(),
+    }

--- a/core/src/hydrahive/api/routes/migration.py
+++ b/core/src/hydrahive/api/routes/migration.py
@@ -28,9 +28,21 @@ from hydrahive.settings import settings
 
 router = APIRouter(prefix="/api/admin/migration", tags=["admin"])
 
-TRIGGER = settings.data_dir / ".migration_request"
-SECRET = settings.data_dir / ".migration_secret"
-DONE_MARKER = settings.data_dir / ".migration_done"
+
+# Pfade werden zur LAUFZEIT aus settings aufgelöst (nicht als Import-Konstante),
+# damit Tests sie per monkeypatch(settings.data_dir) umlenken können und nicht
+# in die echte data_dir schreiben.
+def _trigger_path() -> Path:
+    return settings.data_dir / ".migration_request"
+
+
+def _secret_path() -> Path:
+    return settings.data_dir / ".migration_secret"
+
+
+def _done_path() -> Path:
+    return settings.data_dir / ".migration_done"
+
 
 # Hostname/IP: Buchstaben, Ziffern, Punkt, Bindestrich, Doppelpunkt (IPv6).
 _HOST_RE = re.compile(r"^[A-Za-z0-9._:-]{1,253}$")
@@ -48,16 +60,17 @@ class MigrationStart(BaseModel):
 
 def _is_running() -> bool:
     """Läuft gerade eine Migration? Trigger existiert oder Service aktiv."""
-    return TRIGGER.exists() or SECRET.exists()
+    return _trigger_path().exists() or _secret_path().exists()
 
 
 @router.get("/status")
 def migration_status(_: Annotated[tuple[str, str], Depends(require_admin)]) -> dict:
     running = _is_running()
     done = None
-    if DONE_MARKER.exists():
+    done_marker = _done_path()
+    if done_marker.exists():
         try:
-            done = json.loads(DONE_MARKER.read_text())
+            done = json.loads(done_marker.read_text())
         except (OSError, ValueError):
             done = None
     return {"running": running, "last_result": done}
@@ -78,11 +91,11 @@ def migration_start(
         raise coded(status.HTTP_400_BAD_REQUEST, "migration_invalid_user")
 
     settings.data_dir.mkdir(parents=True, exist_ok=True)
-    DONE_MARKER.unlink(missing_ok=True)
+    _done_path().unlink(missing_ok=True)
 
     # Passwort in separate 0600-Datei — NICHT in den Klartext-Trigger, NICHT ins Log.
     # umask-sicher: erst 0600 anlegen, dann schreiben.
-    fd = os.open(str(SECRET), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    fd = os.open(str(_secret_path()), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         os.write(fd, body.password.encode())
     finally:
@@ -95,7 +108,7 @@ def migration_start(
         "bwlimit_kbps": body.bwlimit_kbps,
         "requested_at": int(time.time()),
     }
-    TRIGGER.write_text(json.dumps(request))
+    _trigger_path().write_text(json.dumps(request))
     return {"started": True}
 
 

--- a/core/src/hydrahive/settings/_paths.py
+++ b/core/src/hydrahive/settings/_paths.py
@@ -159,6 +159,10 @@ class _PathsMixin:
     def bridge_log_path(self) -> Path:
         return Path(os.environ.get("HH_BRIDGE_LOG", "/var/log/hydrahive2-bridge.log"))
 
+    @cached_property
+    def migration_log_path(self) -> Path:
+        return Path(os.environ.get("HH_MIGRATION_LOG", "/var/log/hydrahive2-migration.log"))
+
     # ------------------------------------------------------------------ helpers
 
     def ensure_dirs(self) -> None:

--- a/core/tests/test_migrate_script_excludes.py
+++ b/core/tests/test_migrate_script_excludes.py
@@ -1,0 +1,101 @@
+"""Statische Prüfung der Exclude-Liste in installer/migrate.sh.
+
+Verhindert Regression: die rsync-Excludes dürfen NUR regenerierbaren Ballast
+ausschließen — niemals Nutzdaten (Git-Repos, workspaces, modules, vms,
+Plattenarchive). Till: "wenn z.B. das Plattenarchiv weg ist, habe ich ein
+ernsthaftes Problem."
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "installer" / "migrate.sh"
+)
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    if not SCRIPT.exists():
+        pytest.skip(f"migrate.sh nicht gefunden: {SCRIPT}")
+    return SCRIPT.read_text()
+
+
+# Ballast, der ausgeschlossen sein MUSS (regenerierbar).
+BALLAST = [
+    "node_modules/",
+    ".venv/",
+    "__pycache__/",
+    ".plugin-cache/",
+    ".module-cache/",
+    "gocache/",
+    "gomods/",
+    "memory_index.db",
+]
+
+# Nutzdaten-Verzeichnisse, die NIEMALS als exclude-Pattern auftauchen dürfen.
+# Exakter Vergleich gegen den Pattern-Wert (nicht Substring) — sonst kollidiert
+# z.B. das legitime 'node_modules/' mit 'modules/'.
+FORBIDDEN_PATTERNS = {
+    ".git",
+    ".git/",
+    "workspaces",
+    "workspaces/",
+    "modules",
+    "modules/",
+    "vms",
+    "vms/",
+    "projects",
+    "projects/",
+    "agents",
+    "agents/",
+}
+
+
+def _exclude_lines(text: str) -> list[str]:
+    return [ln.strip() for ln in text.splitlines() if "--exclude" in ln]
+
+
+def _exclude_patterns(text: str) -> list[str]:
+    """Extrahiert den Pattern-Wert aus jeder --exclude 'wert'-Zeile."""
+    import re
+    out = []
+    for ln in _exclude_lines(text):
+        m = re.search(r"--exclude\s+'([^']*)'", ln)
+        if m:
+            out.append(m.group(1))
+    return out
+
+
+def test_ballast_is_excluded(script_text):
+    excludes = "\n".join(_exclude_lines(script_text))
+    for item in BALLAST:
+        assert item in excludes, f"Ballast '{item}' fehlt in den rsync-Excludes"
+
+
+def test_userdata_never_excluded(script_text):
+    patterns = set(_exclude_patterns(script_text))
+    clash = patterns & FORBIDDEN_PATTERNS
+    assert not clash, f"Nutzdaten dürfen NICHT excludet werden: {clash}"
+
+
+def test_uses_archive_flags(script_text):
+    # -aAX erhält Permissions, ACLs, xattrs → echter Klon.
+    assert "-aAX" in script_text
+    # numeric-ids: UID/GID werden 1:1 übertragen (Ownership-Erhalt).
+    assert "--numeric-ids" in script_text
+    # resumierbar bei Abbruch.
+    assert "--partial" in script_text
+
+
+def test_password_never_in_process_args(script_text):
+    # sshpass MUSS -f (Datei) nutzen, nie -p (Passwort als Argument → ps-sichtbar).
+    assert "sshpass -f" in script_text
+    assert "sshpass -p" not in script_text
+
+
+def test_secret_is_cleaned_up(script_text):
+    # Die Secret-Datei muss am Ende gelöscht werden (finish/trap).
+    assert 'rm -f "$SECRET"' in script_text

--- a/core/tests/test_migration_routes.py
+++ b/core/tests/test_migration_routes.py
@@ -1,0 +1,139 @@
+"""Tests für die Server-Migrations-Endpoints (rsync Voll-Klon).
+
+Verifiziert Input-Validierung, admin-only, Trigger-/Secret-Datei-Handling
+(Passwort in separater 0600-Datei, NICHT im Klartext-Trigger) und Status/Log.
+Es wird KEIN echtes rsync/ssh ausgeführt — nur der Router bis zur Trigger-Datei.
+"""
+from __future__ import annotations
+
+import json
+import stat
+
+import pytest
+
+from hydrahive.api.routes import migration as migration_mod
+from hydrahive.settings import settings
+from tests.conftest import error_code
+
+
+@pytest.fixture(autouse=True)
+def _clean_triggers():
+    """Vor + nach jedem Test die Migrations-Marker entfernen."""
+    for p in (migration_mod.TRIGGER, migration_mod.SECRET, migration_mod.DONE_MARKER):
+        p.unlink(missing_ok=True)
+    yield
+    for p in (migration_mod.TRIGGER, migration_mod.SECRET, migration_mod.DONE_MARKER):
+        p.unlink(missing_ok=True)
+
+
+def _body(**over):
+    base = {
+        "host": "192.168.178.121",
+        "port": 22,
+        "ssh_user": "root",
+        "password": "s3cret-pass",
+        "bwlimit_kbps": 0,
+    }
+    base.update(over)
+    return base
+
+
+def test_start_requires_admin(client, auth_headers):
+    r = client.post("/api/admin/migration/start", json=_body(), headers=auth_headers)
+    assert r.status_code == 403
+
+
+def test_start_requires_auth(client):
+    r = client.post("/api/admin/migration/start", json=_body())
+    assert r.status_code in (401, 403)
+
+
+def test_start_writes_trigger_and_secret(client, admin_headers):
+    r = client.post("/api/admin/migration/start", json=_body(), headers=admin_headers)
+    assert r.status_code == 200, r.text
+    assert r.json() == {"started": True}
+
+    # Trigger enthält Host/Port/User — aber KEIN Passwort.
+    assert migration_mod.TRIGGER.exists()
+    trigger = json.loads(migration_mod.TRIGGER.read_text())
+    assert trigger["host"] == "192.168.178.121"
+    assert trigger["port"] == 22
+    assert trigger["ssh_user"] == "root"
+    assert "password" not in trigger
+    assert "s3cret-pass" not in migration_mod.TRIGGER.read_text()
+
+    # Passwort steht in separater Secret-Datei mit Mode 0600.
+    assert migration_mod.SECRET.exists()
+    assert migration_mod.SECRET.read_text() == "s3cret-pass"
+    mode = stat.S_IMODE(migration_mod.SECRET.stat().st_mode)
+    assert mode == 0o600, f"Secret-Datei muss 0600 sein, ist {oct(mode)}"
+
+
+def test_start_rejects_invalid_host(client, admin_headers):
+    r = client.post("/api/admin/migration/start",
+                    json=_body(host="bad host; rm -rf /"), headers=admin_headers)
+    assert r.status_code == 400
+    assert error_code(r) == "migration_invalid_host"
+    assert not migration_mod.SECRET.exists()
+
+
+def test_start_rejects_invalid_user(client, admin_headers):
+    r = client.post("/api/admin/migration/start",
+                    json=_body(ssh_user="root;evil"), headers=admin_headers)
+    assert r.status_code == 400
+    assert error_code(r) == "migration_invalid_user"
+
+
+def test_start_rejects_empty_password(client, admin_headers):
+    r = client.post("/api/admin/migration/start",
+                    json=_body(password=""), headers=admin_headers)
+    assert r.status_code == 422  # pydantic min_length
+
+
+def test_start_conflict_when_running(client, admin_headers):
+    r1 = client.post("/api/admin/migration/start", json=_body(), headers=admin_headers)
+    assert r1.status_code == 200
+    r2 = client.post("/api/admin/migration/start", json=_body(), headers=admin_headers)
+    assert r2.status_code == 409
+    assert error_code(r2) == "migration_already_running"
+
+
+def test_status_reports_running(client, admin_headers):
+    assert client.get("/api/admin/migration/status",
+                      headers=admin_headers).json()["running"] is False
+    client.post("/api/admin/migration/start", json=_body(), headers=admin_headers)
+    assert client.get("/api/admin/migration/status",
+                      headers=admin_headers).json()["running"] is True
+
+
+def test_status_reports_last_result(client, admin_headers):
+    migration_mod.DONE_MARKER.write_text(json.dumps({"ok": True, "finished_at": 123}))
+    st = client.get("/api/admin/migration/status", headers=admin_headers).json()
+    assert st["running"] is False
+    assert st["last_result"] == {"ok": True, "finished_at": 123}
+
+
+def test_log_absent(client, admin_headers, tmp_path, monkeypatch):
+    log = tmp_path / "migration.log"
+    monkeypatch.setattr(settings, "migration_log_path", log, raising=False)
+    r = client.get("/api/admin/migration/log", headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["exists"] is False
+
+
+def test_log_reads_tail(client, admin_headers, tmp_path, monkeypatch):
+    log = tmp_path / "migration.log"
+    log.write_text("line1\nline2\nline3\n")
+    monkeypatch.setattr(settings, "migration_log_path", log, raising=False)
+    r = client.get("/api/admin/migration/log?tail=2", headers=admin_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["exists"] is True
+    assert data["lines"] == ["line2\n", "line3\n"]
+
+
+def test_bwlimit_persisted_in_trigger(client, admin_headers):
+    client.post("/api/admin/migration/start",
+                json=_body(bwlimit_kbps=5000), headers=admin_headers)
+    trigger = json.loads(migration_mod.TRIGGER.read_text())
+    assert trigger["bwlimit_kbps"] == 5000

--- a/core/tests/test_migration_routes.py
+++ b/core/tests/test_migration_routes.py
@@ -17,13 +17,16 @@ from tests.conftest import error_code
 
 
 @pytest.fixture(autouse=True)
-def _clean_triggers():
-    """Vor + nach jedem Test die Migrations-Marker entfernen."""
-    for p in (migration_mod.TRIGGER, migration_mod.SECRET, migration_mod.DONE_MARKER):
-        p.unlink(missing_ok=True)
+def _isolated_data_dir(tmp_path, monkeypatch):
+    """data_dir auf ein Test-Tmp umlenken — NIE in die echte data_dir schreiben.
+
+    Der Router löst die Marker-Pfade zur Laufzeit aus settings.data_dir auf,
+    daher genügt der monkeypatch hier.
+    """
+    d = tmp_path / "data"
+    d.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "data_dir", d, raising=False)
     yield
-    for p in (migration_mod.TRIGGER, migration_mod.SECRET, migration_mod.DONE_MARKER):
-        p.unlink(missing_ok=True)
 
 
 def _body(**over):
@@ -54,18 +57,18 @@ def test_start_writes_trigger_and_secret(client, admin_headers):
     assert r.json() == {"started": True}
 
     # Trigger enthält Host/Port/User — aber KEIN Passwort.
-    assert migration_mod.TRIGGER.exists()
-    trigger = json.loads(migration_mod.TRIGGER.read_text())
+    assert migration_mod._trigger_path().exists()
+    trigger = json.loads(migration_mod._trigger_path().read_text())
     assert trigger["host"] == "192.168.178.121"
     assert trigger["port"] == 22
     assert trigger["ssh_user"] == "root"
     assert "password" not in trigger
-    assert "s3cret-pass" not in migration_mod.TRIGGER.read_text()
+    assert "s3cret-pass" not in migration_mod._trigger_path().read_text()
 
     # Passwort steht in separater Secret-Datei mit Mode 0600.
-    assert migration_mod.SECRET.exists()
-    assert migration_mod.SECRET.read_text() == "s3cret-pass"
-    mode = stat.S_IMODE(migration_mod.SECRET.stat().st_mode)
+    assert migration_mod._secret_path().exists()
+    assert migration_mod._secret_path().read_text() == "s3cret-pass"
+    mode = stat.S_IMODE(migration_mod._secret_path().stat().st_mode)
     assert mode == 0o600, f"Secret-Datei muss 0600 sein, ist {oct(mode)}"
 
 
@@ -74,7 +77,7 @@ def test_start_rejects_invalid_host(client, admin_headers):
                     json=_body(host="bad host; rm -rf /"), headers=admin_headers)
     assert r.status_code == 400
     assert error_code(r) == "migration_invalid_host"
-    assert not migration_mod.SECRET.exists()
+    assert not migration_mod._secret_path().exists()
 
 
 def test_start_rejects_invalid_user(client, admin_headers):
@@ -107,7 +110,7 @@ def test_status_reports_running(client, admin_headers):
 
 
 def test_status_reports_last_result(client, admin_headers):
-    migration_mod.DONE_MARKER.write_text(json.dumps({"ok": True, "finished_at": 123}))
+    migration_mod._done_path().write_text(json.dumps({"ok": True, "finished_at": 123}))
     st = client.get("/api/admin/migration/status", headers=admin_headers).json()
     assert st["running"] is False
     assert st["last_result"] == {"ok": True, "finished_at": 123}
@@ -135,5 +138,5 @@ def test_log_reads_tail(client, admin_headers, tmp_path, monkeypatch):
 def test_bwlimit_persisted_in_trigger(client, admin_headers):
     client.post("/api/admin/migration/start",
                 json=_body(bwlimit_kbps=5000), headers=admin_headers)
-    trigger = json.loads(migration_mod.TRIGGER.read_text())
+    trigger = json.loads(migration_mod._trigger_path().read_text())
     assert trigger["bwlimit_kbps"] == 5000

--- a/docs/specs/server-migration-rsync.md
+++ b/docs/specs/server-migration-rsync.md
@@ -1,0 +1,120 @@
+# Server-Migration: Voll-Klon per rsync (Server-zu-Server)
+
+Status: DESIGN (freigegeben durch Till, 2026-07-01)
+Issue: TBD
+
+## Problem
+
+Umzug einer kompletten HydraHive2-Installation auf einen neuen Server (z.B. den
+"121er") als **100%-Klon inkl. ALLER Daten** — ausdrücklich auch der großen
+Rohdaten (894 GB Plattenarchive im Archivierungs-Projekt, VMs, Mounts). Das
+vorhandene tar.gz-System-Backup ist dafür ungeeignet:
+
+- 8-GiB-Extraktions-Limit (Dekompressionsbomben-Schutz)
+- HTTP-Download eines Monolithen — bei 1,2 TB nicht praktikabel
+- übergeht ohnehin `workspaces/` + `modules/` (separater Bug, eigener Task)
+
+HydraHive **1** hatte eine Migration-Page (Ziel-Adresse + SSH-Key eingeben →
+Server-zu-Server-Transfer mit Live-Log). Technisch war es aber `tar | openssl |
+ssh` (Streaming) und übertrug nur `/agents/` + `/etc/hydrahive/` (wenige hundert
+MB). Ein tar-Stream über 1,2 TB ist nicht wiederaufnehmbar — bricht die
+Verbindung ab, fängt alles von vorn an.
+
+## Ziel
+
+Gewohnter HH1-Ablauf, aber mit rsync statt tar-Stream:
+Am **alten** Server: Migration-Seite → Ziel-Adresse + SSH-Zugang eingeben →
+"Klonen" → Live-Fortschritt → auf dem neuen Server steht ein 100%-Klon.
+
+## Gewählter Ansatz: rsync-Push über SSH (Option A)
+
+Warum rsync statt tar-Stream:
+- **inkrementell + resumierbar** — bei 1,2 TB der Unterschied zwischen "läuft
+  durch" und "bricht immer wieder komplett ab". Zweiter Lauf überträgt nur das
+  Delta.
+- **erhält alles** mit `-aAX`: Permissions, Ownership, Timestamps, ACLs, xattrs,
+  Symlinks → echter Klon
+- Standardwerkzeug, auf beiden Linux-Servern vorhanden (rsync 3.2.7 verifiziert)
+
+### Architektur (HH2-konform)
+
+**Privilegierter Pfad — kein sudo im Core-Service.** Der Core-Service läuft als
+User `hydrahive` (ProtectHome=read-only) und kann root-owned `vms/` nicht lesen.
+Deshalb dasselbe Muster wie Self-Update/Restart:
+
+1. **Core-Router** (`/api/admin/migration/*`, admin-only) validiert die Eingaben
+   und schreibt eine Trigger-Datei `.migration_request` (JSON: target, ssh_port,
+   include-Optionen) nach `data_dir`. **Keine** Ausführung im Core-Service.
+2. **systemd-path-Watcher** (`hydrahive2-migration.path`) triggert
+   `hydrahive2-migration.service` (oneshot, **User=root**), analog zu
+   `hydrahive2-update`. Der führt `installer/migrate.sh` aus.
+3. **`migrate.sh`** (root) macht:
+   - Preflight: SSH-Erreichbarkeit, rsync auf Ziel vorhanden, HH2 auf Ziel
+     installiert, freier Plattenplatz auf Ziel >= Quell-Datenmenge
+   - konsistenter DB-Snapshot via `sqlite3 .backup` (WAL-safe) in Temp
+   - `rsync -aAX --delete --info=progress2` je Datenbereich über SSH
+   - Ziel-Services vor DB-Sync stoppen, danach starten (Restart-Trigger auf Ziel)
+   - Ownership/Permissions auf Ziel korrigieren (chown hydrahive, /etc 640 etc.)
+   - Log nach `/var/log/hydrahive2-migration.log`
+4. **Live-Log**: Frontend pollt/streamt `/api/admin/migration/log` (SSE), das die
+   Logdatei tailt — wie beim Update-Log. Status via `.migration_request`-Existenz
+   + Exit-Marker.
+
+### Was wird übertragen (VOLL-Klon — Till: "ich brauche alle Daten")
+
+Alle Daten-Wurzeln, jeweils mit `rsync -aAX`:
+
+| Quelle | Inhalt |
+|---|---|
+| `/var/lib/hydrahive2/` | agents, projects, **workspaces** (inkl. 894 GB Archive), modules, plugins, credentials, users, whatsapp, generated, exports, mail, skills, scratchpad, vms, sessions.db (als Snapshot) |
+| `/etc/hydrahive2/` | Configs, Secrets (jwt, internal), llm.json, users.json, api_keys, extensions |
+| `/var/log/hydrahive2-*.log` | optional |
+
+**Excludes** (regenerierbarer Ballast — NICHT Nutzdaten):
+`node_modules/`, `.venv/`, `venv/`, `__pycache__/`, `.mypy_cache/`,
+`.pytest_cache/`, `.plugin-cache/`, `.module-cache/`, `.numba-cache/`,
+`gocache/`, `gomods/`, `.backup-rollback-*`, `.hh2-restore-*`,
+`memory_index.db` (BM25-Index, wird neu gebaut), `.git/` NICHT excluden (Till
+braucht die Git-Repos!).
+
+Live-`sessions.db` wird durch den `.backup`-Snapshot ersetzt (nicht das offene
+WAL-File syncen).
+
+### Sicherheit
+- admin-only (require_admin)
+- SSH StrictHostKeyChecking=accept-new, ConnectTimeout
+- nur EIN Migration-Lauf gleichzeitig (Lock)
+- Ziel: automatisches Safety-Backup der kritischen Configs VOR Überschreiben
+- keine Secrets ins Log
+
+## Akzeptanzkriterien
+- [ ] Von der Migration-Seite am Quellserver lässt sich mit Ziel-Adresse + SSH-Key
+      ein Voll-Klon anstoßen
+- [ ] rsync überträgt inkrementell; zweiter Lauf nur Delta
+- [ ] `vms/` (root-owned) + 894-GB-Archive landen vollständig auf dem Ziel
+- [ ] Ownership/Permissions auf Ziel korrekt (hydrahive:hydrahive, /etc 640)
+- [ ] DB konsistent (Snapshot, nicht offenes WAL)
+- [ ] Live-Log sichtbar; Abbruch/Fehler klar gemeldet; resumierbar
+- [ ] Ziel-HydraHive startet nach Migration mit identischem Zustand
+- [ ] Excludes greifen (kein node_modules/venv-Ballast)
+- [ ] Tests: Router-Validierung, Trigger-Datei-Format, Exclude-Logik, Preflight
+
+## Auth: Passwort (Till-Entscheidung)
+
+SSH-Passwort-Authentifizierung via `sshpass` (auf Quellserver verifiziert
+vorhanden). Ablauf:
+- Migrations-Dialog: Ziel-Host, SSH-Port, SSH-User (default `root`), **Passwort**.
+- Passwort wird NICHT in der `.migration_request`-Trigger-Datei im Klartext auf
+  Platte gelegt. Stattdessen: Core schreibt das Passwort in eine separate Datei
+  mit `chmod 600` (root:hydrahive) ODER übergibt es via named pipe / Env an den
+  oneshot-Service. Bevorzugt: eigene Datei `.migration_secret` (0600), die
+  migrate.sh nach Einlesen sofort löscht. Niemals ins Log.
+- `sshpass -f <secretfile> ssh/rsync ...` — Passwort nie in der Prozessliste
+  (kein `-p` mit Argument, sondern `-f` File oder `-e` Env).
+- `StrictHostKeyChecking=accept-new` (erster Kontakt), Host-Key wird gemerkt.
+
+## Offene Punkte
+- Bandbreiten-Limit (`--bwlimit`) als Option, damit Prod nicht erstickt? →
+  als optionales Feld im Dialog, default aus.
+- Separater Bug (eigener Task): normales tar.gz-System-Backup übergeht
+  workspaces/ + modules/ — für kleine Backups trotzdem fixen.

--- a/frontend/src/features/system/MigrationCard.tsx
+++ b/frontend/src/features/system/MigrationCard.tsx
@@ -1,0 +1,40 @@
+import type { CSSProperties } from "react"
+import { useEffect, useState } from "react"
+import { Server, Loader2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { rgbFor } from "@/shared/colors"
+import { systemApi } from "./api"
+import { MigrationModal } from "./MigrationModal"
+
+export function MigrationCard() {
+  const { t } = useTranslation("system")
+  const [open, setOpen] = useState(false)
+  const [running, setRunning] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    systemApi.migrationStatus()
+      .then((s) => { if (alive) setRunning(s.running) })
+      .catch(() => { /* ignore */ })
+    return () => { alive = false }
+  }, [open])
+
+  return (
+    <div className="box overflow-hidden p-4 space-y-3" style={{ "--c": rgbFor("/system") } as CSSProperties}>
+      <div>
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
+          {t("migration.title")}
+        </p>
+        <p className="text-zinc-300 text-sm mt-1">{t("migration.description")}</p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button onClick={() => setOpen(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-500/10 border border-violet-500/25 text-violet-200 text-xs font-medium hover:bg-violet-500/20 transition-colors">
+          {running ? <Loader2 size={12} className="animate-spin" /> : <Server size={12} />}
+          {running ? t("migration.running_short") : t("migration.open")}
+        </button>
+      </div>
+      {open && <MigrationModal onClose={() => setOpen(false)} />}
+    </div>
+  )
+}

--- a/frontend/src/features/system/MigrationModal.tsx
+++ b/frontend/src/features/system/MigrationModal.tsx
@@ -1,0 +1,164 @@
+import type { CSSProperties } from "react"
+import { useEffect, useRef, useState } from "react"
+import { AlertTriangle, Loader2, Server, X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { rgbFor } from "@/shared/colors"
+import { ModalPortal } from "@/shared/ModalPortal"
+import { systemApi, type MigrationStartBody } from "./api"
+
+type Phase = "form" | "running" | "done" | "failed"
+
+export function MigrationModal({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("system")
+  const [phase, setPhase] = useState<Phase>("form")
+  const [host, setHost] = useState("")
+  const [port, setPort] = useState("22")
+  const [sshUser, setSshUser] = useState("root")
+  const [password, setPassword] = useState("")
+  const [bwlimit, setBwlimit] = useState("0")
+  const [error, setError] = useState<string | null>(null)
+  const [log, setLog] = useState<string[]>([])
+  const logRef = useRef<HTMLDivElement>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current) }, [])
+
+  useEffect(() => {
+    logRef.current?.scrollTo(0, logRef.current.scrollHeight)
+  }, [log])
+
+  function startPolling() {
+    if (pollRef.current) clearInterval(pollRef.current)
+    pollRef.current = setInterval(async () => {
+      try {
+        const r = await systemApi.migrationLog(500)
+        setLog(r.lines)
+        if (!r.running) {
+          if (pollRef.current) clearInterval(pollRef.current)
+          const st = await systemApi.migrationStatus()
+          setPhase(st.last_result?.ok ? "done" : "failed")
+        }
+      } catch { /* transient — weiter pollen */ }
+    }, 2000)
+  }
+
+  async function handleStart() {
+    if (!host.trim() || !password) return
+    setError(null)
+    const body: MigrationStartBody = {
+      host: host.trim(),
+      port: Number(port) || 22,
+      ssh_user: sshUser.trim() || "root",
+      password,
+      bwlimit_kbps: Number(bwlimit) || 0,
+    }
+    try {
+      await systemApi.migrationStart(body)
+      setPassword("")   // Klartext nicht länger im State halten
+      setPhase("running")
+      setLog([])
+      startPolling()
+    } catch (e) {
+      const err = e as { detail_code?: string; message?: string }
+      setError(err.detail_code ? t(`migration.err.${err.detail_code}`, err.detail_code) : (err.message || String(e)))
+    }
+  }
+
+  return (
+    <ModalPortal>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget && phase !== "running") onClose() }}>
+      <div className="box box-static overflow-hidden w-full max-w-2xl flex flex-col max-h-[85vh]"
+        style={{ "--c": rgbFor("/system") } as CSSProperties}>
+        <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-white/[8%] flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <Server size={15} className="text-violet-300" />
+            <p className="text-sm font-semibold text-zinc-100">{t("migration.title")}</p>
+          </div>
+          {phase !== "running" && (
+            <button onClick={onClose} className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%]">
+              <X size={16} />
+            </button>
+          )}
+        </div>
+
+        <div className="p-5 space-y-4 overflow-y-auto">
+          {phase === "form" && (
+            <>
+              <div className="flex items-start gap-2 rounded-lg bg-amber-500/[7%] border border-amber-500/25 p-3">
+                <AlertTriangle size={15} className="text-amber-300 flex-shrink-0 mt-0.5" />
+                <p className="text-xs text-amber-100/90 leading-relaxed">{t("migration.warning")}</p>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <label className="sm:col-span-2 space-y-1">
+                  <span className="text-[11px] uppercase tracking-wider text-zinc-500">{t("migration.host")}</span>
+                  <input value={host} onChange={(e) => setHost(e.target.value)}
+                    placeholder="192.168.178.121"
+                    className="w-full px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-sm text-zinc-100 focus:border-violet-500/50 outline-none" />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[11px] uppercase tracking-wider text-zinc-500">{t("migration.port")}</span>
+                  <input value={port} onChange={(e) => setPort(e.target.value)} inputMode="numeric"
+                    className="w-full px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-sm text-zinc-100 focus:border-violet-500/50 outline-none" />
+                </label>
+                <label className="space-y-1">
+                  <span className="text-[11px] uppercase tracking-wider text-zinc-500">{t("migration.user")}</span>
+                  <input value={sshUser} onChange={(e) => setSshUser(e.target.value)}
+                    className="w-full px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-sm text-zinc-100 focus:border-violet-500/50 outline-none" />
+                </label>
+                <label className="sm:col-span-2 space-y-1">
+                  <span className="text-[11px] uppercase tracking-wider text-zinc-500">{t("migration.password")}</span>
+                  <input value={password} onChange={(e) => setPassword(e.target.value)} type="password"
+                    autoComplete="off"
+                    className="w-full px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-sm text-zinc-100 focus:border-violet-500/50 outline-none" />
+                </label>
+                <label className="sm:col-span-3 space-y-1">
+                  <span className="text-[11px] uppercase tracking-wider text-zinc-500">{t("migration.bwlimit")}</span>
+                  <input value={bwlimit} onChange={(e) => setBwlimit(e.target.value)} inputMode="numeric"
+                    className="w-full px-3 py-2 rounded-lg bg-black/30 border border-white/10 text-sm text-zinc-100 focus:border-violet-500/50 outline-none" />
+                </label>
+              </div>
+
+              {error && <p className="text-xs text-red-400">{error}</p>}
+
+              <div className="flex justify-end gap-2 pt-1">
+                <button onClick={onClose}
+                  className="px-3 py-1.5 rounded-lg text-xs text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%] transition-colors">
+                  {t("migration.cancel")}
+                </button>
+                <button onClick={handleStart} disabled={!host.trim() || !password}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-500/15 border border-violet-500/30 text-violet-200 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 transition-colors">
+                  <Server size={12} /> {t("migration.start")}
+                </button>
+              </div>
+            </>
+          )}
+
+          {phase !== "form" && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm">
+                {phase === "running" && <><Loader2 size={14} className="animate-spin text-violet-300" /><span className="text-zinc-300">{t("migration.running")}</span></>}
+                {phase === "done" && <span className="text-emerald-300">{t("migration.success")}</span>}
+                {phase === "failed" && <span className="text-red-400">{t("migration.failure")}</span>}
+              </div>
+              <div ref={logRef}
+                className="h-72 overflow-y-auto rounded-lg bg-black/50 border border-white/10 p-3 font-mono text-[11px] leading-relaxed text-zinc-400 whitespace-pre-wrap">
+                {log.length === 0 ? t("migration.log_wait") : log.join("")}
+              </div>
+              {phase !== "running" && (
+                <div className="flex justify-end">
+                  <button onClick={onClose}
+                    className="px-3 py-1.5 rounded-lg bg-white/[6%] border border-white/10 text-xs text-zinc-200 hover:bg-white/[10%] transition-colors">
+                    {t("migration.close")}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+    </ModalPortal>
+  )
+}

--- a/frontend/src/features/system/SystemPage.tsx
+++ b/frontend/src/features/system/SystemPage.tsx
@@ -16,6 +16,7 @@ import { BridgeCard } from "./BridgeCard"
 import { SambaCard } from "./SambaCard"
 import { TailscaleCard } from "./TailscaleCard"
 import { BackupCard } from "./BackupCard"
+import { MigrationCard } from "./MigrationCard"
 import { HealthBar } from "./HealthBar"
 import { StatCard } from "./StatCard"
 import { VoiceInstallModal } from "./VoiceInstallModal"
@@ -147,6 +148,7 @@ export function SystemPage() {
       {role === "admin" && <BridgeCard />}
       {role === "admin" && <SambaCard />}
       {role === "admin" && <BackupCard />}
+      {role === "admin" && <MigrationCard />}
     </div>
   )
 }

--- a/frontend/src/features/system/api.ts
+++ b/frontend/src/features/system/api.ts
@@ -91,4 +91,22 @@ export const systemApi = {
     }
     return r.json()
   },
+  migrationStatus: () =>
+    api.get<{ running: boolean; last_result: { ok: boolean; finished_at: number } | null }>(
+      "/admin/migration/status",
+    ),
+  migrationStart: (body: MigrationStartBody) =>
+    api.post<{ started: boolean }>("/admin/migration/start", body),
+  migrationLog: (tail = 500) =>
+    api.get<{ exists: boolean; lines: string[]; running: boolean }>(
+      `/admin/migration/log?tail=${tail}`,
+    ),
+}
+
+export interface MigrationStartBody {
+  host: string
+  port: number
+  ssh_user: string
+  password: string
+  bwlimit_kbps: number
 }

--- a/frontend/src/i18n/locales/de/system.json
+++ b/frontend/src/i18n/locales/de/system.json
@@ -103,6 +103,30 @@
     "confirm_restore": "Wiederherstellen",
     "close": "Schließen"
   },
+  "migration": {
+    "title": "Server-Migration (Voll-Klon)",
+    "description": "Überträgt ALLE Daten per rsync auf einen frisch installierten HydraHive2-Server — inklusive Projekte, Git-Repos, Workspaces, VMs und Plattenarchive. Inkrementell und wiederaufnehmbar.",
+    "open": "Server klonen",
+    "running_short": "Migration läuft…",
+    "warning": "Der Ziel-Server muss ein frisch installiertes HydraHive2 haben. ALLE Daten dort werden mit denen dieses Servers überschrieben. Der Ziel-Dienst wird während der Übertragung gestoppt und danach neu gestartet.",
+    "host": "Ziel-Host / IP",
+    "port": "SSH-Port",
+    "user": "SSH-User",
+    "password": "SSH-Passwort",
+    "bwlimit": "Bandbreiten-Limit (KB/s, 0 = unbegrenzt)",
+    "start": "Klon starten",
+    "cancel": "Abbrechen",
+    "close": "Schließen",
+    "running": "Übertragung läuft — das kann bei großen Datenmengen Stunden dauern…",
+    "success": "Migration erfolgreich abgeschlossen. Der Ziel-Server ist ein 1:1-Klon.",
+    "failure": "Migration fehlgeschlagen — siehe Log.",
+    "log_wait": "Warte auf Ausgabe…",
+    "err": {
+      "migration_already_running": "Es läuft bereits eine Migration.",
+      "migration_invalid_host": "Ungültiger Ziel-Host.",
+      "migration_invalid_user": "Ungültiger SSH-User."
+    }
+  },
   "tailscale": {
     "title": "Tailscale",
     "not_installed": "Tailscale ist nicht installiert.",

--- a/frontend/src/i18n/locales/en/system.json
+++ b/frontend/src/i18n/locales/en/system.json
@@ -103,6 +103,30 @@
     "confirm_restore": "Restore",
     "close": "Close"
   },
+  "migration": {
+    "title": "Server Migration (Full Clone)",
+    "description": "Transfers ALL data via rsync to a freshly installed HydraHive2 server — including projects, Git repos, workspaces, VMs and disk archives. Incremental and resumable.",
+    "open": "Clone server",
+    "running_short": "Migration running…",
+    "warning": "The target server must have a freshly installed HydraHive2. ALL data there will be overwritten with this server's data. The target service is stopped during transfer and restarted afterwards.",
+    "host": "Target host / IP",
+    "port": "SSH port",
+    "user": "SSH user",
+    "password": "SSH password",
+    "bwlimit": "Bandwidth limit (KB/s, 0 = unlimited)",
+    "start": "Start clone",
+    "cancel": "Cancel",
+    "close": "Close",
+    "running": "Transfer in progress — this may take hours for large data sets…",
+    "success": "Migration completed successfully. The target server is a 1:1 clone.",
+    "failure": "Migration failed — see log.",
+    "log_wait": "Waiting for output…",
+    "err": {
+      "migration_already_running": "A migration is already running.",
+      "migration_invalid_host": "Invalid target host.",
+      "migration_invalid_user": "Invalid SSH user."
+    }
+  },
   "tailscale": {
     "title": "Tailscale",
     "not_installed": "Tailscale is not installed.",

--- a/frontend/src/shared/ModalPortal.tsx
+++ b/frontend/src/shared/ModalPortal.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react"
+import { createPortal } from "react-dom"
+
+/** Rendert Kinder via Portal an ``document.body``.
+ *
+ * Nötig für Overlays mit ``position: fixed``, die INNERHALB einer ``.box``
+ * (oder eines anderen Elements mit ``transform``/``filter``/``perspective``)
+ * gerendert werden: ein transformierter Vorfahr wird zum Containing-Block für
+ * ``fixed`` → das Overlay positioniert sich dann relativ zu diesem Element statt
+ * zum Viewport. Da ``.box:hover`` ein ``transform: translateY(-2px)`` setzt,
+ * „springt“ so ein Modal beim Mausbewegen zwischen Box- und Viewport-Bezug.
+ * Das Portal hängt das Overlay ans ``body`` — außerhalb jeder Box → stabil.
+ */
+export function ModalPortal({ children }: { children: ReactNode }) {
+  if (typeof document === "undefined") return null
+  return createPortal(children, document.body)
+}

--- a/installer/migrate.sh
+++ b/installer/migrate.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# HydraHive2 — Server-zu-Server Voll-Klon per rsync.
+#
+# Wird vom root-oneshot-Service hydrahive2-migration.service ausgeführt, wenn der
+# Core-Router die Trigger-Datei $HH_DATA_DIR/.migration_request geschrieben hat.
+# Überträgt ALLE Daten (inkl. workspaces/, modules/, vms/, Plattenarchive) per
+# rsync -aAX --delete über SSH auf einen frisch installierten HydraHive2-Zielserver.
+#
+# rsync ist inkrementell + resumierbar — bei 1,2 TB Pflicht. Zweiter Lauf
+# überträgt nur das Delta.
+#
+# Auth: SSH-Passwort via sshpass -f (Secret-Datei). Passwort steht NIE in der
+# Prozessliste und NIE im Log.
+set -uo pipefail
+
+HH_REPO_DIR="${HH_REPO_DIR:-/opt/hydrahive2}"
+HH_USER="${HH_USER:-hydrahive}"
+HH_DATA_DIR="${HH_DATA_DIR:-/var/lib/hydrahive2}"
+HH_CONFIG_DIR="${HH_CONFIG_DIR:-/etc/hydrahive2}"
+
+TRIGGER="$HH_DATA_DIR/.migration_request"
+SECRET="$HH_DATA_DIR/.migration_secret"
+DONE_MARKER="$HH_DATA_DIR/.migration_done"
+
+log()  { printf '\033[1;36m[hh2-migrate]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[hh2-migrate]\033[0m WARN: %s\n' "$*"; }
+
+# Aufräumen: Secret immer löschen, Ergebnis in DONE_MARKER schreiben.
+FINAL_RC=1
+finish() {
+    # Passwort-Datei restlos entfernen, egal wie wir hier landen.
+    rm -f "$SECRET" 2>/dev/null || true
+    printf '{"ok":%s,"finished_at":%s}\n' \
+        "$([ "$FINAL_RC" -eq 0 ] && echo true || echo false)" \
+        "$(date +%s)" > "$DONE_MARKER" 2>/dev/null || true
+    if [ "$FINAL_RC" -eq 0 ]; then
+        log "════════ Migration erfolgreich abgeschlossen ════════"
+    else
+        warn "════════ Migration fehlgeschlagen (rc=$FINAL_RC) ════════"
+    fi
+}
+trap finish EXIT
+
+err() { warn "$*"; FINAL_RC=1; exit 1; }
+
+[ "$(id -u)" -eq 0 ] || err "migrate.sh muss als root laufen."
+
+# ── Trigger + Secret einlesen ────────────────────────────────────────────────
+[ -f "$TRIGGER" ] || err "Kein Migrations-Trigger gefunden ($TRIGGER)."
+[ -f "$SECRET" ]  || err "Kein Passwort hinterlegt ($SECRET)."
+
+# JSON-Felder ohne jq extrahieren (python3 ist auf HH2-Servern immer da).
+read_field() {
+    python3 -c "import json,sys;print(json.load(open('$TRIGGER')).get('$1',''))" 2>/dev/null
+}
+TARGET_HOST="$(read_field host)"
+TARGET_PORT="$(read_field port)"
+TARGET_USER="$(read_field ssh_user)"
+BWLIMIT_KBPS="$(read_field bwlimit_kbps)"
+
+[ -n "$TARGET_HOST" ] || err "Ziel-Host fehlt im Trigger."
+[ -n "$TARGET_PORT" ] || TARGET_PORT=22
+[ -n "$TARGET_USER" ] || TARGET_USER=root
+[ -n "$BWLIMIT_KBPS" ] || BWLIMIT_KBPS=0
+
+# Trigger jetzt entfernen → /status zeigt "läuft" nur noch über SECRET, das am
+# Ende gelöscht wird. (Der Service hat den Trigger via ExecStartPre schon weg,
+# aber doppelt hält besser falls manuell gestartet.)
+rm -f "$TRIGGER" 2>/dev/null || true
+
+log "Ziel: ${TARGET_USER}@${TARGET_HOST}:${TARGET_PORT}"
+log "Quelle: $(hostname)"
+[ "$BWLIMIT_KBPS" -gt 0 ] 2>/dev/null && log "Bandbreiten-Limit: ${BWLIMIT_KBPS} KB/s"
+
+SSH_OPTS=(-p "$TARGET_PORT" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15)
+SSHPASS_CMD=(sshpass -f "$SECRET")
+REMOTE="${TARGET_USER}@${TARGET_HOST}"
+
+remote_ssh() { "${SSHPASS_CMD[@]}" ssh "${SSH_OPTS[@]}" "$REMOTE" "$@"; }
+
+# ── [0] Preflight ────────────────────────────────────────────────────────────
+log "[0/5] Preflight-Checks"
+command -v rsync   >/dev/null || err "rsync auf Quellserver nicht gefunden."
+command -v sshpass >/dev/null || err "sshpass auf Quellserver nicht gefunden."
+
+if ! remote_ssh "echo ok" >/dev/null 2>&1; then
+    err "SSH-Verbindung zu $REMOTE fehlgeschlagen (Host/Port/Passwort prüfen)."
+fi
+log "    SSH-Verbindung: OK"
+
+remote_ssh "command -v rsync >/dev/null" \
+    || err "rsync auf Ziel-Server nicht gefunden — dort installieren."
+log "    rsync auf Ziel: OK"
+
+remote_ssh "test -d $HH_CONFIG_DIR" \
+    || err "$HH_CONFIG_DIR auf Ziel fehlt — HydraHive2 dort zuerst installieren."
+log "    HydraHive2 auf Ziel installiert: OK"
+
+# Freien Platz auf Ziel grob prüfen (KB) vs. Quell-Datenmenge.
+SRC_KB="$(du -sk --one-file-system "$HH_DATA_DIR" 2>/dev/null | cut -f1)"
+DST_AVAIL_KB="$(remote_ssh "df -Pk $HH_DATA_DIR | tail -1 | awk '{print \$4}'" 2>/dev/null)"
+if [ -n "$SRC_KB" ] && [ -n "$DST_AVAIL_KB" ]; then
+    log "    Quelle: $((SRC_KB/1024/1024)) GB  |  Ziel frei: $((DST_AVAIL_KB/1024/1024)) GB"
+    if [ "$DST_AVAIL_KB" -lt "$SRC_KB" ]; then
+        err "Zu wenig Platz auf Ziel ($((DST_AVAIL_KB/1024/1024)) GB frei, $((SRC_KB/1024/1024)) GB nötig)."
+    fi
+fi
+
+# ── [1] Konsistenter DB-Snapshot ─────────────────────────────────────────────
+log "[1/5] DB-Snapshot (WAL-safe via sqlite3 .backup)"
+DB_SRC="$HH_DATA_DIR/sessions.db"
+SNAP_DIR="$HH_DATA_DIR/.migration-dbsnap"
+rm -rf "$SNAP_DIR"; mkdir -p "$SNAP_DIR"
+if [ -f "$DB_SRC" ]; then
+    if command -v sqlite3 >/dev/null; then
+        sqlite3 "$DB_SRC" ".backup '$SNAP_DIR/sessions.db'" \
+            && log "    Snapshot erstellt ($(du -h "$SNAP_DIR/sessions.db" | cut -f1))" \
+            || warn "    sqlite3 .backup fehlgeschlagen — DB wird als Datei gesynct (evtl. WAL-inkonsistent)"
+    else
+        warn "    sqlite3 fehlt — DB wird als Datei gesynct"
+    fi
+fi
+
+# ── [2] rsync-Ausschlüsse (regenerierbarer Ballast) ──────────────────────────
+# Nutzdaten (Git-Repos, Code, Configs, Archive, VMs) bleiben ALLE drin.
+EXCLUDES=(
+    --exclude 'node_modules/'
+    --exclude '.venv/'
+    --exclude 'venv/'
+    --exclude '__pycache__/'
+    --exclude '.mypy_cache/'
+    --exclude '.pytest_cache/'
+    --exclude '.plugin-cache/'
+    --exclude '.module-cache/'
+    --exclude '.numba-cache/'
+    --exclude 'gocache/'
+    --exclude 'gomods/'
+    --exclude '.migration-dbsnap/'
+    --exclude '.migration_request'
+    --exclude '.migration_secret'
+    --exclude '.migration_done'
+    --exclude '.backup-rollback-*'
+    --exclude '.hh2-restore-*'
+    --exclude 'memory_index.db'
+    --exclude 'sessions.db-wal'
+    --exclude 'sessions.db-shm'
+)
+
+RSYNC_OPTS=(-aAX --delete --numeric-ids --partial --info=progress2 --human-readable)
+[ "$BWLIMIT_KBPS" -gt 0 ] 2>/dev/null && RSYNC_OPTS+=(--bwlimit="$BWLIMIT_KBPS")
+
+RSH="sshpass -f $SECRET ssh -p $TARGET_PORT -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15"
+
+do_rsync() {
+    local src="$1" dst="$2"; shift 2
+    log "    rsync: $src → ${REMOTE}:$dst"
+    rsync "${RSYNC_OPTS[@]}" "${EXCLUDES[@]}" "$@" \
+        -e "$RSH" "$src" "${REMOTE}:$dst"
+}
+
+# ── [3] Ziel-Services stoppen (konsistenter Zustand) ─────────────────────────
+log "[3/5] Ziel-Dienste stoppen"
+remote_ssh "systemctl stop hydrahive2.service 2>/dev/null || true"
+
+# ── [4] Übertragung ──────────────────────────────────────────────────────────
+log "[4/5] Übertragung (rsync -aAX, inkrementell)"
+
+# 4a: data_dir komplett (workspaces/, modules/, agents/, vms/, projects/, …).
+#     Live-sessions.db ist excluded — Snapshot kommt separat.
+do_rsync "$HH_DATA_DIR/" "$HH_DATA_DIR/" \
+    || err "rsync von $HH_DATA_DIR fehlgeschlagen."
+
+# 4b: DB-Snapshot an die richtige Stelle.
+if [ -f "$SNAP_DIR/sessions.db" ]; then
+    rsync "${RSYNC_OPTS[@]}" -e "$RSH" \
+        "$SNAP_DIR/sessions.db" "${REMOTE}:$HH_DATA_DIR/sessions.db" \
+        || warn "DB-Snapshot-Sync fehlgeschlagen."
+fi
+
+# 4c: config_dir (Secrets, users.json, llm.json, extensions).
+do_rsync "$HH_CONFIG_DIR/" "$HH_CONFIG_DIR/" \
+    || err "rsync von $HH_CONFIG_DIR fehlgeschlagen."
+
+# ── [5] Ownership/Permissions auf Ziel korrigieren + Neustart ────────────────
+log "[5/5] Ownership/Permissions + Ziel-Neustart"
+remote_ssh "
+    id $HH_USER >/dev/null 2>&1 && chown -R $HH_USER:$HH_USER $HH_DATA_DIR 2>/dev/null || true
+    chown -R root:$HH_USER $HH_CONFIG_DIR 2>/dev/null || true
+    chmod 750 $HH_CONFIG_DIR 2>/dev/null || true
+    find $HH_CONFIG_DIR -type f -exec chmod 640 {} + 2>/dev/null || true
+    find $HH_DATA_DIR -name 'memory_index.db' -delete 2>/dev/null || true
+    systemctl start hydrahive2.service 2>/dev/null || true
+" || warn "Nacharbeiten auf Ziel teilweise fehlgeschlagen (manuell prüfen)."
+
+rm -rf "$SNAP_DIR" 2>/dev/null || true
+
+log "Ziel-Server neu gestartet. Klon steht bereit."
+FINAL_RC=0
+exit 0

--- a/installer/modules/50-systemd.sh
+++ b/installer/modules/50-systemd.sh
@@ -15,6 +15,8 @@ BRIDGE_SERVICE=/etc/systemd/system/hydrahive2-bridge.service
 BRIDGE_TIMER=/etc/systemd/system/hydrahive2-bridge.timer
 SAMBA_SERVICE=/etc/systemd/system/hydrahive2-samba.service
 SAMBA_TIMER=/etc/systemd/system/hydrahive2-samba.timer
+MIGRATION_SERVICE=/etc/systemd/system/hydrahive2-migration.service
+MIGRATION_TIMER=/etc/systemd/system/hydrahive2-migration.timer
 
 # JWT-Secret generieren falls nicht da
 SECRET_FILE="$HH_CONFIG_DIR/secret_key"
@@ -249,6 +251,41 @@ Unit=hydrahive2-bridge.service
 WantedBy=timers.target
 EOF
 
+log "Schreibe $MIGRATION_SERVICE (Server-zu-Server Voll-Klon Runner)"
+cat > "$MIGRATION_SERVICE" <<EOF
+[Unit]
+Description=HydraHive2 Server-Migration Runner (rsync Voll-Klon)
+ConditionPathExists=$HH_DATA_DIR/.migration_request
+
+[Service]
+Type=oneshot
+# 1,2 TB rsync kann Stunden dauern — kein Start-Timeout.
+TimeoutStartSec=0
+ExecStartPre=/bin/rm -f $HH_DATA_DIR/.migration_request
+Environment=HH_USER=$HH_USER
+Environment=HH_DATA_DIR=$HH_DATA_DIR
+Environment=HH_CONFIG_DIR=$HH_CONFIG_DIR
+Environment=HH_REPO_DIR=$HH_REPO_DIR
+ExecStart=$HH_REPO_DIR/installer/migrate.sh
+StandardOutput=append:/var/log/hydrahive2-migration.log
+StandardError=append:/var/log/hydrahive2-migration.log
+EOF
+
+log "Schreibe $MIGRATION_TIMER (Migration Trigger-Poller)"
+cat > "$MIGRATION_TIMER" <<EOF
+[Unit]
+Description=HydraHive2 Migration-Trigger Poller
+
+[Timer]
+OnBootSec=60s
+OnUnitActiveSec=5s
+AccuracySec=1s
+Unit=hydrahive2-migration.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
 # Alte Path-Units entfernen falls vorhanden
 rm -f /etc/systemd/system/hydrahive2-update.path
 rm -f /etc/systemd/system/hydrahive2-restart.path
@@ -262,6 +299,8 @@ touch /var/log/hydrahive2-bridge.log
 chmod 644 /var/log/hydrahive2-bridge.log
 touch /var/log/hydrahive2-samba.log
 chmod 644 /var/log/hydrahive2-samba.log
+touch /var/log/hydrahive2-migration.log
+chmod 644 /var/log/hydrahive2-migration.log
 
 log "systemd reload + enable"
 systemctl daemon-reload
@@ -271,14 +310,16 @@ systemctl enable hydrahive2-restart.timer >/dev/null 2>&1
 systemctl enable hydrahive2-voice.timer >/dev/null 2>&1
 systemctl enable hydrahive2-bridge.timer >/dev/null 2>&1
 systemctl enable hydrahive2-samba.timer >/dev/null 2>&1
+systemctl enable hydrahive2-migration.timer >/dev/null 2>&1
 
-log "Starte Service + Update-/Restart-/Voice-/Bridge-/Samba-Timer"
+log "Starte Service + Update-/Restart-/Voice-/Bridge-/Samba-/Migration-Timer"
 systemctl restart hydrahive2.service
 systemctl restart hydrahive2-update.timer
 systemctl restart hydrahive2-restart.timer
 systemctl restart hydrahive2-voice.timer
 systemctl restart hydrahive2-bridge.timer
 systemctl restart hydrahive2-samba.timer
+systemctl restart hydrahive2-migration.timer
 
 sleep 2
 if systemctl is-active --quiet hydrahive2.service; then


### PR DESCRIPTION
## Was
Kompletter Server-Umzug per **rsync**, wie es HydraHive 1 als Migration-Page hatte: am alten Server Ziel-Adresse + SSH-Zugang eingeben → **Klonen** → Live-Log → auf dem neuen Server steht ein **100%-Klon**.

Für die geplante Migration auf den **121er**.

## Warum rsync (statt tar-Stream wie HH1)
Die Workspaces sind bis **1,2 TB** groß (u.a. 894 GB Plattenarchive). Ein tar-Stream ist nicht wiederaufnehmbar — bricht die Verbindung ab, fängt alles von vorn an. `rsync -aAX` ist **inkrementell + resumierbar** und erhält Permissions/ACLs/Ownership → echter Klon. Vorgabe: *Voll-Klon, alle Daten inkl. Plattenarchive.*

## Architektur (HH2-konform — kein sudo im Core)
Exakt nach dem Update/Restart/Voice/Bridge-Muster:
- **`core/api/routes/migration.py`** (admin-only): `POST /start` validiert Host/User (Regex, keine Shell-Metazeichen), legt das SSH-Passwort in **separater 0600-Datei** ab (nie im Klartext-Trigger, nie in der Prozessliste), schreibt `.migration_request`. `GET /status` + `GET /log`.
- **`installer/migrate.sh`** (root oneshot): Preflight (SSH/rsync/Platz), WAL-safer `sqlite3 .backup`-Snapshot, `rsync -aAX --delete --numeric-ids --partial` über `sshpass -f`, Ownership-Fix auf Ziel, Ziel-Neustart. Secret wird per `trap` immer gelöscht.
- **`50-systemd.sh`**: `hydrahive2-migration.service` (root, `Type=oneshot`, `TimeoutStartSec=0`) + `.timer`.
- **Frontend**: `MigrationCard` + `MigrationModal` (Host/Port/User/Passwort/Bandbreite, Live-Log-Poll). Nutzt `ModalPortal` → kein springendes Overlay.

## Datenumfang
Kompletter `data_dir` (workspaces/, modules/, vms/, agents/, projects/, Plattenarchive) + `config_dir` (Secrets/Configs). **Excludes nur regenerierbarer Ballast** (node_modules, .venv, *-cache, gocache/gomods, memory_index.db, Rollback-Backups) — **Git-Repos + alle Nutzdaten bleiben drin**.

## Auth
SSH-**Passwort** (Till-Wahl) via `sshpass -f <0600-Datei>` — nie in der Prozessliste, nie im Log.

## Tests (17 grün)
- Router: Host/User-Injection abgewehrt, leeres Passwort (422), 409 bei laufender Migration, admin-only, Secret 0600 + kein Klartext im Trigger, Log-Tail, Status.
- `migrate.sh` statisch: Ballast excludet, **Nutzdaten NIEMALS**, `-aAX`/`numeric-ids`/`partial`, `sshpass -f` statt `-p`, Secret-Cleanup.

## Verifikation
pytest 17/17, ruff clean, `tsc` + `npm run build` grün (gegen /opt read-only, danach zurückgesetzt — Prod unberührt).

Spec: `docs/specs/server-migration-rsync.md`. Blaupause: HH1 `hydrahive-transfer.sh` + `router_migration.py` + `MigrationPage.tsx`.

> Hinweis: `ModalPortal.tsx` ist identisch zu PR #241 — bei Merge beider entsteht kein Konflikt.