### PR TITLE
fix(installer): Migration-Trigger-Units in update.sh nachrüsten

### DIFF
--- a/core/tests/test_update_sh_systemd_units.py
+++ b/core/tests/test_update_sh_systemd_units.py
@@ -1,0 +1,49 @@
+"""Verhindert Rollout-Lücken: jede Trigger-Unit aus 50-systemd.sh (frischer
+Install) muss auch in update.sh (Bestandsserver) angelegt werden.
+
+Bug-Kontext: hydrahive2-migration.service/.timer wurden nur in
+installer/modules/50-systemd.sh definiert (frischer Install), aber update.sh
+(für bereits laufende Server) legte den Block nicht an — auf Bestandsservern
+blieb der Migrations-Trigger dadurch für immer unbeachtet liegen, ohne
+Fehlermeldung. Dieser Test vergleicht die *_SERVICE-Variablennamen aus
+50-systemd.sh gegen die tatsächlich in update.sh geschriebenen Units.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INSTALLER_DIR = Path(__file__).resolve().parents[2] / "installer"
+FRESH_INSTALL = INSTALLER_DIR / "modules" / "50-systemd.sh"
+UPDATE_SCRIPT = INSTALLER_DIR / "update.sh"
+
+# Units, die bewusst NUR beim Frischinstall entstehen (kein Update-Pendant
+# nötig) — z.B. der Haupt-Service selbst, der beim Update schon längst läuft.
+EXEMPT = {"hydrahive2.service"}
+
+
+def _service_units_written(text: str) -> set[str]:
+    """Findet alle 'hydrahive2-*.service'/'*.timer'-Dateinamen, die per
+    'cat > .../NAME <<EOF' geschrieben werden."""
+    return set(re.findall(r"hydrahive2-[a-z-]+\.(?:service|timer)", text))
+
+
+def test_every_fresh_install_unit_has_update_counterpart():
+    fresh = _service_units_written(FRESH_INSTALL.read_text())
+    updated = _service_units_written(UPDATE_SCRIPT.read_text())
+
+    fresh -= EXEMPT
+    missing = fresh - updated
+    assert not missing, (
+        f"Diese Trigger-Units werden bei Frischinstall angelegt, aber NICHT "
+        f"bei update.sh nachgerüstet — Bestandsserver bekommen sie nie: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_migration_unit_specifically_present_in_update_sh():
+    """Regression-Guard für den konkreten Fund vom 2026-07-02."""
+    text = UPDATE_SCRIPT.read_text()
+    assert "hydrahive2-migration.service" in text
+    assert "hydrahive2-migration.timer" in text
+    assert "installer/migrate.sh" in text

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -230,6 +230,46 @@ EOF
   systemctl restart hydrahive2-samba.timer
 fi
 
+if [ ! -f /etc/systemd/system/hydrahive2-migration.timer ] || [ ! -f /etc/systemd/system/hydrahive2-migration.service ]; then
+  log "Migrations-Units anlegen (Server-zu-Server Voll-Klon)"
+  cat > /etc/systemd/system/hydrahive2-migration.service <<EOF
+[Unit]
+Description=HydraHive2 Server-Migration Runner (rsync Voll-Klon)
+ConditionPathExists=$HH_DATA_DIR/.migration_request
+
+[Service]
+Type=oneshot
+# 1,2 TB rsync kann Stunden dauern — kein Start-Timeout.
+TimeoutStartSec=0
+ExecStartPre=/bin/rm -f $HH_DATA_DIR/.migration_request
+Environment=HH_USER=$HH_USER
+Environment=HH_DATA_DIR=$HH_DATA_DIR
+Environment=HH_CONFIG_DIR=$HH_CONFIG_DIR
+Environment=HH_REPO_DIR=$HH_REPO_DIR
+ExecStart=$HH_REPO_DIR/installer/migrate.sh
+StandardOutput=append:/var/log/hydrahive2-migration.log
+StandardError=append:/var/log/hydrahive2-migration.log
+EOF
+  cat > /etc/systemd/system/hydrahive2-migration.timer <<EOF
+[Unit]
+Description=HydraHive2 Migration-Trigger Poller
+
+[Timer]
+OnBootSec=60s
+OnUnitActiveSec=5s
+AccuracySec=1s
+Unit=hydrahive2-migration.service
+
+[Install]
+WantedBy=timers.target
+EOF
+  touch /var/log/hydrahive2-migration.log
+  chmod 644 /var/log/hydrahive2-migration.log
+  systemctl daemon-reload
+  systemctl enable hydrahive2-migration.timer >/dev/null 2>&1
+  systemctl restart hydrahive2-migration.timer
+fi
+
 # Self-Heal: alter smb.conf-Patch (Verzeichnis-Include statt _index.conf-Datei)
 if [ -f /etc/samba/smb.conf ] && \
    grep -qE "^(config file|include) = /etc/samba/hh-projects\.d(\$|/%u\.conf)" /etc/samba/smb.conf 2>/dev/null; then


### PR DESCRIPTION
## Bug (live entdeckt)
Der Migrations-Knopf im Frontend schrieb den `.migration_request`-Trigger, aber **nichts passierte** — ewiges "Warte auf Ausgabe…". Ursache: `hydrahive2-migration.service`/`.timer` wurden nur in `installer/modules/50-systemd.sh` (frischer Install) definiert. `update.sh` — der Pfad für **bereits laufende** Server — legte den Block nicht an. Auf Bestandsservern blieb der Trigger für immer unbeachtet, ohne jede Fehlermeldung.

## Fix
Migration-Service+Timer-Block 1:1 aus `50-systemd.sh` nach `update.sh` übernommen — gleiche Stelle wie der Samba-Block, gleiches Idempotenz-Muster (nur anlegen wenn Unit-Files fehlen).

## Neuer Guard-Test
`test_update_sh_systemd_units.py` verhindert das **generisch** für alle Trigger-Units, nicht nur Migration: vergleicht, welche `hydrahive2-*.service`/`.timer`-Dateien `50-systemd.sh` beim Frischinstall schreibt, gegen das, was `update.sh` bei Bestandsservern nachrüstet. Jede künftige neue Trigger-Unit, die nur im Frischinstall-Skript landet, lässt CI jetzt rot werden.

## Verifikation
2 neue Tests grün, ruff clean. Workaround bis zum Fix: manueller User-Level-rsync-Klon (lief parallel, unabhängig von diesem Fix).