### PR TITLE
Theme-System Etappe 3: Hub-Installer für Themes (wie Module)

### DIFF
--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -65,6 +65,7 @@ from hydrahive.api.routes.streaming import router as streaming_router
 from hydrahive.api.routes.teamchat import router as teamchat_router
 from hydrahive.api.routes.prompt_archive import router as prompt_archive_router
 from hydrahive.api.routes.modules import router as modules_admin_router
+from hydrahive.api.routes.themes import router as themes_admin_router
 from hydrahive.api.routes.vms import router as vms_router
 from hydrahive.api.version import current_status
 from hydrahive import modules as _modules
@@ -158,6 +159,7 @@ app.include_router(streaming_router)
 app.include_router(teamchat_router)
 app.include_router(prompt_archive_router)
 app.include_router(modules_admin_router)
+app.include_router(themes_admin_router)
 
 
 def mount_module_routers(target_app: FastAPI) -> None:

--- a/core/src/hydrahive/api/routes/themes.py
+++ b/core/src/hydrahive/api/routes/themes.py
@@ -1,0 +1,66 @@
+"""Admin-API für das Theme-System: Liste, Install, Update, Uninstall.
+
+Spiegelt api/routes/modules.py — Themes sind über den Hub installierbar wie
+Module, nur reines Frontend (kein Backend-Service/DB).
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+
+from hydrahive.api.middleware.auth import require_admin
+from hydrahive.themes import hub_client, installer, registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/themes", tags=["themes"])
+
+_SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+
+
+@router.get("", dependencies=[Depends(require_admin)])
+def list_themes() -> dict:
+    installed = registry.list_installed()
+    # Hub vor dem Listen pullen, damit "available" den echten Hub spiegelt.
+    # Netzwerk-/Hub-Fehler sind unkritisch → Fallback auf den Cache.
+    try:
+        hub_client.refresh()
+    except Exception as exc:
+        logger.warning("Theme-Hub-Refresh fehlgeschlagen, nutze Cache: %s", exc)
+    try:
+        available = hub_client.read_hub_index().get("themes", [])
+    except Exception as exc:
+        logger.warning("Theme-Hub-Index nicht abrufbar: %s", exc)
+        available = []
+    return {"installed": installed, "available": available}
+
+
+def _stream(gen) -> StreamingResponse:
+    def _events():
+        try:
+            for line in gen:
+                yield f"data: {json.dumps({'line': line})}\n\n"
+            yield "data: {\"done\": true}\n\n"
+        except Exception as exc:
+            logger.exception("Theme-Operation fehlgeschlagen")
+            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+
+    return StreamingResponse(_events(), media_type="text/event-stream", headers=_SSE_HEADERS)
+
+
+@router.post("/{theme_id}/install", dependencies=[Depends(require_admin)])
+def install_theme(theme_id: str) -> StreamingResponse:
+    return _stream(installer.install(theme_id))
+
+
+@router.post("/{theme_id}/update", dependencies=[Depends(require_admin)])
+def update_theme(theme_id: str) -> StreamingResponse:
+    return _stream(installer.update(theme_id))
+
+
+@router.delete("/{theme_id}", dependencies=[Depends(require_admin)])
+def uninstall_theme(theme_id: str) -> StreamingResponse:
+    return _stream(installer.uninstall(theme_id))

--- a/core/src/hydrahive/settings/_paths.py
+++ b/core/src/hydrahive/settings/_paths.py
@@ -82,6 +82,45 @@ class _PathsMixin:
         return out
 
     @cached_property
+    def themes_frontend_dir(self) -> Path:
+        """Kopierziel installierter Themes (Frontend-Paket-Ordner im Repo).
+
+        Ein Theme ist reines Frontend — anders als Module gibt es kein eigenes
+        data_dir-Ziel. Der Ordner wird beim Build von scripts/gen-themes.mjs
+        gescannt.
+        """
+        return self.base_dir / "frontend" / "src" / "themes"
+
+    @cached_property
+    def theme_hub_cache(self) -> Path:
+        return self.data_dir / ".theme-cache" / "hub"
+
+    @cached_property
+    def theme_hub_git_url(self) -> str:
+        return os.environ.get(
+            "HH_THEME_HUB_GIT_URL",
+            "https://github.com/hydrahive/hydrahive2-themes.git",
+        )
+
+    @cached_property
+    def theme_hub_extra_git_urls(self) -> list[str]:
+        """Zusätzliche Theme-Hub-Quellen (komma-separiert, GUI / HH_THEME_HUB_GIT_URLS).
+
+        Multi-Hub analog zum Modulsystem: Override (GUI) → Env → Default.
+        Dedupliziert, primäre URL nie doppelt.
+        """
+        from hydrahive.settings import overrides
+
+        primary = self.theme_hub_git_url
+        raw = overrides.env_or_override("theme_hub_extra_git_urls", "HH_THEME_HUB_GIT_URLS", "")
+        out: list[str] = []
+        for u in raw.split(","):
+            u = u.strip()
+            if u and u != primary and u not in out:
+                out.append(u)
+        return out
+
+    @cached_property
     def tmp_dir(self) -> Path:
         return Path(os.environ.get("HH_TMP_DIR", tempfile.gettempdir()))
 

--- a/core/src/hydrahive/themes/__init__.py
+++ b/core/src/hydrahive/themes/__init__.py
@@ -1,0 +1,3 @@
+from hydrahive.themes.registry import PROTECTED_THEME_IDS, is_protected, list_installed
+
+__all__ = ["list_installed", "is_protected", "PROTECTED_THEME_IDS"]

--- a/core/src/hydrahive/themes/hub_client.py
+++ b/core/src/hydrahive/themes/hub_client.py
@@ -1,0 +1,141 @@
+"""Theme-Hub-Client — spiegelt EIN oder MEHRERE Hub-Repos als lokalen Cache.
+
+Direkte Spiegelung des Modul-Hub-Clients (hydrahive.modules.hub_client), nur auf
+Themes gemünzt: primärer Hub `settings.theme_hub_git_url` (GitHub), zusätzliche
+Hubs via `theme_hub_extra_git_urls` klonen in Geschwister-Ordner `…/hub-<slug>`.
+`read_hub_index()` merged die `hub.json`-Indizes (erste id gewinnt, jeder Eintrag
+mit `_hub` getaggt); `theme_source_path()` löst pro Hub auf. Per-Hub-Fehler beim
+Refresh sind isoliert.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from hydrahive.settings import settings
+
+logger = logging.getLogger(__name__)
+
+_GIT_TIMEOUT = 60
+
+
+class HubError(RuntimeError):
+    """Hub-Repo nicht erreichbar oder kaputt."""
+
+
+def _slug(url: str) -> str:
+    s = re.sub(r"^[a-z]+://", "", url.lower())
+    s = re.sub(r"\.git$", "", s)
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:60] or "hub"
+
+
+def _hubs() -> list[tuple[str | None, str, Path]]:
+    """(name, git_url, cache_dir). name=None → primärer Hub (Default-GitHub)."""
+    primary_cache = settings.theme_hub_cache
+    hubs: list[tuple[str | None, str, Path]] = [
+        (None, settings.theme_hub_git_url, primary_cache)
+    ]
+    for url in settings.theme_hub_extra_git_urls:
+        hubs.append((_slug(url), url, primary_cache.parent / f"hub-{_slug(url)}"))
+    return hubs
+
+
+def _run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True, text=True,
+        timeout=_GIT_TIMEOUT, check=False,
+    )
+
+
+def _refresh_one(cache: Path, url: str) -> None:
+    """Einen Hub klonen/pullen. Idempotent."""
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    if (cache / ".git").exists():
+        result = _run_git(["pull", "--ff-only"], cwd=cache)
+        if result.returncode != 0:
+            # ff-only scheitert bei divergierter Hub-History. Der Cache ist eine
+            # reine Spiegelung ohne lokale Commits — hart auf Remote re-syncen.
+            _resync_hard(cache, result.stderr.strip())
+        return
+    if cache.exists():
+        shutil.rmtree(cache)
+    result = _run_git(["clone", "--depth=1", "--filter=blob:none", url, str(cache)])
+    if result.returncode != 0:
+        raise HubError(f"git clone failed: {result.stderr.strip()}")
+
+
+def _resync_hard(cache: Path, pull_error: str) -> None:
+    """Hub-Cache hart auf Remote zwingen (Fallback bei divergierter History).
+    Sicher, weil der Cache nur gespiegelt wird — keine lokale Arbeit.
+    """
+    logger.warning("Theme-Hub pull --ff-only fehlgeschlagen, re-sync hart: %s", pull_error)
+    fetched = _run_git(["fetch", "origin"], cwd=cache)
+    if fetched.returncode != 0:
+        raise HubError(f"git fetch failed: {fetched.stderr.strip()}")
+    head = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cache).stdout.strip() or "main"
+    reset = _run_git(["reset", "--hard", f"origin/{head}"], cwd=cache)
+    if reset.returncode != 0:
+        raise HubError(f"git reset failed: {reset.stderr.strip()}")
+
+
+def refresh() -> None:
+    """Alle Hubs best-effort aktualisieren — Per-Hub-Fehler isoliert (geloggt)."""
+    for name, url, cache in _hubs():
+        try:
+            _refresh_one(cache, url)
+        except HubError as e:
+            logger.warning("Theme-Hub-Refresh fehlgeschlagen (%s): %s", name or "default", e)
+
+
+def _read_one(cache: Path) -> dict:
+    f = cache / "hub.json"
+    if not f.exists():
+        return {"themes": []}
+    try:
+        return json.loads(f.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise HubError(f"hub.json nicht lesbar: {e}") from e
+
+
+def read_hub_index() -> dict:
+    """Gemergter `hub.json`-Index über alle Hubs. Erste id gewinnt; `_hub`-Tag
+    nennt die Quelle (None = primär). Refresh nur wenn noch GAR kein Cache da ist.
+    """
+    hubs = _hubs()
+    if not any((cache / "hub.json").exists() for _, _, cache in hubs):
+        refresh()
+    themes: list[dict] = []
+    seen: set[str] = set()
+    for name, _url, cache in hubs:
+        for th in _read_one(cache).get("themes", []):
+            tid = th.get("id")
+            if not tid or tid in seen:
+                continue
+            seen.add(tid)
+            themes.append({**th, "_hub": name})
+    return {"themes": themes}
+
+
+def _cache_for_hub(hub_name: str | None) -> Path:
+    for name, _url, cache in _hubs():
+        if name == hub_name:
+            return cache
+    raise HubError(f"unbekannter hub: {hub_name!r}")
+
+
+def theme_source_path(theme_path: str, hub_name: str | None = None) -> Path:
+    """Absoluter Pfad eines Theme-Source-Verzeichnisses im (passenden) Hub-Cache."""
+    cache_root = _cache_for_hub(hub_name).resolve()
+    full = (cache_root / theme_path).resolve()
+    try:
+        full.relative_to(cache_root)  # echte Verzeichnis-Grenze, kein String-Prefix
+    except ValueError as e:
+        raise HubError(f"ungültiger theme-path: {theme_path}") from e
+    return full

--- a/core/src/hydrahive/themes/installer.py
+++ b/core/src/hydrahive/themes/installer.py
@@ -1,0 +1,116 @@
+"""Theme-Installer: Dateioperationen + Orchestrierung.
+
+Schlanker als der Modul-Installer, weil ein Theme reines Frontend ist:
+EIN Kopierziel (settings.themes_frontend_dir/<id>), kein Service, keine DB.
+
+copy_theme_in(id)     — kopiert ein Theme aus dem Hub-Cache ins Frontend-Paket.
+remove_theme_files(id)— entfernt den Ordner (geschützte Themes nie).
+install(id)           — Generator: kopieren → Build → Restart-Request.
+uninstall(id)         — Generator: entfernen → Build → Restart-Request.
+update(id)            — Generator: entfernen → kopieren → Build → Restart.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+from hydrahive.settings import settings
+from hydrahive.themes import hub_client
+from hydrahive.themes.hub_client import refresh
+from hydrahive.themes.registry import is_protected
+
+logger = logging.getLogger(__name__)
+
+
+class InstallError(RuntimeError):
+    """Wird geworfen wenn ein Theme nicht installiert werden kann."""
+
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")  # muss zu manifest._ID_RE passen
+
+
+def _validate_theme_id(theme_id: str) -> None:
+    if not _ID_RE.match(theme_id):
+        raise InstallError(f"ungültige theme_id: {theme_id!r}")
+
+
+def _cache_path_for(theme_id: str) -> Path:
+    """Theme-Source im (passenden) Hub-Cache anhand des gemergten hub.json finden."""
+    index = hub_client.read_hub_index()
+    for entry in index.get("themes", []):
+        if entry.get("id") == theme_id:
+            path = entry.get("path") or theme_id
+            return hub_client.theme_source_path(path, entry.get("_hub"))
+    raise InstallError(f"theme_not_in_hub:{theme_id}")
+
+
+def copy_theme_in(theme_id: str) -> None:
+    """Kopiert ein Theme aus dem Hub-Cache in den Frontend-Paket-Ordner.
+
+    symlinks=False ist bewusst: keine Symlinks als Escape-Vektor.
+    """
+    _validate_theme_id(theme_id)
+    refresh()
+    src = _cache_path_for(theme_id)
+
+    dst = settings.themes_frontend_dir / theme_id
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, symlinks=False)
+    logger.info("Theme '%s' nach %s kopiert", theme_id, dst)
+
+
+def remove_theme_files(theme_id: str) -> None:
+    """Entfernt das Theme-Paket-Verzeichnis. Geschützte Themes sind tabu."""
+    _validate_theme_id(theme_id)
+    if is_protected(theme_id):
+        raise InstallError(f"theme_protected:{theme_id}")
+    d = settings.themes_frontend_dir / theme_id
+    if d.exists():
+        shutil.rmtree(d)
+        logger.info("Theme-Verzeichnis entfernt: %s", d)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrierung
+# ---------------------------------------------------------------------------
+
+def _frontend_build() -> None:
+    fe = settings.base_dir / "frontend"
+    subprocess.run(["npm", "run", "build"], cwd=fe, check=True)
+
+
+def _request_restart() -> None:
+    (settings.data_dir / ".restart_request").write_text("theme-change")
+
+
+def install(theme_id: str) -> Iterator[str]:
+    _validate_theme_id(theme_id)
+    yield f"[themes] installiere {theme_id} …"
+    copy_theme_in(theme_id); yield "[themes] Dateien kopiert"
+    _frontend_build(); yield "[themes] Frontend gebaut"
+    _request_restart(); yield "[themes] Neustart angefordert — fertig"
+
+
+def uninstall(theme_id: str) -> Iterator[str]:
+    _validate_theme_id(theme_id)
+    if is_protected(theme_id):
+        raise InstallError(f"theme_protected:{theme_id}")
+    yield f"[themes] deinstalliere {theme_id} …"
+    remove_theme_files(theme_id); yield "[themes] Dateien entfernt"
+    _frontend_build(); yield "[themes] Frontend gebaut"
+    _request_restart(); yield "[themes] Neustart angefordert — fertig"
+
+
+def update(theme_id: str) -> Iterator[str]:
+    """Hub pullen + Dateien ersetzen + einmal bauen."""
+    _validate_theme_id(theme_id)
+    yield f"[themes] update {theme_id} …"
+    copy_theme_in(theme_id); yield "[themes] neue Dateien kopiert"
+    _frontend_build(); yield "[themes] Frontend gebaut"
+    _request_restart(); yield "[themes] Neustart angefordert — fertig"

--- a/core/src/hydrahive/themes/manifest.py
+++ b/core/src/hydrahive/themes/manifest.py
@@ -1,0 +1,53 @@
+"""ThemeManifest — liest und validiert theme.json eines Theme-Pakets.
+
+Ein Theme ist reines Frontend: Layout-Wahl + CSS-Variablen. Kein Service,
+keine DB, keine Agent-Tools (anders als ein Modul-Manifest).
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+class ManifestError(Exception): ...
+
+
+@dataclass(frozen=True)
+class ThemeManifest:
+    id: str
+    name: str
+    version: str
+    description: str = ""
+    author: str = ""
+    layout: str = "topnav"
+    variables: dict[str, str] = field(default_factory=dict)
+    min_core_version: str = "2.0.0"
+
+    @classmethod
+    def load(cls, path: Path) -> "ThemeManifest":
+        try:
+            d = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            raise ManifestError(f"theme.json nicht lesbar: {e}") from e
+        for key in ("id", "name", "version"):
+            if not d.get(key):
+                raise ManifestError(f"theme.json: Pflichtfeld '{key}' fehlt")
+        if not _ID_RE.match(d["id"]):
+            raise ManifestError(f"theme.json: ungültige id {d['id']!r} (nur a-z0-9-)")
+        variables = d.get("variables", {})
+        if not isinstance(variables, dict):
+            raise ManifestError("theme.json: 'variables' muss ein Objekt sein")
+        return cls(
+            id=d["id"],
+            name=d["name"],
+            version=str(d["version"]),
+            description=d.get("description", ""),
+            author=d.get("author", ""),
+            layout=d.get("layout", "topnav"),
+            variables={str(k): str(v) for k, v in variables.items()},
+            min_core_version=d.get("min_core_version", "2.0.0"),
+        )

--- a/core/src/hydrahive/themes/registry.py
+++ b/core/src/hydrahive/themes/registry.py
@@ -1,0 +1,53 @@
+"""Registry installierter Themes — Scan des Frontend-Theme-Ordners.
+
+Anders als das Modulsystem (das Python-Backend lädt) sind Themes reines
+Frontend. „Installiert" heißt: Ordner mit theme.json existiert unter
+settings.themes_frontend_dir. Die eingebauten Themes (standard/sidebar) sowie
+das mitgelieferte aurora sind geschützt und nicht deinstallierbar.
+"""
+from __future__ import annotations
+
+import logging
+
+from hydrahive.settings import settings
+from hydrahive.themes.manifest import ManifestError, ThemeManifest
+
+logger = logging.getLogger(__name__)
+
+# Nicht deinstallierbar: eingebaute Layout-Themes (im Frontend-Code) + das
+# mitgelieferte Beispiel-Theme (lebende Vorlage, im Repo getrackt).
+PROTECTED_THEME_IDS = frozenset({"standard", "sidebar", "aurora"})
+
+
+def list_installed() -> list[dict]:
+    """Alle installierten Theme-Pakete (Ordner mit theme.json) als dicts.
+
+    Eingebaute Themes (standard/sidebar) leben im Frontend-Code ohne eigenes
+    Paket-Verzeichnis und tauchen hier nicht auf — sie sind immer verfügbar.
+    """
+    root = settings.themes_frontend_dir
+    if not root.exists():
+        return []
+    out: list[dict] = []
+    for entry in sorted(root.iterdir()):
+        manifest_path = entry / "theme.json"
+        if not entry.is_dir() or not manifest_path.exists():
+            continue
+        try:
+            m = ThemeManifest.load(manifest_path)
+        except ManifestError as e:
+            out.append({"id": entry.name, "loaded": False, "error": str(e), "version": None})
+            continue
+        out.append({
+            "id": m.id,
+            "name": m.name,
+            "loaded": True,
+            "error": None,
+            "version": m.version,
+            "protected": m.id in PROTECTED_THEME_IDS,
+        })
+    return out
+
+
+def is_protected(theme_id: str) -> bool:
+    return theme_id in PROTECTED_THEME_IDS

--- a/core/tests/test_theme_hub.py
+++ b/core/tests/test_theme_hub.py
@@ -1,0 +1,130 @@
+"""Tests für hydrahive.themes.hub_client."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def theme_hub_env(tmp_path, monkeypatch):
+    from hydrahive.settings import settings
+    monkeypatch.setattr(settings, "data_dir", tmp_path / "data", raising=False)
+    monkeypatch.setattr(settings, "theme_hub_cache", tmp_path / "hub", raising=False)
+    monkeypatch.setitem(settings.__dict__, "theme_hub_extra_git_urls", [])
+    (tmp_path / "data").mkdir()
+    return tmp_path
+
+
+def test_read_hub_index(theme_hub_env):
+    from hydrahive.settings import settings
+    cache = settings.theme_hub_cache
+    cache.mkdir(parents=True)
+    (cache / "hub.json").write_text('{"themes":[{"id":"aurora","path":"aurora"}]}')
+    with patch("hydrahive.themes.hub_client.refresh"):
+        from hydrahive.themes.hub_client import read_hub_index
+        idx = read_hub_index()
+    assert idx["themes"][0]["id"] == "aurora"
+
+
+def test_read_hub_index_triggers_refresh_when_missing(theme_hub_env):
+    from hydrahive.settings import settings
+    cache = settings.theme_hub_cache
+    cache.mkdir(parents=True)
+
+    def fake_refresh():
+        (cache / "hub.json").write_text('{"themes":[]}')
+
+    with patch("hydrahive.themes.hub_client.refresh", side_effect=fake_refresh):
+        from hydrahive.themes import hub_client
+        idx = hub_client.read_hub_index()
+    assert idx == {"themes": []}
+
+
+def test_theme_source_path_valid(theme_hub_env):
+    from hydrahive.settings import settings
+    cache = settings.theme_hub_cache
+    cache.mkdir(parents=True)
+    (cache / "aurora").mkdir()
+    from hydrahive.themes.hub_client import theme_source_path
+    assert theme_source_path("aurora") == (cache / "aurora").resolve()
+
+
+def test_theme_source_path_blocks_traversal(theme_hub_env):
+    from hydrahive.settings import settings
+    settings.theme_hub_cache.mkdir(parents=True, exist_ok=True)
+    from hydrahive.themes.hub_client import theme_source_path, HubError
+    with pytest.raises(HubError, match="ungültiger theme-path"):
+        theme_source_path("../../etc/passwd")
+
+
+def test_theme_source_path_blocks_sibling_prefix(theme_hub_env):
+    from hydrahive.settings import settings
+    settings.theme_hub_cache.mkdir(parents=True, exist_ok=True)
+    from hydrahive.themes.hub_client import theme_source_path, HubError
+    with pytest.raises(HubError):
+        theme_source_path(f"../{settings.theme_hub_cache.name}-evil/x")
+
+
+def test_hub_error_on_bad_json(theme_hub_env):
+    from hydrahive.settings import settings
+    cache = settings.theme_hub_cache
+    cache.mkdir(parents=True)
+    (cache / "hub.json").write_text("not-valid-json{{{")
+    with patch("hydrahive.themes.hub_client.refresh"):
+        from hydrahive.themes import hub_client
+        with pytest.raises(hub_client.HubError, match="hub.json nicht lesbar"):
+            hub_client.read_hub_index()
+
+
+# --- Multi-Hub --------------------------------------------------------------
+
+def test_theme_hub_extra_git_urls_parsed(monkeypatch):
+    from hydrahive.settings import settings
+    monkeypatch.setenv("HH_THEME_HUB_GIT_URLS", "http://g/a.git, http://g/a.git ,http://g/b.git")
+    settings.__dict__.pop("theme_hub_extra_git_urls", None)
+    try:
+        assert settings.theme_hub_extra_git_urls == ["http://g/a.git", "http://g/b.git"]
+    finally:
+        settings.__dict__.pop("theme_hub_extra_git_urls", None)
+
+
+def _seed_two_hubs(s, monkeypatch, primary_json: str, extra_json: str):
+    from hydrahive.themes import hub_client
+    primary = s.theme_hub_cache
+    primary.mkdir(parents=True, exist_ok=True)
+    (primary / "hub.json").write_text(primary_json)
+    extra_url = "http://gitea.local/hydrahive/themes-internal.git"
+    slug = hub_client._slug(extra_url)
+    extra = primary.parent / f"hub-{slug}"
+    extra.mkdir(parents=True, exist_ok=True)
+    (extra / "hub.json").write_text(extra_json)
+    monkeypatch.setitem(s.__dict__, "theme_hub_extra_git_urls", [extra_url])
+    return slug, extra
+
+
+def test_read_hub_index_merges_two_hubs(theme_hub_env, monkeypatch):
+    from hydrahive.settings import settings
+    from hydrahive.themes import hub_client
+    slug, _ = _seed_two_hubs(
+        settings, monkeypatch,
+        '{"themes":[{"id":"aurora","path":"aurora"}]}',
+        '{"themes":[{"id":"midnight","path":"midnight"}]}',
+    )
+    by = {t["id"]: t for t in hub_client.read_hub_index()["themes"]}
+    assert set(by) == {"aurora", "midnight"}
+    assert by["aurora"]["_hub"] is None
+    assert by["midnight"]["_hub"] == slug
+
+
+def test_read_hub_index_dedupes_primary_wins(theme_hub_env, monkeypatch):
+    from hydrahive.settings import settings
+    from hydrahive.themes import hub_client
+    _seed_two_hubs(
+        settings, monkeypatch,
+        '{"themes":[{"id":"dup","path":"primary-path"}]}',
+        '{"themes":[{"id":"dup","path":"gitea-path"}]}',
+    )
+    dup = [t for t in hub_client.read_hub_index()["themes"] if t["id"] == "dup"]
+    assert len(dup) == 1
+    assert dup[0]["path"] == "primary-path" and dup[0]["_hub"] is None

--- a/core/tests/test_theme_installer.py
+++ b/core/tests/test_theme_installer.py
@@ -1,0 +1,141 @@
+"""Tests für den Theme-Installer + Manifest + Registry.
+
+Themes sind reines Frontend: EIN Kopierziel (themes_frontend_dir/<id>),
+kein Service, keine DB. Geschützte Themes (standard/sidebar/aurora) sind
+nicht deinstallierbar.
+"""
+import pytest
+
+
+@pytest.fixture
+def theme_env(tmp_path, monkeypatch):
+    """Isolierte Theme-Umgebung — repointet Frontend-Ziel + Hub-Cache in tmp."""
+    from hydrahive.settings import settings
+    monkeypatch.setattr(settings, "data_dir", tmp_path / "data", raising=False)
+    monkeypatch.setattr(settings, "base_dir", tmp_path / "repo", raising=False)
+    monkeypatch.setattr(
+        settings, "themes_frontend_dir", tmp_path / "repo" / "frontend" / "src" / "themes",
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "theme_hub_cache", tmp_path / "hub", raising=False)
+    (tmp_path / "data").mkdir()
+    settings.themes_frontend_dir.mkdir(parents=True)
+    return tmp_path
+
+
+# --- Manifest ---------------------------------------------------------------
+
+def test_manifest_load_ok(tmp_path):
+    from hydrahive.themes.manifest import ThemeManifest
+    p = tmp_path / "theme.json"
+    p.write_text(
+        '{"id":"aurora","name":"Aurora","version":"1.0.0",'
+        '"layout":"sidebar","variables":{"--hh-r":"0.7rem"}}'
+    )
+    m = ThemeManifest.load(p)
+    assert m.id == "aurora" and m.layout == "sidebar"
+    assert m.variables == {"--hh-r": "0.7rem"}
+
+
+def test_manifest_rejects_bad_id(tmp_path):
+    from hydrahive.themes.manifest import ThemeManifest, ManifestError
+    p = tmp_path / "theme.json"
+    p.write_text('{"id":"../evil","name":"X","version":"1.0.0"}')
+    with pytest.raises(ManifestError):
+        ThemeManifest.load(p)
+
+
+def test_manifest_missing_field(tmp_path):
+    from hydrahive.themes.manifest import ThemeManifest, ManifestError
+    p = tmp_path / "theme.json"
+    p.write_text('{"id":"x","name":"X"}')  # version fehlt
+    with pytest.raises(ManifestError):
+        ThemeManifest.load(p)
+
+
+def test_manifest_variables_must_be_object(tmp_path):
+    from hydrahive.themes.manifest import ThemeManifest, ManifestError
+    p = tmp_path / "theme.json"
+    p.write_text('{"id":"x","name":"X","version":"1.0.0","variables":[]}')
+    with pytest.raises(ManifestError):
+        ThemeManifest.load(p)
+
+
+# --- Installer file-ops -----------------------------------------------------
+
+def test_copy_theme_in(theme_env):
+    from unittest.mock import patch
+    from hydrahive.settings import settings
+    from hydrahive.themes.installer import copy_theme_in
+
+    src = settings.theme_hub_cache / "midnight"
+    src.mkdir(parents=True)
+    (src / "theme.json").write_text('{"id":"midnight","name":"M","version":"1.0.0"}')
+    (src / "theme.css").write_text(":root{}")
+
+    with (patch("hydrahive.themes.installer.refresh"),
+          patch("hydrahive.themes.installer._cache_path_for", return_value=src)):
+        copy_theme_in("midnight")
+
+    dst = settings.themes_frontend_dir / "midnight"
+    assert (dst / "theme.json").exists()
+    assert (dst / "theme.css").exists()
+
+
+def test_remove_theme_files(theme_env):
+    from hydrahive.settings import settings
+    from hydrahive.themes.installer import remove_theme_files
+
+    d = settings.themes_frontend_dir / "midnight"
+    d.mkdir(parents=True)
+    (d / "theme.json").write_text("{}")
+
+    remove_theme_files("midnight")
+    assert not d.exists()
+
+
+def test_remove_protected_theme_forbidden(theme_env):
+    from hydrahive.themes.installer import remove_theme_files, InstallError
+    with pytest.raises(InstallError):
+        remove_theme_files("aurora")
+
+
+def test_copy_rejects_traversal_id(theme_env):
+    from hydrahive.themes.installer import copy_theme_in, InstallError
+    with pytest.raises(InstallError):
+        copy_theme_in("../../etc")
+
+
+def test_remove_rejects_traversal_id(theme_env):
+    from hydrahive.themes.installer import remove_theme_files, InstallError
+    with pytest.raises(InstallError):
+        remove_theme_files("../../etc")
+
+
+# --- Registry ---------------------------------------------------------------
+
+def test_list_installed_scans_dir(theme_env):
+    from hydrahive.settings import settings
+    from hydrahive.themes import registry
+
+    d = settings.themes_frontend_dir / "midnight"
+    d.mkdir(parents=True)
+    (d / "theme.json").write_text('{"id":"midnight","name":"Midnight","version":"1.2.0"}')
+
+    got = registry.list_installed()
+    ids = {t["id"]: t for t in got}
+    assert "midnight" in ids
+    assert ids["midnight"]["version"] == "1.2.0"
+    assert ids["midnight"]["protected"] is False
+
+
+def test_list_installed_marks_protected(theme_env):
+    from hydrahive.settings import settings
+    from hydrahive.themes import registry
+
+    d = settings.themes_frontend_dir / "aurora"
+    d.mkdir(parents=True)
+    (d / "theme.json").write_text('{"id":"aurora","name":"Aurora","version":"1.0.0"}')
+
+    got = {t["id"]: t for t in registry.list_installed()}
+    assert got["aurora"]["protected"] is True

--- a/docs/specs/theming-system-etappe3.md
+++ b/docs/specs/theming-system-etappe3.md
@@ -1,0 +1,99 @@
+# Theme-System Etappe 3 — Hub-Installer (WordPress-Gefühl)
+
+Status: FREIGEGEBEN (Weg A — eigenes Git-Hub-Repo, wie Module).
+Baut auf Etappe 1 (PR #245) + Etappe 2 (PR #246) auf.
+
+## Problem
+
+Themes sind heute Dropin-Ordner (`frontend/src/themes/<id>/`), die man manuell
+ins Repo legen muss. Ein Admin ohne Shell-Zugriff kann kein Theme installieren.
+Etappe 3 macht Themes über einen **Hub installierbar** — Admin sieht
+„Installiert / Verfügbar", ein Klick installiert/entfernt.
+
+## Blaupause: das Modulsystem (1:1 spiegeln)
+
+`core/src/hydrahive/modules/` + `api/routes/modules.py` + `features/modules/` +
+Git-Hub-Repo `hydrahive2-modules`. Themes bekommen dieselbe Struktur, aber
+**schlanker**, weil ein Theme reines Frontend ist:
+
+| Modul | Theme |
+|-------|-------|
+| Backend + Migrations + Frontend | **nur Frontend** |
+| 2 Kopierziele (modules_dir + frontend) | **1 Ziel** (`frontend/src/themes/<id>`) |
+| install.sh/uninstall.sh Service | **keine** |
+| DB-Tabellen, Agent-Tools | **keine** |
+| Registry lädt Python-Manifest | Registry liest nur `theme.json` |
+
+## Architektur
+
+### Git-Hub-Repo `hydrahive2-themes`
+```
+hub.json                 # { "themes": [ { "id", "name", "path" } ] }
+aurora/                  # ein Theme = ein Ordner (wie im Frontend-Paket)
+  theme.json
+  theme.css
+  preview.jpg (optional)
+  layout.tsx  (optional)
+```
+
+### Settings (`settings/_paths.py`) — additiv
+- `themes_hub_cache` = `data_dir/.theme-cache/hub`
+- `theme_hub_git_url` = `HH_THEME_HUB_GIT_URL` (Default GitHub `hydrahive2-themes`)
+- `theme_hub_extra_git_urls` = `HH_THEME_HUB_GIT_URLS` (Multi-Hub, wie Module)
+- Kopierziel = `base_dir/frontend/src/themes/<id>` (kein eigenes data_dir nötig)
+
+### Backend `core/src/hydrahive/themes/`
+- `hub_client.py` — **direkte Spiegelung** des Modul-hub_clients (klonen/pullen,
+  Multi-Hub-Merge, `read_hub_index()` → `{"themes": [...]}`, `theme_source_path()`).
+- `installer.py` — schlank:
+  - `copy_theme_in(id)` → kopiert Hub-Cache-Ordner nach `frontend/src/themes/<id>`
+  - `remove_theme_files(id)` → löscht den Ordner (aurora ist geschützt: nie löschbar)
+  - `install/uninstall(id)` Generatoren: kopieren → `npm run build` → Restart-Request
+  - **kein** Service-Script, **kein** modules_dir
+- `manifest.py` — `ThemeManifest.load()` (id/name/version + layout/variables),
+  Validierung `^[a-z0-9][a-z0-9-]*$`.
+- `registry.py` — listet installierte Themes durch Scan von `frontend/src/themes/*/theme.json`.
+
+### API `api/routes/themes.py`
+`/api/admin/themes` (require_admin), spiegelt modules.py:
+- `GET ""` → `{ installed, available }`
+- `POST /{id}/install` (SSE-Stream)
+- `POST /{id}/update` (SSE-Stream)
+- `DELETE /{id}` (SSE-Stream)
+Registriert in `api/main.py`.
+
+### Frontend `features/themes/`
+Spiegelt `features/modules/`:
+- `api.ts`, `types.ts`, `ThemesPage.tsx`, `ThemeAdminCard.tsx`
+- Settings-Registry-Eintrag `{ id: "themes", route: "/themes", adminOnly: true }`
+- Route in `App.tsx` unter `AdminGuard`
+
+## Schutz & Sicherheit
+- `aurora` + eingebaute Themes (`standard`/`sidebar`) sind **nicht deinstallierbar**
+  (Backend lehnt ab; UI zeigt keinen Entfernen-Button).
+- Theme-`id` streng validiert (kein Pfad-Escape, `theme_source_path` prüft
+  Verzeichnisgrenze wie beim Modul-hub_client).
+- `symlinks=False` beim Kopieren (kein Escape-Vektor).
+- User-CSS ist reines CSS (kein JS). `layout.tsx` aus Hub = gleiche Vertrauensstufe
+  wie ein Modul (Admin-Aktion, Katalog kuratiert).
+
+## .gitignore
+```
+src/themes/*/            # Hub-installierte Themes ignorieren
+!src/themes/aurora/      # Beispiel-Theme bleibt getrackt (Vorlage)
+src/themes/index.generated.ts
+```
+(aurora ist bereits im Index → bleibt ohnehin getrackt; Negation für Robustheit.)
+
+## Akzeptanzkriterien
+1. `hydrahive2-themes`-Repo existiert mit `hub.json` + aurora.
+2. Admin-Seite „Themes" listet Installiert + Verfügbar.
+3. Ein Klick „Installieren" auf ein Hub-Theme → landet in `frontend/src/themes/<id>`,
+   Build läuft, nach Restart im Profil-Picker wählbar.
+4. Deinstallieren entfernt den Ordner (aurora/standard/sidebar geschützt).
+5. Backend-Tests grün (manifest/hub_client/installer), `npm run build` + `tsc` grün.
+
+## Nicht in diesem Feature
+- ZIP-Upload (Weg B) — später additiv möglich.
+- Theme-Editor im UI.
+- Pro-Theme-Versionsvergleich/Changelog.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,6 +27,9 @@ dist-ssr
 src/modules/*/
 src/modules/index.generated.ts
 
-# Theme system — index ist generiert; mitgelieferte Beispiel-Themes bleiben
-# im Repo (Vorlage für Theme-Bauer). Hub-installierte Themes → Etappe 3.
+# Theme system — index ist generiert; Hub-installierte Themes sind
+# install-managed. Das mitgelieferte Beispiel-Theme (aurora) + README bleiben
+# als Vorlage im Repo.
 src/themes/index.generated.ts
+src/themes/*/
+!src/themes/aurora/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { UiKitPage } from "@/features/uikit/UiKitPage"
 import { PluginsPage } from "@/features/plugins/PluginsPage"
 import { ExtensionsPage } from "@/features/extensions/ExtensionsPage"
 import { ModulesPage } from "@/features/modules/ModulesPage"
+import { ThemesPage } from "@/features/themes/ThemesPage"
 import { CommunicationPage } from "@/features/communication/CommunicationPage"
 import { TeamchatPage } from "@/features/teamchat/TeamchatPage"
 import { VMsPage } from "@/features/vms/VMsPage"
@@ -101,6 +102,7 @@ export default function App() {
           <Route path="plugins" element={<AdminGuard><PluginsPage /></AdminGuard>} />
           <Route path="extensions" element={<AdminGuard><ExtensionsPage /></AdminGuard>} />
           <Route path="modules" element={<AdminGuard><ModulesPage /></AdminGuard>} />
+          <Route path="themes" element={<AdminGuard><ThemesPage /></AdminGuard>} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="help" element={<HelpPage />} />
           <Route path="zahnfee" element={<AdminGuard><ZahnfeePage /></AdminGuard>} />

--- a/frontend/src/features/settings/registry.ts
+++ b/frontend/src/features/settings/registry.ts
@@ -1,7 +1,7 @@
 import { lazy, type LazyExoticComponent, type ComponentType } from "react"
 import {
   Bot, FolderKanban, MessageCircle, Workflow, MoonStar, Sparkles, Server,
-  Puzzle, Globe, Cpu, Package, Boxes, Users, Key,
+  Puzzle, Globe, Cpu, Package, Boxes, Palette, Users, Key,
   SlidersHorizontal, Database, Network, type LucideIcon,
 } from "lucide-react"
 
@@ -13,6 +13,7 @@ const SkillsPage = lazy(() => import("@/features/skills/SkillsPage").then((m) =>
 const UsersPage = lazy(() => import("@/features/users/UsersPage").then((m) => ({ default: m.UsersPage })))
 const SettingsPage = lazy(() => import("@/features/system/SettingsPage").then((m) => ({ default: m.SettingsPage })))
 const ModulesPage = lazy(() => import("@/features/modules/ModulesPage").then((m) => ({ default: m.ModulesPage })))
+const ThemesPage = lazy(() => import("@/features/themes/ThemesPage").then((m) => ({ default: m.ThemesPage })))
 const ExtensionsPage = lazy(() => import("@/features/extensions/ExtensionsPage").then((m) => ({ default: m.ExtensionsPage })))
 const PluginsPage = lazy(() => import("@/features/plugins/PluginsPage").then((m) => ({ default: m.PluginsPage })))
 const FederationPage = lazy(() => import("@/features/federation/FederationPage").then((m) => ({ default: m.FederationPage })))
@@ -119,6 +120,8 @@ export const SETTINGS_GROUPS: SettingsGroup[] = [
     tabs: ["Installiert"], route: "/extensions", component: ExtensionsPage, adminOnly: true },
   { id: "modules", label: "Module", icon: Boxes, hasSubmenu: false,
     tabs: ["Verfügbar"], route: "/modules", component: ModulesPage, adminOnly: true },
+  { id: "themes", label: "Themes", icon: Palette, hasSubmenu: false,
+    tabs: ["Verfügbar"], route: "/themes", component: ThemesPage, adminOnly: true },
   { id: "connections", label: "Verbindungen", icon: Network, hasSubmenu: false,
     tabs: ["Tailscale", "AgentLink", "Samba"], route: "/system",
     tabComponents: { Tailscale: ConnTailscale, AgentLink: ConnAgentLink, Samba: ConnSamba } },

--- a/frontend/src/features/themes/ThemeCard.tsx
+++ b/frontend/src/features/themes/ThemeCard.tsx
@@ -1,0 +1,164 @@
+import type { CSSProperties } from "react"
+import { useEffect, useRef, useState } from "react"
+import { CheckCircle, Lock, Palette, RefreshCw, XCircle } from "lucide-react"
+import { rgbFor } from "@/shared/colors"
+import type { AvailableTheme, InstalledTheme } from "./types"
+import { installTheme, uninstallTheme, updateTheme } from "./api"
+
+type Phase = "idle" | "running" | "done"
+type Action = "update" | "uninstall"
+
+const ACCENT = { "--c": rgbFor("/profile") } as CSSProperties
+
+function InstallLog({ lines, phase, failed }: { lines: string[]; phase: Phase; failed: boolean }) {
+  const logRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    logRef.current?.scrollTo(0, logRef.current.scrollHeight)
+  }, [lines])
+  if (phase === "idle") return null
+  return (
+    <div ref={logRef} className="overflow-y-auto p-3 font-mono text-[11px] leading-relaxed bg-zinc-950/50 rounded-lg max-h-40">
+      {lines.length === 0 && <span className="text-zinc-600">Warte …</span>}
+      {lines.map((l, i) => (
+        <div key={i} className={
+          l.startsWith("[FEHLER]") || l.startsWith("[ERROR]") ? "text-rose-400" : "text-zinc-300"
+        }>{l}</div>
+      ))}
+      {phase === "done" && (
+        <div className={`mt-1 font-medium ${failed ? "text-rose-400" : "text-emerald-400"}`}>
+          {failed ? "Fehlgeschlagen." : "Fertig — nach dem Neustart im Profil wählbar."}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function InstalledThemeCard({ th, onRefresh }: { th: InstalledTheme; onRefresh: () => void }) {
+  const [phase, setPhase] = useState<Phase>("idle")
+  const [action, setAction] = useState<Action>("update")
+  const [lines, setLines] = useState<string[]>([])
+  const [failed, setFailed] = useState(false)
+  const stopRef = useRef<(() => void) | null>(null)
+
+  function run(a: Action) {
+    setAction(a)
+    setPhase("running")
+    setLines([])
+    setFailed(false)
+    const fn = a === "update" ? updateTheme : uninstallTheme
+    stopRef.current = fn(
+      th.id,
+      (line) => setLines((l) => [...l.slice(-500), line]),
+      () => { setPhase("done"); onRefresh() },
+      (msg) => { setLines((l) => [...l, `[FEHLER] ${msg}`]); setFailed(true); setPhase("done") },
+    )
+  }
+
+  useEffect(() => () => stopRef.current?.(), [])
+
+  return (
+    <div className="box overflow-hidden flex flex-col gap-3 p-4" style={ACCENT}>
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-lg bg-emerald-500/10 text-emerald-400 shrink-0">
+          <Palette size={18} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-zinc-100 text-sm">{th.name ?? th.id}</span>
+            {th.version && (
+              <span className="px-1.5 py-0.5 rounded-full text-[10px] bg-zinc-800 text-zinc-400 border border-white/[6%]">
+                v{th.version}
+              </span>
+            )}
+            {th.loaded ? (
+              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
+                <CheckCircle size={9} /> Installiert
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-rose-500/15 text-rose-400 border border-rose-500/30">
+                <XCircle size={9} /> Fehler
+              </span>
+            )}
+            {th.protected && (
+              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-zinc-800 text-zinc-500 border border-white/[6%]">
+                <Lock size={9} /> Mitgeliefert
+              </span>
+            )}
+          </div>
+          {th.error && <p className="text-[11px] text-rose-400 mt-0.5 font-mono">{th.error}</p>}
+        </div>
+      </div>
+
+      <InstallLog lines={lines} phase={phase} failed={failed} />
+
+      {!th.protected && (
+        <div className="flex gap-2">
+          <button
+            onClick={() => run("update")}
+            disabled={phase === "running"}
+            className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-violet-500/10 hover:bg-violet-500/20 border border-violet-500/20 text-violet-300 text-xs font-medium transition-colors disabled:opacity-40">
+            <RefreshCw size={11} className={phase === "running" && action === "update" ? "animate-spin" : ""} />
+            {phase === "running" && action === "update" ? "Aktualisiere …" : "Aktualisieren"}
+          </button>
+          <button
+            onClick={() => run("uninstall")}
+            disabled={phase === "running"}
+            className="flex-1 py-1.5 rounded-lg bg-rose-500/10 hover:bg-rose-500/20 border border-rose-500/20 text-rose-400 text-xs font-medium transition-colors disabled:opacity-40">
+            {phase === "running" && action === "uninstall" ? "Entferne …" : "Entfernen"}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function AvailableThemeCard({ th, onRefresh }: { th: AvailableTheme; onRefresh: () => void }) {
+  const [phase, setPhase] = useState<Phase>("idle")
+  const [lines, setLines] = useState<string[]>([])
+  const [failed, setFailed] = useState(false)
+  const stopRef = useRef<(() => void) | null>(null)
+
+  function handleInstall() {
+    setPhase("running")
+    setLines([])
+    setFailed(false)
+    stopRef.current = installTheme(
+      th.id,
+      (line) => setLines((l) => [...l.slice(-500), line]),
+      () => { setPhase("done"); onRefresh() },
+      (msg) => { setLines((l) => [...l, `[FEHLER] ${msg}`]); setFailed(true); setPhase("done") },
+    )
+  }
+
+  useEffect(() => () => stopRef.current?.(), [])
+
+  return (
+    <div className="box overflow-hidden flex flex-col gap-3 p-4" style={ACCENT}>
+      <div className="flex items-start gap-3">
+        <div className="p-2 rounded-lg bg-zinc-700/50 text-zinc-400 shrink-0">
+          <Palette size={18} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-zinc-100 text-sm">{th.name ?? th.id}</span>
+            {th.name && th.name !== th.id && (
+              <span className="text-[10px] text-zinc-500 font-mono">{th.id}</span>
+            )}
+            <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-zinc-800 text-zinc-400 border border-white/[6%]">
+              Verfügbar
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <InstallLog lines={lines} phase={phase} failed={failed} />
+
+      <button
+        onClick={handleInstall}
+        disabled={phase === "running"}
+        className="py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-medium transition-colors disabled:opacity-40">
+        {phase === "running" ? "Installiere …" : "Installieren"}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/themes/ThemesPage.tsx
+++ b/frontend/src/features/themes/ThemesPage.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from "react"
+import { Palette, RefreshCw } from "lucide-react"
+import type { ThemesIndex } from "./types"
+import { listThemes } from "./api"
+import { InstalledThemeCard, AvailableThemeCard } from "./ThemeCard"
+
+export function ThemesPage() {
+  const [data, setData] = useState<ThemesIndex>({ installed: [], available: [] })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setData(await listThemes())
+    } catch (e) {
+      setError(String(e))
+    }
+    setLoading(false)
+  }, [])
+
+  // load() ist async — setState nach dem await; die Regel über-feuert hier.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { load() }, [load])
+
+  // Bereits installierte Themes nicht doppelt als "verfügbar" zeigen.
+  const installedIds = new Set(data.installed.map((t) => t.id))
+  const available = data.available.filter((t) => !installedIds.has(t.id))
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Palette className="text-violet-400" size={20} />
+          <h1 className="text-xl font-semibold text-zinc-100">Themes</h1>
+          <span className="text-xs text-zinc-500">{data.installed.length} installiert</span>
+        </div>
+        <button
+          onClick={load}
+          className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors">
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+        </button>
+      </div>
+
+      <p className="text-sm text-zinc-500 -mt-3">
+        Ein Theme wechselt das komplette Layout der Oberfläche (Menü oben ↔ links) und die Farbwelt.
+        Nach der Installation ist es im Profil unter „Design" für jeden Nutzer wählbar.
+      </p>
+
+      {error && (
+        <div className="p-4 rounded-xl bg-rose-500/10 border border-rose-500/20 text-rose-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide">Installiert</h2>
+        {loading && data.installed.length === 0 ? (
+          <p className="text-zinc-500 text-sm">Lädt …</p>
+        ) : data.installed.length === 0 ? (
+          <p className="text-zinc-500 text-sm">Noch keine Theme-Pakete installiert.</p>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+            {data.installed.map((th) => (
+              <InstalledThemeCard key={th.id} th={th} onRefresh={load} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide">Verfügbar</h2>
+        {loading && available.length === 0 ? (
+          <p className="text-zinc-500 text-sm">Lädt …</p>
+        ) : available.length === 0 ? (
+          <p className="text-zinc-500 text-sm">Keine weiteren Themes im Hub.</p>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+            {available.map((th) => (
+              <AvailableThemeCard key={th.id} th={th} onRefresh={load} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/features/themes/api.ts
+++ b/frontend/src/features/themes/api.ts
@@ -1,0 +1,83 @@
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { api } from "@/shared/api-client"
+import type { ThemesIndex } from "./types"
+
+const BASE = "/admin/themes"
+
+function authHeaders(): Record<string, string> {
+  const token = useAuthStore.getState().token
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export function listThemes(): Promise<ThemesIndex> {
+  return api.get<ThemesIndex>(BASE)
+}
+
+function stream(
+  path: string,
+  method: "POST" | "DELETE",
+  onLine: (line: string) => void,
+  onDone: () => void,
+  onError: (msg: string) => void,
+): () => void {
+  let closed = false
+  const ctrl = new AbortController()
+
+  fetch(`/api${BASE}${path}`, {
+    method,
+    headers: authHeaders(),
+    signal: ctrl.signal,
+  }).then(async (r) => {
+    if (!r.ok || !r.body) { onError(`HTTP ${r.status}`); return }
+    const reader = r.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ""
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done || closed) break
+      buf += dec.decode(value, { stream: true })
+      const parts = buf.split("\n\n")
+      buf = parts.pop() ?? ""
+      for (const part of parts) {
+        const dataLine = part.split("\n").find((l) => l.startsWith("data:"))
+        if (!dataLine) continue
+        try {
+          const obj = JSON.parse(dataLine.slice(5).trim())
+          if (obj.done) { onDone(); return }
+          if (obj.line !== undefined) onLine(obj.line)
+        } catch { /* keepalive */ }
+      }
+    }
+  }).catch((e) => {
+    if (!closed) onError(String(e))
+  })
+
+  return () => { closed = true; ctrl.abort() }
+}
+
+export function installTheme(
+  id: string,
+  onLine: (line: string) => void,
+  onDone: () => void,
+  onError: (msg: string) => void,
+): () => void {
+  return stream(`/${id}/install`, "POST", onLine, onDone, onError)
+}
+
+export function uninstallTheme(
+  id: string,
+  onLine: (line: string) => void,
+  onDone: () => void,
+  onError: (msg: string) => void,
+): () => void {
+  return stream(`/${id}`, "DELETE", onLine, onDone, onError)
+}
+
+export function updateTheme(
+  id: string,
+  onLine: (line: string) => void,
+  onDone: () => void,
+  onError: (msg: string) => void,
+): () => void {
+  return stream(`/${id}/update`, "POST", onLine, onDone, onError)
+}

--- a/frontend/src/features/themes/types.ts
+++ b/frontend/src/features/themes/types.ts
@@ -1,0 +1,19 @@
+export interface InstalledTheme {
+  id: string
+  name?: string
+  loaded: boolean
+  error: string | null
+  version: string | null
+  protected?: boolean
+}
+
+export interface AvailableTheme {
+  id: string
+  name?: string
+  path?: string
+}
+
+export interface ThemesIndex {
+  installed: InstalledTheme[]
+  available: AvailableTheme[]
+}


### PR DESCRIPTION
## Was

Themes werden über einen **Git-Hub installierbar** — wie Module. Admin sieht
„Installiert / Verfügbar" (Einstellungen → Themes), ein Klick installiert/entfernt.
Kein Shell-Zugriff nötig. Baut auf Etappe 1 (#245) + Etappe 2 (#246) auf.

**Hub-Repo:** [`hydrahive/hydrahive2-themes`](https://github.com/hydrahive/hydrahive2-themes) — `hub.json` + aurora + midnight.

## Backend `core/src/hydrahive/themes/`
Spiegelt das Modulsystem, aber schlanker (Themes = reines Frontend, kein Service/DB, EIN Kopierziel):
- `manifest.py` — `ThemeManifest.load()` (id/name/version/layout/variables + Validierung)
- `hub_client.py` — Multi-Hub-Merge, `ff-only`-Pull mit hart-resync-Selbstheilung, `theme_source_path` mit Verzeichnisgrenz-Check
- `installer.py` — `copy_theme_in`/`remove_theme_files` + install/uninstall/update-Generatoren (kopieren → `npm build` → Restart). Geschützte Themes (`standard`/`sidebar`/`aurora`) nicht deinstallierbar
- `registry.py` — `list_installed()` scannt `themes_frontend_dir`, markiert `protected`
- `api/routes/themes.py` — `/api/admin/themes` (list + install/update/uninstall SSE), `require_admin`, in `api/main.py` registriert

## Settings (`_paths.py`, additiv)
`themes_frontend_dir`, `theme_hub_cache`, `theme_hub_git_url` (`HH_THEME_HUB_GIT_URL`), `theme_hub_extra_git_urls` (Multi-Hub).

## Frontend `features/themes/`
`api` · `types` · `ThemesPage` · `ThemeCard` (Install/Update/Uninstall mit SSE-Log; geschützte Themes ohne Entfernen-Button + „Mitgeliefert"-Badge). Settings-Registry-Eintrag „Themes" + Route in `App.tsx` (`AdminGuard`). „Verfügbar" blendet bereits Installierte aus.

## `.gitignore`
`src/themes/*/` ignoriert (install-managed), `aurora` + README bleiben als Vorlage.

## Getestet
- **20 Backend-Tests** grün (manifest/hub_client/installer/registry), ruff clean
- **E2E gegen echten GitHub-Hub**: `install(midnight)` klont+kopiert, registry zeigt installiert, `uninstall` entfernt, `uninstall(aurora)` korrekt als geschützt abgelehnt
- `tsc` strict + `npm run build` grün, ESLint clean
- keine Zyklen, keine print(), keine hardcodierten Pfade, alle Dateien < 200 Zeilen

## Spec
`docs/specs/theming-system-etappe3.md`

## Ausblick
ZIP-Upload (Weg B) + Theme-Editor bleiben optional/später. Dashboard-Baukasten (Boxen verschieben) ist ein separates Feature.