### PR TITLE
feat(llm): Claude Fable 5 in die Modell-Auswahl aufnehmen

### DIFF
--- a/core/src/hydrahive/llm/_anthropic.py
+++ b/core/src/hydrahive/llm/_anthropic.py
@@ -29,7 +29,7 @@ EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
 # Alle anderen (Claude 4.5/4.1/4.0/3.x, MiniMax) nutzen den Legacy-Pfad.
 EFFORT_PARAM_MODELS = (
     "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6",
-    "claude-sonnet-5",
+    "claude-sonnet-5", "claude-fable-5",
 )
 
 # Legacy: Reasoning-Effort → extended_thinking budget_tokens (Claude 4.5/älter, MiniMax).

--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -27,7 +27,8 @@ PROVIDER_ENDPOINTS = {
 # Static-Listen für Provider ohne /v1/models-Endpoint.
 STATIC_MODELS = {
     "anthropic": [
-        "claude-sonnet-5", "claude-sonnet-4-6", "claude-opus-4-8", "claude-opus-4-7",
+        "claude-fable-5", "claude-sonnet-5", "claude-sonnet-4-6",
+        "claude-opus-4-8", "claude-opus-4-7",
         "claude-haiku-4-5", "claude-sonnet-4-5", "claude-3-7-sonnet-20250219",
         "claude-3-5-haiku-20241022",
     ],
@@ -59,6 +60,7 @@ PROVIDER_PREFIX = {
 # tool_use: True/False/None (None = ungetestet/unbekannt).
 METADATA: dict[str, dict[str, Any]] = {
     # Anthropic
+    "claude-fable-5":    {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-sonnet-5":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-opus-4-8":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-opus-4-7":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},

--- a/core/src/hydrahive/llm/_pricing.py
+++ b/core/src/hydrahive/llm/_pricing.py
@@ -23,6 +23,8 @@ class Pricing(NamedTuple):
 # Anthropic Claude — $/1M tokens × 100 cents × 1000 micros / 1M tokens = $-Wert × 0.1 micros/token
 # Beispiel: Sonnet $3/1M input = 3 × 0.1 = 0.3 micros/token
 _ANTHROPIC: dict[str, Pricing] = {
+    # Fable 5: $10 / $50 / cache_read $1.00 / cache_write $12.50 (Stand 2026-06, Release 09.06)
+    "claude-fable-5": Pricing(1.0, 5.0, 0.1, 1.25),
     # Sonnet 5: $2 / $10 / cache_read $0.20 / cache_write $2.50 (Intro-Preis, Stand 2026-07)
     "claude-sonnet-5": Pricing(0.2, 1.0, 0.02, 0.25),
     # Sonnet 4.x (4-5, 4-6, 4-7): $3 / $15 / cache_read $0.30 / cache_write $3.75

--- a/core/tests/test_claude_fable_5.py
+++ b/core/tests/test_claude_fable_5.py
@@ -1,0 +1,45 @@
+"""Claude Fable 5 (Release 2026-06-09) ist in allen LLM-Registern eingetragen.
+
+Prüft, dass das neue Anthropic-Top-Coding-Modell überall bekannt ist:
+Katalog (auswählbar), Metadata (1M Context, tool_use), Pricing ($10/$50),
+Effort-Param-Support (Mythos-Klasse nutzt output_config.effort wie Sonnet 5).
+"""
+from __future__ import annotations
+
+MODEL = "claude-fable-5"
+
+
+def test_in_static_catalog():
+    from hydrahive.llm._catalog_data import STATIC_MODELS
+    assert MODEL in STATIC_MODELS["anthropic"]
+
+
+def test_metadata_present():
+    from hydrahive.llm._catalog_data import METADATA
+    meta = METADATA[MODEL]
+    assert meta["context_window"] == 1_000_000
+    assert meta["tool_use"] is True
+    assert meta["family"] == "anthropic"
+
+
+def test_pricing_present():
+    from hydrahive.llm._pricing import lookup
+    p = lookup("anthropic", MODEL)
+    assert p is not None
+    # $10 input / $50 output in Micro-Cents ($ × 0.1).
+    assert p.input == 1.0
+    assert p.output == 5.0
+    assert p.cache_read == 0.1
+    assert p.cache_creation == 1.25
+
+
+def test_supports_effort_param():
+    from hydrahive.llm._anthropic import _uses_effort_param
+    assert _uses_effort_param(MODEL) is True
+    # auch mit Provider-Prefix (falls je über LiteLLM geroutet):
+    assert _uses_effort_param("anthropic/" + MODEL) is True
+
+
+def test_catalog_enrich_marks_effort():
+    from hydrahive.llm.catalog import _enrich
+    assert _enrich("anthropic", {"id": MODEL})["supports_effort"] is True

--- a/frontend/src/features/chat/pricing.ts
+++ b/frontend/src/features/chat/pricing.ts
@@ -8,6 +8,7 @@ interface Pricing {
 }
 
 const PRICING: { match: RegExp; price: Pricing }[] = [
+  { match: /^claude-fable-5/i,            price: { input: 10.00, output: 50.00, cache_read: 1.00,  cache_write: 12.50 } },
   { match: /^claude-opus-4/i,             price: { input: 15.00, output: 75.00, cache_read: 1.50,  cache_write: 18.75 } },
   { match: /^claude-sonnet-5/i,           price: { input: 2.00,  output: 10.00, cache_read: 0.20,  cache_write: 2.50  } },
   { match: /^claude-sonnet-4/i,           price: { input: 3.00,  output: 15.00, cache_read: 0.30,  cache_write: 3.75  } },


### PR DESCRIPTION
## Was
Anthropic **Claude Fable 5** (Release 09.06.2026) in die LLM-Modell-Auswahl aufgenommen — Anthropics aktuell stärkstes Modell für anspruchsvolle Coding-Projekte (Mythos-Klasse, 1M Context, 128k max output).

Model-ID: `claude-fable-5` (ohne Provider-Prefix, Anthropic-Konvention).

## Eingetragen in allen 4 LLM-Registern (SSOT)
| Datei | Was |
|---|---|
| `_catalog_data.py` STATIC_MODELS | auswählbar (1. Stelle bei anthropic) |
| `_catalog_data.py` METADATA | 1M context_window, tool_use, family=anthropic |
| `_pricing.py` _ANTHROPIC | $10 in / $50 out / cache $1 / $12.50 → Micro-Cents (1.0, 5.0, 0.1, 1.25) |
| `_anthropic.py` EFFORT_PARAM_MODELS | nutzt `output_config.effort` (wie Sonnet 5) |
| `frontend/chat/pricing.ts` | Kostenanzeige im Chat ($10/$50), Regex vor `claude-opus-4` |

Das `claude-*` → anthropic Provider-Routing greift automatisch (`_ensure_model_in_providers`), daher dort keine Änderung nötig.

## Verifikation
- Preise: Anthropic-Ankündigung + mehrere Pricing-Guides ($10/$50 pro 1M Tokens, Stand Juni 2026)
- Context/Effort: Simon Willison + Anthropic-Docs (1M Context, Mythos-Klasse)
- **5 neue Tests** grün (`test_claude_fable_5.py`: Katalog, Metadata, Pricing, Effort-Param, catalog-enrich)
- Regression grün (effort-models, catalog-live, models-endpoint)
- ruff + TypeScript clean

Nach Merge + Update erscheint Fable 5 im Modell-Dropdown und ist per Agent auswählbar.