### PR TITLE
Dashboard-Baukasten: Widgets anordnen & aus-/einblenden (pro Nutzer)

### DIFF
--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -1,24 +1,21 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Check, RotateCcw, SlidersHorizontal } from "lucide-react"
 import { HelpButton } from "@/i18n/HelpButton"
 import { dashboardApi, type DashboardSummary } from "./api"
-import { StatsRow } from "./_StatsRow"
-import { RecentSessions } from "./_RecentSessions"
-import { ServersOverview } from "./_ServersOverview"
-import { AgentsList } from "./_AgentsList"
-import { HealthStrip } from "./_HealthStrip"
-import { TokenAuditCard } from "./_TokenAuditCard"
 import { UpdateBanner } from "./_UpdateBanner"
-import { TailscaleCard } from "@/features/system/TailscaleCard"
-import { AgentLinkCard } from "@/features/system/AgentLinkCard"
-import { MinimaxUsageCard } from "@/features/system/MinimaxUsageCard"
 import { EmptyState } from "@/shared/EmptyState"
+import { getWidget } from "./widgets"
+import { useDashboardLayout } from "./useDashboardLayout"
+import { WidgetFrame } from "./WidgetFrame"
 
 const REFRESH_MS = 30_000
 
 export function DashboardPage() {
   const { t } = useTranslation("dashboard")
   const [data, setData] = useState<DashboardSummary | null>(null)
+  const [editing, setEditing] = useState(false)
+  const { layout, move, toggle, reset, isHidden } = useDashboardLayout()
 
   useEffect(() => {
     let alive = true
@@ -29,9 +26,13 @@ export function DashboardPage() {
       } catch { /* leise */ }
     }
     load()
-    const t = setInterval(load, REFRESH_MS)
-    return () => { alive = false; clearInterval(t) }
+    const id = setInterval(load, REFRESH_MS)
+    return () => { alive = false; clearInterval(id) }
   }, [])
