### PR TITLE
Theme-System Etappe 1: austauschbare Layout-Gerüste + UI-Kit

### DIFF
--- a/docs/specs/theming-system.md
+++ b/docs/specs/theming-system.md
@@ -1,0 +1,118 @@
+# Theme-System — installierbare Designs (WordPress-Prinzip)
+
+Status: **ENTWURF — wartet auf Freigabe**
+Autor: Agent · Datum: 2026-07-02 · Branch-Ziel: `feature/theme-system`
+
+## Was
+
+Ein Design-/Theme-System für HydraHive2, bei dem ein **Theme** nicht nur Farben
+tauscht, sondern das **komplette Layout + die Optik** — und als **eigenständiges
+Paket** installierbar ist, das jeder User selbst bauen kann (wie ein Plugin/Modul).
+
+Kernpunkte (von Till bestätigt):
+1. Mehrere Themes stehen zur Auswahl.
+2. User können **eigene Themes bauen** wie Plugins/Module.
+3. Das **jetzige Design** ist als Standard-Theme mit dabei.
+
+## Warum
+
+Der bisherige `LookSwitcher`/`ThemeSwitcher` ändert nur Farbe & Form (CSS-Variablen).
+Das ist zu wenig — ein „Designwechsel" muss auch das **Layout** ändern können
+(Menü oben ↔ Menü links ↔ Grid), so wie ein WordPress-Theme die ganze Seite umbaut.
+
+## Bestehende Patterns (wiederverwenden statt neu erfinden)
+
+- **Modul-System**: `hydrahive2-modules/<id>/manifest.json` + `frontend/` → via
+  `gen-modules.mjs` in `src/modules/index.generated.ts` gebündelt. Hub-installierbar
+  über `hub.json`.
+- **Plugin-System**: `plugins/{manifest,loader,installer,registry,hub_client}.py`
+  mit `plugin.yaml` (name/version/description/permissions), Installer + Registry.
+- **Layout**: steckt komplett in EINER Datei `frontend/src/shared/Layout.tsx`
+  (134 Zeilen, `<header>`-Menü oben + `<main><Outlet/>`). ← der Angelpunkt.
+- **CSS-Variablen**: `--hh-*` (Farbe/Form) + neue Look-Variablen aus `feature/ui-kit`.
+
+→ Ein Theme = **dasselbe Muster wie ein Modul**, nur dass es statt einer neuen Seite
+ein **Layout + CSS-Variablen-Set** liefert.
+
+## Architektur-Entscheidung: EIN global aktives Theme
+
+Wie WordPress: **genau ein Theme ist aktiv** und gilt für die ganze Oberfläche.
+(Begründung: „wie Plugins" + „jetziges Theme mit drin" = ein austauschbares aktives
+Design. Pro-Bereich-Themes wären eine spätere additive Erweiterung, kein MVP.)
+
+Offen für Till: global-für-alle (Admin schaltet) vs. pro-User-wählbar. MVP: **pro
+User in localStorage** (wie jetzt schon Theme/Look), Admin kann Default setzen.
+
+## Theme-Paket — Aufbau
+
+```
+themes/<id>/
+  theme.json           # Manifest
+  layout.tsx           # exportiert default: React-Komponente mit <Outlet/>
+  theme.css            # optional: CSS-Variablen + eigene Regeln (scoped)
+  preview.jpg          # optional: Vorschaubild für den Theme-Picker
+```
+
+`theme.json`:
+```json
+{
+  "id": "aurora",
+  "name": "Aurora",
+  "version": "1.0.0",
+  "author": "till",
+  "description": "Sidebar-Layout, ruhige Flächen.",
+  "layout": "sidebar",            // welches eingebaute Layout-Gerüst (oder "custom")
+  "variables": {                   // überschreibt --hh-* CSS-Variablen
+    "--hh-r": "0.6rem",
+    "--hh-accent-from": "rgb(2 132 199)"
+  },
+  "min_core_version": "2.0.0"
+}
+```
+
+## Layout-Gerüste (eingebaut, von Themes wählbar)
+
+`Layout.tsx` wird zerlegt in austauschbare Gerüste, die alle `<Outlet/>` + die
+bestehende Nav-Config (`NAV_ITEMS`, `visibleItems`) nutzen — die 382 Seiten bleiben
+**unangetastet**, nur das Gerüst drumherum wechselt:
+
+- `topnav` — Menü oben (= aktuelles Design, 1:1 aus heutiger Layout.tsx extrahiert)
+- `sidebar` — Menü links, Content rechts
+- `grid` — Startseite als Kachel-Grid, Sekundär-Nav
+
+Ein „custom"-Theme kann später eine eigene `layout.tsx` mitliefern (volle Freiheit).
+
+## Umsetzung in Etappen
+
+**Etappe 1 — Fundament (dieser PR):**
+- `Layout.tsx` → `layouts/TopnavLayout.tsx` extrahieren (verhaltensgleich, 1:1).
+- `LayoutHost` liest aktives Theme → wählt Gerüst + injiziert CSS-Variablen.
+- Theme-Registry (`shared/themes/`) mit **2 mitgelieferten** Themes:
+  „Standard" (topnav, heutiges Design) + „Sidebar" (Beweis dass Layout wirklich wechselt).
+- Theme-Picker im Profil (ersetzt/erweitert LookSwitcher) mit Vorschau.
+- **Akzeptanz:** Theme umschalten ändert sichtbar das Layout (oben↔links),
+  Standard sieht 1:1 aus wie heute, Build + tsc strict grün.
+
+**Etappe 2 — User-Themes (Paket-Loader):**
+- `theme.json`-Loader + Codegen (`gen-themes.mjs` analog gen-modules).
+- Themes aus einem `themes/`-Ordner einlesen (Dropin), Validierung.
+- **Akzeptanz:** Ein Theme-Ordner reinlegen → erscheint im Picker.
+
+**Etappe 3 — Hub/Installer (WordPress-Gefühl):**
+- Theme über den bestehenden Hub installierbar (wie Module), Backend-Route.
+- Optional: „Theme-Editor" im UI (Variablen live einstellen → als Paket exportieren).
+- **Akzeptanz:** Theme aus Hub installieren/entfernen ohne Redeploy.
+
+## Constraints
+
+- Additiv — Standard-Theme = pixelgleich zum heutigen Design (kein Regressions-Risiko).
+- Keine neue Fremd-Lib; React-Stack bleibt.
+- Custom-Theme-CSS wird **scoped** geladen (kein globales Durchbluten fremder Regeln).
+- Security: user-gebautes Theme-CSS darf kein JS ausführen; `layout.tsx` aus Hub =
+  gleiche Vertrauensstufe wie ein Modul (Review/Signatur — in Etappe 3 klären).
+- Max ~200 Zeilen/Datei, eine Verantwortung/Datei.
+
+## Nicht in diesem Feature
+
+- Pro-Bereich unterschiedliche Themes gleichzeitig (spätere additive Option).
+- Theme-Marktplatz/Remote-Registry (erst wenn Hub-Weg steht).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { SettingsPage } from "@/features/system/SettingsPage"
 import { SettingsHubPage } from "@/features/settings/SettingsHubPage"
 import { UsersPage } from "@/features/users/UsersPage"
 import { ProfilePage } from "@/features/profile/ProfilePage"
