### PR TITLE
fix(themes): Sidebar-Avatar-Menü öffnet nach oben statt aus dem Viewport

### DIFF
--- a/frontend/src/shared/AvatarMenu.tsx
+++ b/frontend/src/shared/AvatarMenu.tsx
@@ -5,7 +5,17 @@ import { LogOut, User } from "lucide-react"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { LanguageSwitcher } from "@/i18n/LanguageSwitcher"
 
-export function AvatarMenu() {
+/** Öffnungsrichtung des Dropdowns. In der Topbar (Avatar oben rechts) klappt es
+ *  nach unten auf; in der Sidebar (Avatar unten links) muss es nach oben +
+ *  rechtsbündig zur linken Kante öffnen, sonst landet es außerhalb des Viewports. */
+type AvatarMenuPlacement = "bottom-right" | "top-left"
+
+const PLACEMENT_CLASS: Record<AvatarMenuPlacement, string> = {
+  "bottom-right": "right-0 top-full mt-2",
+  "top-left": "left-0 bottom-full mb-2",
+}
+
+export function AvatarMenu({ placement = "bottom-right" }: { placement?: AvatarMenuPlacement }) {
   const { username, role, logout } = useAuthStore()
   const { t } = useTranslation("auth")
   const [open, setOpen] = useState(false)
@@ -32,7 +42,7 @@ export function AvatarMenu() {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-64 rounded-xl border border-white/[10%] bg-zinc-950/95 backdrop-blur-xl shadow-2xl shadow-black/60 z-50 overflow-hidden">
+        <div className={`absolute ${PLACEMENT_CLASS[placement]} w-64 rounded-xl border border-white/[10%] bg-zinc-950/95 backdrop-blur-xl shadow-2xl shadow-black/60 z-50 overflow-hidden`}>
           <div className="px-4 py-3 border-b border-white/[6%]">
             <p className="text-sm font-medium text-zinc-100 truncate">{username}</p>
             <p className="text-[11px] text-zinc-500">{role}</p>

--- a/frontend/src/shared/layouts/SidebarLayout.tsx
+++ b/frontend/src/shared/layouts/SidebarLayout.tsx
@@ -71,7 +71,7 @@ export function SidebarLayout({ chrome }: { chrome: LayoutChrome }) {
             <Grip size={16} />
           </button>
           <div className="ml-auto">
-            <AvatarMenu />
+            <AvatarMenu placement="top-left" />
           </div>
         </div>
       </aside>


### PR DESCRIPTION
## Bug
Im **Sidebar-Theme** sitzt das Avatar-/Profil-Menü unten links. Ein Klick zeigte
scheinbar **kein Menü** — es öffnete unter den Fensterrand.

## Root-Cause (gemessen)
Das Dropdown war hart auf „nach unten rechts" verdrahtet (`absolute right-0 mt-2`).
In der Sidebar (Avatar bei y≈680, Fenster 720px) landete es bei **y=720..932**
(komplett unsichtbar) und **x=-25** (links raus). In der Topbar oben passt „nach
unten" — in der Sidebar unten nicht.

## Fix
`AvatarMenu` bekommt ein `placement`-Prop:
- `"bottom-right"` (Default, Topnav): `right-0 top-full mt-2` — **unverändert**
- `"top-left"` (Sidebar): `left-0 bottom-full mb-2` — öffnet **nach oben**, im Viewport

`SidebarLayout` nutzt `placement="top-left"`. Topnav bleibt 1:1.

## Getestet
tsc strict + eslint + `npm run build` grün. Nur 2 Nutzungen von `AvatarMenu`
(Topnav = Default, Sidebar = top-left) — kein anderer Aufrufer betroffen.