+
+  const orderedWidgets = layout.order
+    .map((id) => getWidget(id))
+    .filter((w): w is NonNullable<typeof w> => Boolean(w))
 
   return (
     <div className="space-y-3">
@@ -40,7 +41,30 @@ export function DashboardPage() {
           <h1 className="text-xl font-bold text-white">{t("title")}</h1>
           <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
         </div>
-        <HelpButton topic="dashboard" />
+        <div className="flex items-center gap-1.5">
+          {editing && (
+            <button
+              onClick={reset}
+              title="Standard wiederherstellen"
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-zinc-400 hover:text-zinc-100 hover:bg-white/[5%] transition-colors"
+            >
+              <RotateCcw size={13} /> Zurücksetzen
+            </button>
+          )}
+          <button
+            onClick={() => setEditing((e) => !e)}
+            title={editing ? "Anpassen beenden" : "Dashboard anpassen"}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              editing
+                ? "bg-[var(--hh-accent-soft)] text-[var(--hh-accent-text)] border border-[var(--hh-accent-border)]"
+                : "text-zinc-400 hover:text-zinc-100 hover:bg-white/[5%]"
+            }`}
+          >
+            {editing ? <Check size={13} /> : <SlidersHorizontal size={13} />}
+            {editing ? "Fertig" : "Anpassen"}
+          </button>
+          <HelpButton topic="dashboard" />
+        </div>
       </div>
 
       {data && (
@@ -49,25 +73,26 @@ export function DashboardPage() {
             <UpdateBanner behind={data.version.update_behind!} />
           )}
 
-          <HealthStrip health={data.health} />
-
-          <StatsRow stats={data.stats} />
-
-          <TokenAuditCard />
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-            <TailscaleCard />
-            <AgentLinkCard />
-          </div>
-
-          <MinimaxUsageCard />
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-            <RecentSessions sessions={data.recent_sessions} />
-            <AgentsList agents={data.agents} />
-          </div>
-
-          <ServersOverview servers={data.servers} />
+          {orderedWidgets.map((w, idx) => {
+            const hidden = isHidden(w.id)
+            if (editing) {
+              return (
+                <WidgetFrame
+                  key={w.id}
+                  label={w.label}
+                  hidden={hidden}
+                  isFirst={idx === 0}
+                  isLast={idx === orderedWidgets.length - 1}
+                  onUp={() => move(w.id, -1)}
+                  onDown={() => move(w.id, 1)}
+                  onToggle={() => toggle(w.id)}
+                >
+                  {w.render(data)}
+                </WidgetFrame>
+              )
+            }
+            return hidden ? null : <div key={w.id}>{w.render(data)}</div>
+          })}
         </>
       )}
 

--- a/frontend/src/features/dashboard/WidgetFrame.tsx
+++ b/frontend/src/features/dashboard/WidgetFrame.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react"
+import { ChevronDown, ChevronUp, Eye, EyeOff } from "lucide-react"
+
+interface Props {
+  label: string
+  hidden: boolean
+  isFirst: boolean
+  isLast: boolean
+  onUp: () => void
+  onDown: () => void
+  onToggle: () => void
+  children: ReactNode
+}
+
+/** Rahmen um ein Widget im Anpassen-Modus: Titel + Hoch/Runter/Sichtbarkeit.
+ *  Bewusst Buttons statt Drag&Drop — eindeutig bedienbar, kein Rätselraten. */
+export function WidgetFrame({
+  label, hidden, isFirst, isLast, onUp, onDown, onToggle, children,
+}: Props) {
+  return (
+    <div className={`rounded-xl border border-dashed border-white/15 p-2 transition-opacity ${hidden ? "opacity-45" : ""}`}>
+      <div className="flex items-center gap-1.5 mb-2 px-1">
+        <span className="text-xs font-medium text-zinc-300 flex-1 truncate">{label}</span>
+
+        <button
+          onClick={onUp}
+          disabled={isFirst}
+          title="Nach oben"
+          className="p-1 rounded-md text-zinc-400 hover:text-zinc-100 hover:bg-white/[7%] disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+        >
+          <ChevronUp size={15} />
+        </button>
+        <button
+          onClick={onDown}
+          disabled={isLast}
+          title="Nach unten"
+          className="p-1 rounded-md text-zinc-400 hover:text-zinc-100 hover:bg-white/[7%] disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+        >
+          <ChevronDown size={15} />
+        </button>
+        <button
+          onClick={onToggle}
+          title={hidden ? "Einblenden" : "Ausblenden"}
+          className="p-1 rounded-md text-zinc-400 hover:text-zinc-100 hover:bg-white/[7%] transition-colors"
+        >
+          {hidden ? <EyeOff size={15} /> : <Eye size={15} />}
+        </button>
+      </div>
+
+      {!hidden && <div>{children}</div>}
+    </div>
+  )
+}

--- a/frontend/src/features/dashboard/useDashboardLayout.ts
+++ b/frontend/src/features/dashboard/useDashboardLayout.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react"
+import { DEFAULT_WIDGET_ORDER } from "./widgets"
+
+const STORAGE_KEY = "hh-dashboard-layout"
+
+export interface DashboardLayout {
+  /** Widget-IDs in Anzeige-Reihenfolge. */
+  order: string[]
+  /** IDs, die ausgeblendet sind. */
+  hidden: string[]
+}
+
+function defaultLayout(): DashboardLayout {
+  return { order: [...DEFAULT_WIDGET_ORDER], hidden: [] }
+}
+
+/** Gespeichertes Layout laden und mit den aktuell verfügbaren Widgets
+ *  abgleichen: neue Widget-IDs werden ans Ende gehängt (sichtbar), entfernte
+ *  IDs fallen raus. So bleibt eine gespeicherte Anordnung nach einem Update
+ *  gültig, ohne neue Widgets zu verschlucken. */
+function loadLayout(): DashboardLayout {
+  let stored: Partial<DashboardLayout> | null = null
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) stored = JSON.parse(raw)
+  } catch {
+    stored = null
+  }
+  const known = new Set(DEFAULT_WIDGET_ORDER)
+  const storedOrder = Array.isArray(stored?.order) ? stored!.order.filter((id) => known.has(id)) : []
+  const missing = DEFAULT_WIDGET_ORDER.filter((id) => !storedOrder.includes(id))
+  const order = [...storedOrder, ...missing]
+  const hidden = Array.isArray(stored?.hidden) ? stored!.hidden.filter((id) => known.has(id)) : []
+  return { order, hidden }
+}
+
+export function useDashboardLayout() {
+  const [layout, setLayout] = useState<DashboardLayout>(loadLayout)
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(layout))
+    } catch {
+      /* ignore */
+    }
+  }, [layout])
+
+  const move = useCallback((id: string, dir: -1 | 1) => {
+    setLayout((prev) => {
+      const order = [...prev.order]
+      const i = order.indexOf(id)
+      const j = i + dir
+      if (i < 0 || j < 0 || j >= order.length) return prev
+      ;[order[i], order[j]] = [order[j], order[i]]
+      return { ...prev, order }
+    })
+  }, [])
+
+  const toggle = useCallback((id: string) => {
+    setLayout((prev) => {
+      const hidden = prev.hidden.includes(id)
+        ? prev.hidden.filter((h) => h !== id)
+        : [...prev.hidden, id]
+      return { ...prev, hidden }
+    })
+  }, [])
+
+  const reset = useCallback(() => setLayout(defaultLayout()), [])
+
+  const isHidden = useCallback((id: string) => layout.hidden.includes(id), [layout.hidden])
+
+  return { layout, move, toggle, reset, isHidden }
+}

--- a/frontend/src/features/dashboard/widgets.tsx
+++ b/frontend/src/features/dashboard/widgets.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react"
+import type { DashboardSummary } from "./api"
+import { StatsRow } from "./_StatsRow"
+import { RecentSessions } from "./_RecentSessions"
+import { ServersOverview } from "./_ServersOverview"
+import { AgentsList } from "./_AgentsList"
+import { HealthStrip } from "./_HealthStrip"
+import { TokenAuditCard } from "./_TokenAuditCard"
+import { TailscaleCard } from "@/features/system/TailscaleCard"
+import { AgentLinkCard } from "@/features/system/AgentLinkCard"
+import { MinimaxUsageCard } from "@/features/system/MinimaxUsageCard"
+
+/** Ein anordbares Dashboard-Widget. `render` bekommt die geladenen Daten und
+ *  gibt den Karten-Inhalt zurück. Reihenfolge + Sichtbarkeit werden pro Nutzer
+ *  gespeichert (siehe useDashboardLayout). */
+export interface DashboardWidget {
+  id: string
+  /** Anzeigename im Anpassen-Modus. */
+  label: string
+  render: (data: DashboardSummary) => ReactNode
+}
+
+/** Alle verfügbaren Widgets in ihrer Standard-Reihenfolge. Neue Widgets hier
+ *  ergänzen — sie erscheinen automatisch (ans Ende, sichtbar) bei bestehenden
+ *  Nutzern, weil useDashboardLayout unbekannte IDs anhängt. */
+export const DASHBOARD_WIDGETS: DashboardWidget[] = [
+  {
+    id: "health",
+    label: "System-Status",
+    render: (d) => <HealthStrip health={d.health} />,
+  },
+  {
+    id: "stats",
+    label: "Kennzahlen",
+    render: (d) => <StatsRow stats={d.stats} />,
+  },
+  {
+    id: "token-audit",
+    label: "Token-Verbrauch",
+    render: () => <TokenAuditCard />,
+  },
+  {
+    id: "connections",
+    label: "Verbindungen (Tailscale / AgentLink)",
+    render: () => (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <TailscaleCard />
+        <AgentLinkCard />
+      </div>
+    ),
+  },
+  {
+    id: "minimax",
+    label: "MiniMax-Nutzung",
+    render: () => <MinimaxUsageCard />,
+  },
+  {
+    id: "sessions-agents",
+    label: "Sessions & Agenten",
+    render: (d) => (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <RecentSessions sessions={d.recent_sessions} />
+        <AgentsList agents={d.agents} />
+      </div>
+    ),
+  },
+  {
+    id: "servers",
+    label: "Server-Übersicht",
+    render: (d) => <ServersOverview servers={d.servers} />,
+  },
+]
+
+/** Standard-Reihenfolge als ID-Liste (für den Storage-Default). */
+export const DEFAULT_WIDGET_ORDER = DASHBOARD_WIDGETS.map((w) => w.id)
+
+export function getWidget(id: string): DashboardWidget | undefined {
+  return DASHBOARD_WIDGETS.find((w) => w.id === id)
+}


### PR DESCRIPTION
## Was
Jeder Nutzer ordnet seine Dashboard-Widgets selbst an und blendet ungenutzte aus.
Bewusst mit **Hoch/Runter-Buttons + Auge** statt Drag&Drop — eindeutig bedienbar,
keine versteckte Geste, keine zusätzliche Lib.

## Bedienung
Oben rechts **„Anpassen"** → jedes Widget bekommt eine Leiste:
- **▲ / ▼** — ein Widget hoch/runter
- **👁 Auge** — aus-/einblenden
- **„Zurücksetzen"** — Standard wiederherstellen · **„Fertig"** beendet den Modus

## Wie
- `widgets.tsx` — Registry aller Dashboard-Widgets (`id`, `label`, `render(data)`).
  Neue Widgets hier ergänzen → erscheinen automatisch (ans Ende, sichtbar).
- `useDashboardLayout.ts` — Reihenfolge + Sichtbarkeit in `localStorage`
  (`hh-dashboard-layout`, pro Nutzer/Browser wie Theme/Landing/TTS). Robuster Merge:
  neue IDs ans Ende, entfernte/kaputte gefiltert, defektes JSON → Default.
- `WidgetFrame.tsx` — Anpassen-Rahmen pro Widget.
- `DashboardPage.tsx` — „Anpassen"-Schalter, rendert alles über die Registry.
  `UpdateBanner` bleibt fix oben.

Kein Backend nötig (konsistent mit bestehendem localStorage-Prefs-Muster).

## Getestet
- **Merge-Logik 11/11** (Persistenz, kaputtes JSON, neue/entfernte Widgets, keine Duplikate)
- `tsc` strict + `npm run build` grün; neue Dateien eslint-clean, alle < 200 Zeilen

_Hinweis: Live-Preview in der Build-Sandbox nicht möglich (keine langlebigen Hintergrund-Server) — daher Logik isoliert + Compiler-Absicherung statt Screenshot._

## Nicht in diesem PR
Freies Nebeneinander/Größe (Grid) und 1/2-Spalten-Wahl — additiv später möglich.
Nur Dashboard (andere Seiten unberührt).