+import { UiKitPage } from "@/features/uikit/UiKitPage"
 import { PluginsPage } from "@/features/plugins/PluginsPage"
 import { ExtensionsPage } from "@/features/extensions/ExtensionsPage"
 import { ModulesPage } from "@/features/modules/ModulesPage"
@@ -90,6 +91,7 @@ export default function App() {
           <Route path="llm/catalog" element={<CatalogPage />} />
           <Route path="mcp" element={<McpPage />} />
           <Route path="skills" element={<SkillsPage />} />
+          <Route path="ui-kit" element={<UiKitPage />} />
           <Route path="credentials" element={<CredentialsPage />} />
           <Route path="settings" element={<SettingsHubPage />} />
           <Route path="settings/:groupId" element={<SettingsHubPage />} />

--- a/frontend/src/features/profile/LookSwitcher.tsx
+++ b/frontend/src/features/profile/LookSwitcher.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react"
+import { Check, Layers } from "lucide-react"
+import { useState } from "react"
+import { rgbFor } from "@/shared/colors"
+import { applyLook, getStoredLook, LOOKS, type LookId } from "@/shared/look"
+
+export function LookSwitcher() {
+  const [active, setActive] = useState<LookId>(getStoredLook())
+
+  function pick(id: LookId) {
+    applyLook(id)
+    setActive(id)
+  }
+
+  return (
+    <div className="box overflow-hidden p-5 space-y-3" style={{ "--c": rgbFor("/profile") } as CSSProperties}>
+      <div>
+        <h2 className="text-sm font-semibold text-zinc-200 flex items-center gap-2">
+          <Layers size={14} className="text-[var(--hh-accent-text)]" />
+          Oberflächen-Stil
+        </h2>
+        <p className="text-xs text-zinc-500 mt-0.5">
+          Verändert Form, Ränder und Dichte der Oberfläche — unabhängig von der Farbe.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {LOOKS.map((lk) => {
+          const isActive = lk.id === active
+          return (
+            <button
+              key={lk.id}
+              onClick={() => pick(lk.id)}
+              className={`flex items-start gap-3 px-3 py-2.5 rounded-lg border transition-all text-left ${
+                isActive
+                  ? "border-[var(--hh-accent-border)] bg-[var(--hh-accent-soft)]"
+                  : "border-white/[8%] hover:border-white/20 hover:bg-white/[3%]"
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-zinc-100 truncate flex items-center gap-1.5">
+                  {lk.name}
+                  {isActive && <Check size={12} className="text-[var(--hh-accent-text)]" />}
+                </p>
+                <p className="text-[11px] text-zinc-500">{lk.description}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/profile/ProfilePage.tsx
+++ b/frontend/src/features/profile/ProfilePage.tsx
@@ -7,6 +7,7 @@ import { LanguageSwitcher } from "@/i18n/LanguageSwitcher"
 import { BackupRestoreCard } from "./BackupRestoreCard"
 import { ChangeOwnPasswordCard } from "./ChangeOwnPasswordCard"
 import { LandingSwitcher } from "./LandingSwitcher"
+import { LookSwitcher } from "./LookSwitcher"
 import { ThemeSwitcher } from "./ThemeSwitcher"
 import { TTSSettings } from "./TTSSettings"
 
@@ -50,6 +51,8 @@ export function ProfilePage() {
       </div>
 
       <ThemeSwitcher />
+
+      <LookSwitcher />
 
       <LandingSwitcher />
 

--- a/frontend/src/features/profile/ProfilePage.tsx
+++ b/frontend/src/features/profile/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { BackupRestoreCard } from "./BackupRestoreCard"
 import { ChangeOwnPasswordCard } from "./ChangeOwnPasswordCard"
 import { LandingSwitcher } from "./LandingSwitcher"
 import { LookSwitcher } from "./LookSwitcher"
+import { ThemePicker } from "./ThemePicker"
 import { ThemeSwitcher } from "./ThemeSwitcher"
 import { TTSSettings } from "./TTSSettings"
 
@@ -49,6 +50,8 @@ export function ProfilePage() {
           <LanguageSwitcher />
         </div>
       </div>
+
+      <ThemePicker />
 
       <ThemeSwitcher />
 

--- a/frontend/src/features/profile/ThemePicker.tsx
+++ b/frontend/src/features/profile/ThemePicker.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties } from "react"
+import { Check, LayoutTemplate } from "lucide-react"
+import { useState } from "react"
+import { rgbFor } from "@/shared/colors"
+import { getStoredThemeId, storeThemeId, THEMES } from "@/shared/themes/registry"
+
+/** Theme-Picker: wählt das aktive Layout-Theme (Menü oben / Sidebar / …).
+ *  Speichert in localStorage und benachrichtigt den LayoutHost live. */
+export function ThemePicker() {
+  const [active, setActive] = useState<string>(getStoredThemeId())
+
+  function pick(id: string) {
+    storeThemeId(id)
+    setActive(id)
+    window.dispatchEvent(new Event("hh-theme-change"))
+  }
+
+  return (
+    <div className="box overflow-hidden p-5 space-y-3" style={{ "--c": rgbFor("/profile") } as CSSProperties}>
+      <div>
+        <h2 className="text-sm font-semibold text-zinc-200 flex items-center gap-2">
+          <LayoutTemplate size={14} className="text-[var(--hh-accent-text)]" />
+          Design
+        </h2>
+        <p className="text-xs text-zinc-500 mt-0.5">
+          Wechselt das komplette Layout der Oberfläche — nicht nur die Farbe.
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {THEMES.map((th) => {
+          const isActive = th.id === active
+          return (
+            <button
+              key={th.id}
+              onClick={() => pick(th.id)}
+              className={`flex items-start gap-3 px-3 py-2.5 rounded-lg border transition-all text-left ${
+                isActive
+                  ? "border-[var(--hh-accent-border)] bg-[var(--hh-accent-soft)]"
+                  : "border-white/[8%] hover:border-white/20 hover:bg-white/[3%]"
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-zinc-100 flex items-center gap-1.5">
+                  {th.name}
+                  {isActive && <Check size={12} className="text-[var(--hh-accent-text)]" />}
+                </p>
+                <p className="text-[11px] text-zinc-500">{th.description}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/uikit/UiKitPage.tsx
+++ b/frontend/src/features/uikit/UiKitPage.tsx
@@ -1,0 +1,150 @@
+import type { CSSProperties } from "react"
+import { useState } from "react"
+import { Check, Layers, Palette, Rocket, Save, Search, Settings, Trash2 } from "lucide-react"
+import { rgbFor } from "@/shared/colors"
+import { applyTheme, getStoredTheme, THEMES, type ThemeId } from "@/shared/theme"
+import { applyLook, getStoredLook, LOOKS, type LookId } from "@/shared/look"
+import { Badge, Button, Card, CardHeader, Input, Select, Textarea } from "@/shared/ui"
+
+/**
+ * Lebende Vorschau des HydraHive UI-Kits. Zeigt alle Basis-Komponenten und
+ * erlaubt oben das Live-Umschalten von Farbe UND Look — damit sichtbar wird,
+ * wie stark ein Theme-Wechsel die komplette Optik verändert (WordPress-artig).
+ */
+export function UiKitPage() {
+  const [theme, setTheme] = useState<ThemeId>(getStoredTheme())
+  const [look, setLook] = useState<LookId>(getStoredLook())
+
+  function pickTheme(id: ThemeId) {
+    applyTheme(id)
+    setTheme(id)
+  }
+  function pickLook(id: LookId) {
+    applyLook(id)
+    setLook(id)
+  }
+
+  const c = rgbFor("/settings")
+
+  return (
+    <div className="space-y-5 max-w-4xl">
+      <div>
+        <h1 className="text-xl font-bold text-white">UI-Kit — Vorschau</h1>
+        <p className="text-zinc-500 text-sm mt-0.5">
+          Konsistente Basis-Komponenten. Schalte oben Farbe &amp; Stil um — alle Elemente ändern sich live mit.
+        </p>
+      </div>
+
+      {/* ── Umschalter ──────────────────────────────────────────── */}
+      <Card color={c} style={{ ["--c" as string]: c } as CSSProperties}>
+        <CardHeader icon={<Palette size={15} />} title="Farbe" />
+        <div className="flex flex-wrap gap-2">
+          {THEMES.map((th) => (
+            <button
+              key={th.id}
+              onClick={() => pickTheme(th.id)}
+              className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs transition-all ${
+                th.id === theme
+                  ? "border-[var(--hh-accent-border)] bg-[var(--hh-accent-soft)] text-zinc-100"
+                  : "border-white/[8%] text-zinc-400 hover:border-white/20 hover:bg-white/[3%]"
+              }`}
+            >
+              <span
+                className="w-4 h-4 rounded-full"
+                style={{ background: `linear-gradient(135deg, ${th.preview.from}, ${th.preview.to})` }}
+              />
+              {th.name}
+              {th.id === theme && <Check size={11} className="text-[var(--hh-accent-text)]" />}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-4 mb-2 flex items-center gap-2 text-zinc-100">
+          <Layers size={15} className="text-[var(--hh-accent-text)]" />
+          <h3 className="text-sm font-semibold">Stil</h3>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {LOOKS.map((lk) => (
+            <button
+              key={lk.id}
+              onClick={() => pickLook(lk.id)}
+              className={`px-3 py-1.5 rounded-lg border text-xs transition-all ${
+                lk.id === look
+                  ? "border-[var(--hh-accent-border)] bg-[var(--hh-accent-soft)] text-zinc-100"
+                  : "border-white/[8%] text-zinc-400 hover:border-white/20 hover:bg-white/[3%]"
+              }`}
+            >
+              {lk.name}
+              {lk.id === look && <Check size={11} className="inline ml-1 text-[var(--hh-accent-text)]" />}
+            </button>
+          ))}
+        </div>
+      </Card>
+
+      {/* ── Buttons ─────────────────────────────────────────────── */}
+      <Card color={c} style={{ ["--c" as string]: c } as CSSProperties}>
+        <CardHeader icon={<Rocket size={15} />} title="Buttons" />
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="outline">Outline</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="danger" icon={<Trash2 size={14} />}>Löschen</Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button size="sm">Small</Button>
+            <Button size="md" icon={<Save size={14} />}>Medium</Button>
+            <Button size="lg">Large</Button>
+            <Button disabled>Disabled</Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* ── Formular-Elemente ───────────────────────────────────── */}
+      <Card color={c} style={{ ["--c" as string]: c } as CSSProperties}>
+        <CardHeader icon={<Settings size={15} />} title="Eingaben" />
+        <div className="grid sm:grid-cols-2 gap-3">
+          <Input placeholder="Normales Textfeld…" />
+          <Input placeholder="Mit Icon…" icon={<Search size={15} />} />
+          <Input placeholder="Fehlerzustand" invalid defaultValue="ungültig" />
+          <Select defaultValue="">
+            <option value="" disabled>Bitte wählen…</option>
+            <option>Option A</option>
+            <option>Option B</option>
+            <option>Option C</option>
+          </Select>
+          <Textarea placeholder="Mehrzeiliger Text…" rows={3} className="sm:col-span-2" />
+        </div>
+      </Card>
+
+      {/* ── Badges ──────────────────────────────────────────────── */}
+      <Card color={c} style={{ ["--c" as string]: c } as CSSProperties}>
+        <CardHeader title="Badges" />
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="accent">Accent</Badge>
+          <Badge variant="neutral">Neutral</Badge>
+          <Badge variant="success" icon={<Check size={11} />}>Erfolg</Badge>
+          <Badge variant="warning">Warnung</Badge>
+          <Badge variant="danger">Fehler</Badge>
+        </div>
+      </Card>
+
+      {/* ── Karten in Domain-Farben ─────────────────────────────── */}
+      <div className="grid sm:grid-cols-3 gap-4">
+        <Card color={rgbFor("/chat")}>
+          <CardHeader title="Werkstatt" />
+          <p className="text-xs text-zinc-400">Karte mit eigener Domain-Farbe.</p>
+        </Card>
+        <Card color={rgbFor("/atelier")}>
+          <CardHeader title="Atelier" />
+          <p className="text-xs text-zinc-400">Jede Box trägt ihre Bereichsfarbe.</p>
+        </Card>
+        <Card color={rgbFor("/cryptoboard")}>
+          <CardHeader title="Cryptoboard" />
+          <p className="text-xs text-zinc-400">Glow &amp; Rand folgen dem Stil-Preset.</p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,18 @@
     --hh-bd:        rgba(255,255,255,.10);
     --hh-r:         1.1rem;
 
+    /* ── Look-Stellschrauben (data-look überschreibt sie) ──────────────
+       Steuern die FORM statt der Farbe. Default = Neon (Original).
+       Multiplikatoren skalieren Farbwäsche/Rand/Glow der .box & Controls,
+       ohne Layout zu reflowen (rein visuell). */
+    --hh-box-wash:   1;      /* Farbwäsche-Intensität der Panels    */
+    --hh-box-border: 1;      /* Randdeckkraft                        */
+    --hh-glow:       1;      /* Glow-Halo-Intensität (0 = kein Glow) */
+    --hh-lift:       -2px;   /* Hover-Anheben der .box               */
+    --hh-ctl-r:      0.5rem; /* Radius interaktiver Controls (Button/Input) */
+    --hh-ctl-py:     0.5rem; /* vertikales Control-Padding (Dichte)  */
+    --hh-ctl-px:     0.9rem; /* horizontales Control-Padding (Dichte)*/
+
     /* Theme-Akzentfarben — default Violet (Standard) */
     --hh-accent-from: rgb(79 70 229);    /* indigo-600 */
     --hh-accent-to:   rgb(124 58 237);   /* violet-600 */
@@ -85,6 +97,39 @@
     --hh-accent-border: rgba(161, 161, 170, 0.30);
     --hh-scrollbar-thumb: rgba(161, 161, 170, 0.18);
     --hh-scrollbar-thumb-hover: rgba(161, 161, 170, 0.35);
+  }
+
+  /* ── Look-Presets ─────────────────────────────────────────────────
+     Verändern Radius/Ränder/Glow/Dichte. Kombinierbar mit jeder Farbe. */
+  [data-look="clean"] {
+    --hh-r:          0.6rem;
+    --hh-box-wash:   0.35;
+    --hh-box-border: 0.5;
+    --hh-glow:       0.15;
+    --hh-lift:       0px;
+    --hh-ctl-r:      0.5rem;
+    --hh-panel:      #161b28;
+  }
+
+  [data-look="compact"] {
+    --hh-r:          0.5rem;
+    --hh-box-wash:   0.7;
+    --hh-box-border: 0.8;
+    --hh-glow:       0.5;
+    --hh-lift:       -1px;
+    --hh-ctl-r:      0.4rem;
+    --hh-ctl-py:     0.3rem;
+    --hh-ctl-px:     0.65rem;
+  }
+
+  [data-look="solid"] {
+    --hh-r:          0.7rem;
+    --hh-box-wash:   1.4;
+    --hh-box-border: 1.6;
+    --hh-glow:       0.25;
+    --hh-lift:       0px;
+    --hh-ctl-r:      0.55rem;
+    --hh-panel:      #232a3d;
   }
 
   .light {
@@ -156,23 +201,23 @@
     border-radius: var(--hh-r);
     background:
       linear-gradient(158deg, var(--hh-panel-top), var(--hh-panel-bot)),
-      linear-gradient(160deg, rgb(var(--c) / .38), rgb(var(--c) / .13) 65%),
+      linear-gradient(160deg, rgb(var(--c) / calc(.38 * var(--hh-box-wash))), rgb(var(--c) / calc(.13 * var(--hh-box-wash))) 65%),
       var(--hh-panel);
-    border: 1px solid rgb(var(--c) / .62);
+    border: 1px solid rgb(var(--c) / calc(.62 * var(--hh-box-border)));
     box-shadow:
       inset 0 1px 0 rgba(255,255,255,.12),
-      0 0 0 1px rgb(var(--c) / .30),
-      0 0 24px -2px rgb(var(--c) / .50),
-      0 18px 44px -20px rgb(var(--c) / .95);
+      0 0 0 1px rgb(var(--c) / calc(.30 * var(--hh-box-border))),
+      0 0 24px -2px rgb(var(--c) / calc(.50 * var(--hh-glow))),
+      0 18px 44px -20px rgb(var(--c) / calc(.95 * var(--hh-glow)));
     transition: .22s;
   }
   .box:hover {
-    transform: translateY(-2px);
+    transform: translateY(var(--hh-lift));
     box-shadow:
       inset 0 1px 0 rgba(255,255,255,.16),
-      0 0 0 1px rgb(var(--c) / .45),
-      0 0 34px 0 rgb(var(--c) / .60),
-      0 24px 54px -18px rgb(var(--c));
+      0 0 0 1px rgb(var(--c) / calc(.45 * var(--hh-box-border))),
+      0 0 34px 0 rgb(var(--c) / calc(.60 * var(--hh-glow))),
+      0 24px 54px -18px rgb(var(--c) / calc(1 * var(--hh-glow)));
   }
   /* Statische Box für INTERAKTIVE Inhalte (Konsole/xterm, Monaco): gleicher
      Glow-Look, aber KEIN Hover-Lift + keine Transition — die verschieben/

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,8 +4,10 @@ import './index.css'
 import './i18n'
 import App from './App.tsx'
 import { applyTheme, getStoredTheme } from './shared/theme'
+import { applyLook, getStoredLook } from './shared/look'
 
 applyTheme(getStoredTheme())
+applyLook(getStoredLook())
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -1,17 +1,17 @@
-import { useState } from "react"
-import { Link, Outlet, useLocation } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { Grip, Settings } from "lucide-react"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { UpdateModal } from "@/shared/UpdateModal"
 import { useLayoutUpdate } from "./useLayoutUpdate"
-import { AppFooter } from "./AppFooter"
-import { AvatarMenu } from "./AvatarMenu"
 import { BentoMenu } from "./BentoMenu"
-import { DOMAIN_TW, colorFor } from "./colors"
 import { NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
-import { navLabel } from "./nav-label"
+import { getStoredThemeId, getTheme } from "./themes/registry"
+import type { LayoutChrome } from "./layouts/types"
 
+/** LayoutHost — sammelt gemeinsames Chrome (Nav, Update-State), wählt das aktive
+ *  Theme-Layout-Gerüst und hält globale Overlays (Bento, UpdateModal). Das
+ *  eigentliche Gerüst (Menü oben / Sidebar / …) liefert das Theme. */
 export function Layout() {
   const { role } = useAuthStore()
   const { t } = useTranslation("nav")
@@ -24,103 +24,51 @@ export function Layout() {
   } = useLayoutUpdate()
   const [bentoOpen, setBentoOpen] = useState(false)
 
+  // Aktives Theme (aus localStorage). Re-render bei Wechsel via Custom-Event.
+  const [themeId, setThemeId] = useState(getStoredThemeId)
+  useEffect(() => {
+    const onChange = () => setThemeId(getStoredThemeId())
+    window.addEventListener("hh-theme-change", onChange)
+    return () => window.removeEventListener("hh-theme-change", onChange)
+  }, [])
+
+  const theme = getTheme(themeId)
+
+  // Theme-CSS-Variablen auf <html> anwenden (überschreibt --hh-*).
+  useEffect(() => {
+    const el = document.documentElement
+    const vars = theme.variables ?? {}
+    for (const [k, v] of Object.entries(vars)) el.style.setProperty(k, v)
+    return () => {
+      for (const k of Object.keys(vars)) el.style.removeProperty(k)
+    }
+  }, [theme])
+
   const visible = visibleItems(role)
   const quickLinks = QUICK_LINK_PATHS
     .map((p) => visible.find((i) => i.path === p))
     .filter(Boolean) as typeof NAV_ITEMS
   const currentPage = visible.find((i) =>
-    i.path === "/" ? pathname === "/" : pathname.startsWith(i.path)
+    i.path === "/" ? pathname === "/" : pathname.startsWith(i.path),
   )
 
+  const chrome: LayoutChrome = {
+    role, t, pathname, visible, quickLinks, currentPage,
+    onBentoToggle: () => setBentoOpen((o) => !o),
+    footer: {
+      version, commit, updateBehind,
+      isAdmin: role === "admin",
+      onUpdateClick: openUpdateModal,
+    },
+  }
+
+  const ActiveLayout = theme.layout
+
   return (
-    <div className="flex flex-col h-[100dvh] overflow-hidden bg-[#0b0e16]">
-      {/* Atmosphäre-Glows (Redesign): violett oben-mitte, teal unten-links, amber unten-rechts */}
-      <div className="fixed inset-0 pointer-events-none overflow-hidden">
-        <div className="absolute -top-40 left-1/2 -translate-x-1/2 w-[560px] h-[400px] bg-violet-600/[18%] rounded-full blur-3xl" />
-        <div className="absolute -bottom-40 -left-24 w-[520px] h-[440px] bg-teal-500/[15%] rounded-full blur-3xl" />
-        <div className="absolute -bottom-44 -right-24 w-[520px] h-[440px] bg-amber-500/[14%] rounded-full blur-3xl" />
-      </div>
-
-      {/* Top-Bar */}
-      <header className="relative z-30 flex items-center gap-2 px-3 sm:px-4 h-12 border-b border-white/[6%] bg-zinc-950/80 backdrop-blur">
-        <Link to="/" className="flex items-center gap-2 shrink-0">
-          <img
-            src="/illustrations/logo-mark.png"
-            alt=""
-            className="w-8 h-8 object-contain drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] select-none"
-          />
-          <span className="hidden sm:inline font-bold text-[var(--hh-accent-text)] tracking-tight">
-            HydraHive
-          </span>
-        </Link>
-
-        {currentPage && (
-          <span className="flex items-center gap-1.5 text-[11px] sm:text-sm text-zinc-400 ml-1 sm:ml-2 truncate">
-            <span className="text-zinc-600 mx-1">/</span>
-            <span className={`w-1.5 h-1.5 rounded-full ${DOMAIN_TW[colorFor(currentPage.path)].iconBgActive}`} />
-            {navLabel(t, currentPage.labelKey)}
-          </span>
-        )}
-
-        <div className="flex-1" />
-
-        <nav className="hidden lg:flex items-center gap-1">
-          {quickLinks.map(({ path, icon: Icon, labelKey }) => {
-            const active = path === "/" ? pathname === "/" : pathname.startsWith(path)
-            const c = DOMAIN_TW[colorFor(path)]
-            return (
-              <Link
-                key={path}
-                to={path}
-                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors ${
-                  active
-                    ? `${c.bgActive} ${c.textActive}`
-                    : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
-                }`}
-              >
-                <Icon size={13} /> {navLabel(t, labelKey)}
-              </Link>
-            )
-          })}
-        </nav>
-
-        <Link
-          to="/settings"
-          className={`p-1.5 rounded-md transition-colors ${
-            pathname.startsWith("/settings")
-              ? "text-violet-300 bg-violet-500/15"
-              : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
-          }`}
-          title={t("settings.gear_tooltip", { ns: "system", defaultValue: "Einstellungen" })}
-        >
-          <Settings size={16} />
-        </Link>
-
-        <button
-          onClick={() => setBentoOpen((o) => !o)}
-          className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
-          title="Apps"
-        >
-          <Grip size={16} />
-        </button>
-
-        <AvatarMenu />
-      </header>
+    <>
+      <ActiveLayout chrome={chrome} />
 
       <BentoMenu open={bentoOpen} onClose={() => setBentoOpen(false)} />
-
-      {/* Content — overflow-x-hidden + overscroll-x-none: kein horizontales Pannen
-          auf Touch-Geräten (sonst wischt der Chat „ins Nirvana"). Vertikal scrollt
-          weiter; breite Inhalte (Code/Tabellen/Monaco) haben eigene innere Scroller. */}
-      <main className="flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none relative z-10 p-4 md:p-6">
-        <Outlet />
-      </main>
-
-      <AppFooter
-        version={version} commit={commit} updateBehind={updateBehind}
-        isAdmin={role === "admin"}
-        onUpdateClick={openUpdateModal}
-      />
 
       {updateState !== "idle" && (
         <UpdateModal
@@ -129,6 +77,6 @@ export function Layout() {
           onConfirm={confirmUpdate} onClose={closeUpdateModal}
         />
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/src/shared/layouts/SidebarLayout.tsx
+++ b/frontend/src/shared/layouts/SidebarLayout.tsx
@@ -1,0 +1,104 @@
+import { Link, Outlet } from "react-router-dom"
+import { Grip, Settings } from "lucide-react"
+import { AppFooter } from "@/shared/AppFooter"
+import { AvatarMenu } from "@/shared/AvatarMenu"
+import { DOMAIN_TW, colorFor } from "@/shared/colors"
+import { navLabel } from "@/shared/nav-label"
+import type { LayoutChrome } from "./types"
+
+/** Test-Layout: Menü links in einer Seitenleiste, Inhalt rechts.
+ *  Nutzt dieselben Nav-Daten wie das Standard-Layout — nur anders angeordnet.
+ *  Beweist, dass ein Theme das komplette Layout umbaut, nicht nur Farben. */
+export function SidebarLayout({ chrome }: { chrome: LayoutChrome }) {
+  const { t, pathname, visible, currentPage, onBentoToggle, footer } = chrome
+
+  return (
+    <div className="flex h-[100dvh] overflow-hidden bg-[#0b0e16]">
+      {/* Atmosphäre-Glow, dezenter am Rand */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute -top-40 -left-24 w-[520px] h-[440px] bg-violet-600/[14%] rounded-full blur-3xl" />
+        <div className="absolute -bottom-44 -right-24 w-[520px] h-[440px] bg-teal-500/[12%] rounded-full blur-3xl" />
+      </div>
+
+      {/* Seitenleiste links */}
+      <aside className="relative z-30 flex flex-col w-60 shrink-0 border-r border-white/[6%] bg-zinc-950/80 backdrop-blur">
+        <div className="flex items-center gap-2 h-12 px-4 border-b border-white/[6%]">
+          <Link to="/" className="flex items-center gap-2">
+            <img
+              src="/illustrations/logo-mark.png"
+              alt=""
+              className="w-8 h-8 object-contain drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] select-none"
+            />
+            <span className="font-bold text-[var(--hh-accent-text)] tracking-tight">HydraHive</span>
+          </Link>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto p-2 space-y-0.5">
+          {visible.map(({ path, icon: Icon, labelKey }) => {
+            const active = path === "/" ? pathname === "/" : pathname.startsWith(path)
+            const c = DOMAIN_TW[colorFor(path)]
+            return (
+              <Link
+                key={path}
+                to={path}
+                className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
+                  active ? `${c.bgActive} ${c.textActive}` : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+                }`}
+              >
+                <Icon size={15} className="shrink-0" /> {navLabel(t, labelKey)}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="flex items-center gap-1 p-2 border-t border-white/[6%]">
+          <Link
+            to="/settings"
+            className={`p-1.5 rounded-md transition-colors ${
+              pathname.startsWith("/settings")
+                ? "text-violet-300 bg-violet-500/15"
+                : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+            }`}
+            title={t("settings.gear_tooltip", { ns: "system", defaultValue: "Einstellungen" })}
+          >
+            <Settings size={16} />
+          </Link>
+          <button
+            onClick={onBentoToggle}
+            className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+            title="Apps"
+          >
+            <Grip size={16} />
+          </button>
+          <div className="ml-auto">
+            <AvatarMenu />
+          </div>
+        </div>
+      </aside>
+
+      {/* Rechte Spalte: schmale Kopfzeile mit Breadcrumb + Content + Footer */}
+      <div className="flex flex-col flex-1 min-w-0">
+        <header className="relative z-20 flex items-center h-12 px-4 border-b border-white/[6%] bg-zinc-950/40 backdrop-blur">
+          {currentPage && (
+            <span className="flex items-center gap-1.5 text-sm text-zinc-300 truncate">
+              <span className={`w-1.5 h-1.5 rounded-full ${DOMAIN_TW[colorFor(currentPage.path)].iconBgActive}`} />
+              {navLabel(t, currentPage.labelKey)}
+            </span>
+          )}
+        </header>
+
+        <main className="flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none relative z-10 p-4 md:p-6">
+          <Outlet />
+        </main>
+
+        <AppFooter
+          version={footer.version}
+          commit={footer.commit}
+          updateBehind={footer.updateBehind}
+          isAdmin={footer.isAdmin}
+          onUpdateClick={footer.onUpdateClick}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/shared/layouts/TopnavLayout.tsx
+++ b/frontend/src/shared/layouts/TopnavLayout.tsx
@@ -1,0 +1,101 @@
+import { Link, Outlet } from "react-router-dom"
+import { Grip, Settings } from "lucide-react"
+import { AppFooter } from "@/shared/AppFooter"
+import { AvatarMenu } from "@/shared/AvatarMenu"
+import { DOMAIN_TW, colorFor } from "@/shared/colors"
+import { navLabel } from "@/shared/nav-label"
+import type { LayoutChrome } from "./types"
+
+/** Standard-Layout: Menü oben (1:1 das bisherige HydraHive-Design). */
+export function TopnavLayout({ chrome }: { chrome: LayoutChrome }) {
+  const { t, pathname, quickLinks, currentPage, onBentoToggle, footer } = chrome
+
+  return (
+    <div className="flex flex-col h-[100dvh] overflow-hidden bg-[#0b0e16]">
+      {/* Atmosphäre-Glows: violett oben-mitte, teal unten-links, amber unten-rechts */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <div className="absolute -top-40 left-1/2 -translate-x-1/2 w-[560px] h-[400px] bg-violet-600/[18%] rounded-full blur-3xl" />
+        <div className="absolute -bottom-40 -left-24 w-[520px] h-[440px] bg-teal-500/[15%] rounded-full blur-3xl" />
+        <div className="absolute -bottom-44 -right-24 w-[520px] h-[440px] bg-amber-500/[14%] rounded-full blur-3xl" />
+      </div>
+
+      {/* Top-Bar */}
+      <header className="relative z-30 flex items-center gap-2 px-3 sm:px-4 h-12 border-b border-white/[6%] bg-zinc-950/80 backdrop-blur">
+        <Link to="/" className="flex items-center gap-2 shrink-0">
+          <img
+            src="/illustrations/logo-mark.png"
+            alt=""
+            className="w-8 h-8 object-contain drop-shadow-[0_0_8px_rgba(34,211,238,0.5)] select-none"
+          />
+          <span className="hidden sm:inline font-bold text-[var(--hh-accent-text)] tracking-tight">
+            HydraHive
+          </span>
+        </Link>
+
+        {currentPage && (
+          <span className="flex items-center gap-1.5 text-[11px] sm:text-sm text-zinc-400 ml-1 sm:ml-2 truncate">
+            <span className="text-zinc-600 mx-1">/</span>
+            <span className={`w-1.5 h-1.5 rounded-full ${DOMAIN_TW[colorFor(currentPage.path)].iconBgActive}`} />
+            {navLabel(t, currentPage.labelKey)}
+          </span>
+        )}
+
+        <div className="flex-1" />
+
+        <nav className="hidden lg:flex items-center gap-1">
+          {quickLinks.map(({ path, icon: Icon, labelKey }) => {
+            const active = path === "/" ? pathname === "/" : pathname.startsWith(path)
+            const c = DOMAIN_TW[colorFor(path)]
+            return (
+              <Link
+                key={path}
+                to={path}
+                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors ${
+                  active ? `${c.bgActive} ${c.textActive}` : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+                }`}
+              >
+                <Icon size={13} /> {navLabel(t, labelKey)}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <Link
+          to="/settings"
+          className={`p-1.5 rounded-md transition-colors ${
+            pathname.startsWith("/settings")
+              ? "text-violet-300 bg-violet-500/15"
+              : "text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+          }`}
+          title={t("settings.gear_tooltip", { ns: "system", defaultValue: "Einstellungen" })}
+        >
+          <Settings size={16} />
+        </Link>
+
+        <button
+          onClick={onBentoToggle}
+          className="p-1.5 rounded-md text-zinc-400 hover:text-zinc-200 hover:bg-white/[5%]"
+          title="Apps"
+        >
+          <Grip size={16} />
+        </button>
+
+        <AvatarMenu />
+      </header>
+
+      {/* Content — overflow-x-hidden + overscroll-x-none: kein horizontales Pannen
+          auf Touch-Geräten. Vertikal scrollt weiter. */}
+      <main className="flex-1 overflow-y-auto overflow-x-hidden overscroll-x-none relative z-10 p-4 md:p-6">
+        <Outlet />
+      </main>
+
+      <AppFooter
+        version={footer.version}
+        commit={footer.commit}
+        updateBehind={footer.updateBehind}
+        isAdmin={footer.isAdmin}
+        onUpdateClick={footer.onUpdateClick}
+      />
+    </div>
+  )
+}

--- a/frontend/src/shared/layouts/types.ts
+++ b/frontend/src/shared/layouts/types.ts
@@ -1,0 +1,33 @@
+import type { TFunction } from "i18next"
+import type { NAV_ITEMS } from "@/shared/nav-config"
+
+export type NavItems = typeof NAV_ITEMS
+
+/** Alles, was ein Layout-Gerüst zum Rendern braucht. Vom LayoutHost gebaut,
+ *  an das aktive Layout-Gerüst durchgereicht — so bleibt jedes Gerüst schlank
+ *  und die Logik (Update-State, Nav-Filterung) lebt an EINER Stelle. */
+export interface LayoutChrome {
+  role: string | null
+  t: TFunction
+  pathname: string
+  /** Sichtbare Nav-Items (rollen-gefiltert). */
+  visible: NavItems
+  /** Schnellzugriff-Links für die Top-/Seitennavigation. */
+  quickLinks: NavItems
+  /** Aktuell aktive Seite (für Breadcrumb/Highlight). */
+  currentPage: NavItems[number] | undefined
+  /** Bento-App-Menü öffnen/schließen. */
+  onBentoToggle: () => void
+  /** Footer-Update-Infos. */
+  footer: {
+    version: string | null
+    commit: string | null
+    updateBehind: number | null
+    isAdmin: boolean
+    onUpdateClick: () => void
+  }
+}
+
+/** Ein Layout-Gerüst ist eine React-Komponente, die das Chrome bekommt und
+ *  <Outlet/> selbst rendert. */
+export type LayoutComponent = (props: { chrome: LayoutChrome }) => React.ReactNode

--- a/frontend/src/shared/look.ts
+++ b/frontend/src/shared/look.ts
@@ -1,0 +1,57 @@
+// Look-Presets — verändern die FORM der Oberfläche (Radius, Ränder, Glow,
+// Dichte), unabhängig von der Akzentfarbe (siehe theme.ts). Zusammen ergeben
+// Farbe × Look ein WordPress-artiges Theming: ein Umschalten baut die komplette
+// GUI-Optik um, nicht nur die Farbe.
+
+export type LookId = "neon" | "clean" | "compact" | "solid"
+
+export interface LookMeta {
+  id: LookId
+  name: string
+  description: string
+}
+
+export const LOOKS: LookMeta[] = [
+  {
+    id: "neon",
+    name: "Neon (Standard)",
+    description: "Glasige Panels, Glow-Ränder, runde Ecken — der Original-HydraHive-Look.",
+  },
+  {
+    id: "clean",
+    name: "Clean",
+    description: "Flache Flächen, dünne Ränder, kaum Glow. Ruhig und sachlich.",
+  },
+  {
+    id: "compact",
+    name: "Kompakt",
+    description: "Enge Abstände, kleinere Radien. Mehr Inhalt pro Bildschirm.",
+  },
+  {
+    id: "solid",
+    name: "Solid",
+    description: "Kräftige Flächen, klare Kanten, hoher Kontrast. Kein Glas.",
+  },
+]
+
+const STORAGE_KEY = "hh-look"
+
+export function getStoredLook(): LookId {
+  const v = (typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null) as LookId | null
+  if (v && LOOKS.some((l) => l.id === v)) return v
+  return "neon"
+}
+
+export function applyLook(id: LookId): void {
+  if (typeof document === "undefined") return
+  if (id === "neon") {
+    document.documentElement.removeAttribute("data-look")
+  } else {
+    document.documentElement.setAttribute("data-look", id)
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, id)
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/shared/themes/registry.ts
+++ b/frontend/src/shared/themes/registry.ts
@@ -1,0 +1,52 @@
+// Theme-Registry — mitgelieferte Themes. Ein Theme wählt ein Layout-Gerüst und
+// kann CSS-Variablen (--hh-*) überschreiben. Später kommen hier user-gebaute
+// Themes (Paket-Loader, Etappe 2) additiv dazu.
+import type { LayoutComponent } from "@/shared/layouts/types"
+import { TopnavLayout } from "@/shared/layouts/TopnavLayout"
+import { SidebarLayout } from "@/shared/layouts/SidebarLayout"
+
+export interface ThemeMeta {
+  id: string
+  name: string
+  description: string
+  /** Layout-Gerüst dieses Themes. */
+  layout: LayoutComponent
+  /** Optionale CSS-Variablen-Overrides (--hh-*). */
+  variables?: Record<string, string>
+}
+
+export const THEMES: ThemeMeta[] = [
+  {
+    id: "standard",
+    name: "Standard",
+    description: "Das Original — Menü oben, Waben-Glow, runde Panels.",
+    layout: TopnavLayout,
+  },
+  {
+    id: "sidebar",
+    name: "Sidebar (Test)",
+    description: "Menü links in einer Seitenleiste, Inhalt rechts. Testdesign.",
+    layout: SidebarLayout,
+  },
+]
+
+const STORAGE_KEY = "hh-active-theme"
+export const DEFAULT_THEME_ID = "standard"
+
+export function getStoredThemeId(): string {
+  const v = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null
+  if (v && THEMES.some((t) => t.id === v)) return v
+  return DEFAULT_THEME_ID
+}
+
+export function storeThemeId(id: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, id)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getTheme(id: string): ThemeMeta {
+  return THEMES.find((t) => t.id === id) ?? THEMES[0]
+}

--- a/frontend/src/shared/ui/Badge.tsx
+++ b/frontend/src/shared/ui/Badge.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react"
+import { cn } from "@/shared/cn"
+
+export type BadgeVariant = "accent" | "neutral" | "success" | "warning" | "danger"
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant
+  icon?: ReactNode
+}
+
+const variantClass: Record<BadgeVariant, string> = {
+  accent: "bg-[var(--hh-accent-soft)] text-[var(--hh-accent-text)] border-[var(--hh-accent-border)]",
+  neutral: "bg-white/[6%] text-zinc-300 border-white/[12%]",
+  success: "bg-emerald-500/12 text-emerald-300 border-emerald-500/30",
+  warning: "bg-amber-500/12 text-amber-300 border-amber-500/30",
+  danger: "bg-red-500/12 text-red-300 border-red-500/30",
+}
+
+export function Badge({ variant = "neutral", icon, className, style, children, ...rest }: BadgeProps) {
+  return (
+    <span
+      {...rest}
+      style={{ borderRadius: "calc(var(--hh-ctl-r) * 1.6)", ...style } as CSSProperties}
+      className={cn(
+        "inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium border leading-none",
+        variantClass[variant],
+        className,
+      )}
+    >
+      {icon && <span className="[&>svg]:block">{icon}</span>}
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/shared/ui/Button.tsx
+++ b/frontend/src/shared/ui/Button.tsx
@@ -1,0 +1,73 @@
+import type { ButtonHTMLAttributes, CSSProperties, ReactNode } from "react"
+import { cn } from "@/shared/cn"
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger" | "outline"
+export type ButtonSize = "sm" | "md" | "lg"
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  /** Icon links vom Label (lucide o.ä.). */
+  icon?: ReactNode
+  /** Voll-Breite. */
+  block?: boolean
+}
+
+// Größen nutzen die Look-Control-Variablen als Basis (Dichte skaliert mit
+// dem Look-Preset). sm/lg weichen relativ davon ab.
+const sizeStyle: Record<ButtonSize, CSSProperties> = {
+  sm: { paddingBlock: "calc(var(--hh-ctl-py) * 0.7)", paddingInline: "calc(var(--hh-ctl-px) * 0.75)" },
+  md: { paddingBlock: "var(--hh-ctl-py)", paddingInline: "var(--hh-ctl-px)" },
+  lg: { paddingBlock: "calc(var(--hh-ctl-py) * 1.3)", paddingInline: "calc(var(--hh-ctl-px) * 1.3)" },
+}
+
+const sizeText: Record<ButtonSize, string> = {
+  sm: "text-xs",
+  md: "text-sm",
+  lg: "text-base",
+}
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary:
+    "bg-gradient-to-r from-[var(--hh-accent-from)] to-[var(--hh-accent-to)] text-white font-medium " +
+    "shadow-lg shadow-black/30 hover:brightness-110",
+  secondary:
+    "bg-white/[6%] text-zinc-200 border border-white/[10%] hover:bg-white/[10%] hover:border-white/20",
+  ghost:
+    "text-zinc-400 hover:text-zinc-100 hover:bg-white/5",
+  outline:
+    "bg-transparent text-[var(--hh-accent-text)] border border-[var(--hh-accent-border)] " +
+    "hover:bg-[var(--hh-accent-soft)]",
+  danger:
+    "bg-gradient-to-r from-red-600 to-rose-600 text-white font-medium shadow-lg shadow-black/30 hover:brightness-110",
+}
+
+export function Button({
+  variant = "primary",
+  size = "md",
+  icon,
+  block = false,
+  className,
+  style,
+  children,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      {...rest}
+      style={{ borderRadius: "var(--hh-ctl-r)", ...sizeStyle[size], ...style }}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 font-medium leading-none",
+        "transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--hh-accent-border)]",
+        "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:brightness-100",
+        sizeText[size],
+        variantClass[variant],
+        block && "w-full",
+        className,
+      )}
+    >
+      {icon && <span className="shrink-0 [&>svg]:block">{icon}</span>}
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/shared/ui/Card.tsx
+++ b/frontend/src/shared/ui/Card.tsx
@@ -1,0 +1,41 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react"
+import { cn } from "@/shared/cn"
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  /** Domain-Farbe der Box als "r g b" (siehe shared/colors rgbFor). */
+  color?: string
+  /** Kein Hover-Lift (für interaktive Inhalte wie Terminals). */
+  static?: boolean
+  /** Innen-Padding aus. */
+  flush?: boolean
+  children?: ReactNode
+}
+
+export function Card({ color, static: isStatic, flush, className, style, children, ...rest }: CardProps) {
+  const cssVars = color ? ({ "--c": color } as CSSProperties) : undefined
+  return (
+    <div
+      {...rest}
+      style={{ ...cssVars, ...style }}
+      className={cn("box", isStatic && "box-static", !flush && "p-5", className)}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface CardHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+  icon?: ReactNode
+  title: ReactNode
+  right?: ReactNode
+}
+
+export function CardHeader({ icon, title, right, className, ...rest }: CardHeaderProps) {
+  return (
+    <div {...rest} className={cn("flex items-center gap-2 mb-3", className)}>
+      {icon && <span className="text-[var(--hh-accent-text)] [&>svg]:block">{icon}</span>}
+      <h3 className="text-sm font-semibold text-zinc-100">{title}</h3>
+      {right && <div className="ml-auto">{right}</div>}
+    </div>
+  )
+}

--- a/frontend/src/shared/ui/Input.tsx
+++ b/frontend/src/shared/ui/Input.tsx
@@ -1,0 +1,49 @@
+import type { CSSProperties, InputHTMLAttributes, ReactNode } from "react"
+import { forwardRef } from "react"
+import { cn } from "@/shared/cn"
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Icon links im Feld. */
+  icon?: ReactNode
+  /** Fehlerzustand (roter Rand). */
+  invalid?: boolean
+}
+
+const ctlStyle: CSSProperties = {
+  borderRadius: "var(--hh-ctl-r)",
+  paddingBlock: "var(--hh-ctl-py)",
+  paddingInline: "var(--hh-ctl-px)",
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { icon, invalid, className, style, ...rest },
+  ref,
+) {
+  const field = (
+    <input
+      ref={ref}
+      {...rest}
+      style={{ ...ctlStyle, ...(icon ? { paddingInlineStart: "2.25rem" } : null), ...style }}
+      className={cn(
+        "w-full bg-zinc-900/70 text-sm text-zinc-100 placeholder:text-zinc-600",
+        "border transition-colors focus:outline-none focus-visible:ring-2",
+        invalid
+          ? "border-red-500/60 focus-visible:ring-red-500/40"
+          : "border-white/[10%] focus:border-[var(--hh-accent-border)] focus-visible:ring-[var(--hh-accent-border)]",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+    />
+  )
+
+  if (!icon) return field
+
+  return (
+    <div className="relative w-full">
+      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500 [&>svg]:block pointer-events-none">
+        {icon}
+      </span>
+      {field}
+    </div>
+  )
+})

--- a/frontend/src/shared/ui/Select.tsx
+++ b/frontend/src/shared/ui/Select.tsx
@@ -1,0 +1,41 @@
+import type { CSSProperties, SelectHTMLAttributes } from "react"
+import { forwardRef } from "react"
+import { ChevronDown } from "lucide-react"
+import { cn } from "@/shared/cn"
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>
+
+const ctlStyle: CSSProperties = {
+  borderRadius: "var(--hh-ctl-r)",
+  paddingBlock: "var(--hh-ctl-py)",
+  paddingInline: "var(--hh-ctl-px)",
+  paddingInlineEnd: "2.25rem",
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { className, style, children, ...rest },
+  ref,
+) {
+  return (
+    <div className="relative w-full">
+      <select
+        ref={ref}
+        {...rest}
+        style={{ ...ctlStyle, ...style }}
+        className={cn(
+          "w-full appearance-none bg-zinc-900/70 text-sm text-zinc-100",
+          "border border-white/[10%] transition-colors focus:outline-none",
+          "focus:border-[var(--hh-accent-border)] focus-visible:ring-2 focus-visible:ring-[var(--hh-accent-border)]",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          className,
+        )}
+      >
+        {children}
+      </select>
+      <ChevronDown
+        size={15}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 pointer-events-none"
+      />
+    </div>
+  )
+})

--- a/frontend/src/shared/ui/Textarea.tsx
+++ b/frontend/src/shared/ui/Textarea.tsx
@@ -1,0 +1,35 @@
+import type { CSSProperties, TextareaHTMLAttributes } from "react"
+import { forwardRef } from "react"
+import { cn } from "@/shared/cn"
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  invalid?: boolean
+}
+
+const ctlStyle: CSSProperties = {
+  borderRadius: "var(--hh-ctl-r)",
+  paddingBlock: "var(--hh-ctl-py)",
+  paddingInline: "var(--hh-ctl-px)",
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { invalid, className, style, ...rest },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      {...rest}
+      style={{ ...ctlStyle, ...style }}
+      className={cn(
+        "w-full bg-zinc-900/70 text-sm text-zinc-100 placeholder:text-zinc-600 resize-y",
+        "border transition-colors focus:outline-none focus-visible:ring-2",
+        invalid
+          ? "border-red-500/60 focus-visible:ring-red-500/40"
+          : "border-white/[10%] focus:border-[var(--hh-accent-border)] focus-visible:ring-[var(--hh-accent-border)]",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+    />
+  )
+})

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -1,0 +1,9 @@
+// HydraHive UI-Kit — konsistente, theme- & look-fähige Basis-Komponenten.
+// Alle Komponenten ziehen Farbe aus --hh-accent-* und Form aus den Look-
+// Variablen (--hh-ctl-r/py/px), reagieren also automatisch auf Farbe × Look.
+export { Button, type ButtonVariant, type ButtonSize } from "./Button"
+export { Input } from "./Input"
+export { Textarea } from "./Textarea"
+export { Select } from "./Select"
+export { Card, CardHeader } from "./Card"
+export { Badge, type BadgeVariant } from "./Badge"


### PR DESCRIPTION
## Was

WordPress-artiges Theme-System — **Fundament (Etappe 1)**. Ein Theme wechselt
das komplette Layout (Menü oben ↔ links), nicht nur Farben.

### Enthaltene Commits
- `875fd32f` UI-Kit v1: `shared/ui/` (Button/Input/Textarea/Select/Card/Badge) + Look-Presets (Farbe × Stil), Vorschau-Route `/ui-kit`
- `ab01fd21` Theme-System Etappe 1: Layout zerlegt

### Theme-System
- `Layout.tsx` → **LayoutHost**: sammelt Chrome (Nav, Update-State), wählt aktives Theme-Gerüst, injiziert CSS-Vars, hält Overlays (Bento, UpdateModal)
- `layouts/TopnavLayout`: **Standard-Theme** — aktuelles Design 1:1 (Menü oben)
- `layouts/SidebarLayout`: **Test-Theme** — Menü links (`<aside>`), beweist echten Layoutwechsel
- `layouts/types`: `LayoutChrome`-Vertrag Host ↔ Gerüst
- `themes/registry`: 2 mitgelieferte Themes, localStorage (`hh-active-theme`), Live-Wechsel via `hh-theme-change`-Event
- `features/profile/ThemePicker`: Design-Auswahl im Profil

## Warum sicher
Standard-Theme pixelgleich zum bisherigen Design — additiv, kein Regressionsrisiko. Die 382 Seiten wurden nicht angefasst, nur in ein anderes Gerüst gehängt.

## Getestet
- `tsc` strict + `npm run build` grün
- Layoutwechsel im Browser verifiziert (Standard = Menü oben, Sidebar = `<aside>` links, per Vision-Check bestätigt)

## Spec
`docs/specs/theming-system.md` (3 Etappen). Etappe 2/3 (user-baubare Themes, Hub-Installer) folgen nach Feedback.