### PR TITLE
Template-System Proof: Designer-HTML mit <hh-…/>-Platzhaltern

### DIFF
--- a/docs/specs/theme-templates-brainstorm.md
+++ b/docs/specs/theme-templates-brainstorm.md
@@ -1,0 +1,109 @@
+# Brainstorm-Anker: Theme-Templates mit Platzhaltern
+
+> Lebendes Dokument. Hält Entscheidungen fest, damit wir nicht driften.
+> KEIN Code bis Design steht. Jede Entscheidung wird hier eingetragen.
+
+## Vision (Tills Bild)
+
+Ein Webdesigner baut 5–6 Themes, jedes in eigenem Ordner (`/themes/theme1/`).
+Ein Theme enthält **Seiten-Vorlagen** (buddy, werkstatt, atelier, …) als echtes
+HTML/CSS, „höllisch grafisch aufgebohrt". An die Stellen, wo interaktive Teile
+hin sollen, setzt der Designer **Platzhalter**:
+
+```html
+<div class="mein-design">
+   <hh-menu type="horizontal"/>
+   <hh-chatbox agent="buddy"/>
+</div>
+```
+
+Die App füllt die Platzhalter mit den echten interaktiven React-Bausteinen.
+Das, was heute fest in den Core-Menüs steckt, liegt dann im Theme.
+
+## Vokabular (verbindlich)
+
+- **Theme** — Ordner mit Seiten-Vorlagen + Style. Das Drumherum.
+- **Baustein** — interaktives Element mit echter Funktion (Chatbox, Video-Editor,
+  Musicplayer, Dashboard-Widget). Bringt eigenen Zustand/Daten mit.
+- **Slot / Platzhalter** — `<hh-xxx/>`-Tag im Theme, wird durch einen Baustein ersetzt.
+- **Template** — eine Seiten-Vorlage (HTML + Platzhalter) für eine Route.
+
+## Grundsatz-Entscheidung: MITTELWEG (freigegeben)
+
+Der Designer schreibt **freies HTML/CSS** für das Aussehen (volle optische
+Freiheit — Layout, Farben, Verläufe, Grafiken). Die **interaktiven Teile sind
+Platzhalter-Tags** (`<hh-chatbox/>`), die die App kontrolliert einsetzt.
+Fremd-HTML wird **sanitized** (Scripts/gefährliches raus). **Kein eigenes JS im
+Theme** — wer eigene Logik will, baut ein Modul.
+
+= WordPress-Shortcode-Modell: freies Markup, eingezäunter interaktiver Teil.
+
+**Bewusst akzeptierter Trade-off:** Designer kann kein eigenes JavaScript
+ausführen, nur vorhandene Bausteine nutzen. Für „Seite grafisch aufbohren" reicht das.
+
+## SICHERHEITSREGEL NR. 1 (Till, hart)
+
+**Das aktuelle Design darf NIE verloren gehen.** Es bleibt als eingebauter
+Standard + Fallback in der App. Das Template-System ist **rein additiv**:
+
+- Ein Theme KANN eine Seite per Template überschreiben.
+- Überschreibt es nicht (oder Template fehlt/bricht) → App zeigt automatisch
+  die aktuelle React-Seite. Das aktuelle Design ist das Sicherheitsnetz.
+- Kein Big-Bang, keine Massen-Übersetzung der 118 Seiten. Seite für Seite,
+  optional, jederzeit umkehrbar.
+- Layout-Sinn bereits erfüllt: „Standard"-Theme (topnav) = pixelgleich zum
+  aktuellen Design, ist DEFAULT_THEME_ID, liegt auf main.
+
+## Wichtige technische Wahrheit
+
+- HydraHive ist eine **React-App** (Browser baut UI aus Komponenten), nicht PHP.
+- Ein „Baustein" ist oft **kein simples Bild**: die Chatbox = 268 Zeilen, 11
+  State-Hooks, redet mit dem Server. Solche Teile müssen einmalig
+  **„droppbar" (self-contained)** gemacht werden, bevor sie an einen beliebigen
+  Platzhalter passen.
+- **Gute Nachricht:** Die Dashboard-Karten (TokenAudit, Tailscale, AgentLink,
+  MiniMax) sind bereits self-contained ✓. Der Slot-Mechanismus existiert schon
+  an 4 Stellen (moduleNav, moduleRoutes, moduleWorkspaceTabs, moduleBuddyWidgets).
+- **Doppelnutzen:** Die gekapselten Bausteine sind gleichzeitig die
+  UI-Bausteinbibliothek (die „Alternative zu Nuxt UI" / das UI-Kit). Ein Baustein
+  ist droppbar UND wiederverwendbares UI-Element.
+
+## Ausbaustufen (Zielbild, grob → fein)
+
+1. Bausteine als Platzhalter einsetzbar (`<hh-chatbox/>`).
+2. Eigene Seiten aus Platzhaltern zusammenstellbar.
+3. Theme liefert Seiten-Templates mit (nicht nur Layout).
+4. Core-Menüpunkte werden zu Theme-Vorlagen (überschreibbar).
+5. Parameter am Platzhalter (`<hh-chatbox agent="buddy"/>`).
+6. Marktplatz-Reife (Themes + Bausteine über Hub teilen).
+
+## Offene Entscheidungen (zu klären, bevor Code)
+
+- [ ] **Baustein-Katalog v1:** Welche Bausteine braucht die erste Runde? Kandidaten:
+      `hh-menu` (horizontal/vertikal), `hh-chatbox` (buddy/werkstatt),
+      `hh-dashboard-widget`, `hh-musicplayer`, `hh-videoeditor`?
+- [ ] **Platzhalter-Syntax:** `<hh-chatbox agent="buddy"/>` (HTML-Custom-Tag) vs.
+      `[[chatbox:buddy]]` (Shortcode-Text)? → beeinflusst Parser.
+- [ ] **Template-Format:** reine `.html`-Dateien pro Route? Oder `.html` + `theme.json`
+      (Style) getrennt?
+- [ ] **Welche Seiten zuerst** als Template verfügbar? (buddy zuerst = Proof)
+- [ ] **Sanitizing-Regeln:** welche HTML-Tags/Attribute erlaubt, was fliegt raus?
+- [ ] **Theme ↔ Modul-Konflikt:** wenn beide eine Seite liefern — wer gewinnt?
+- [ ] **Rollen:** wer darf Templates bearbeiten/installieren? (Designer/Admin/User)
+- [ ] **Daten-Versorgung:** jeder Baustein holt seine Daten selbst (Regel).
+
+## Proof-first Plan (gegen Drift)
+
+Bevor das ganze Register gebaut wird: **EIN** Theme-Ordner, **eine** `buddy.html`
+mit **einem** Platzhalter `<hh-chatbox/>`. Sichtbar machen: Designer-HTML drumherum
++ echte Chatbox drin. Erst wenn das steht und sich richtig anfühlt → hochziehen.
+
+## Nicht in diesem Feature
+
+- Designer-eigenes JavaScript im Theme (= Modul-Territorium).
+- Visueller Drag&Drop-Theme-Editor (evtl. viel später).
+- Server-seitiges Rendering (bleibt Client-React).
+
+## Ideen-Halde (Tills „wirre Dinge" — unsortiert, willkommen)
+
+- (hier landet, was noch kommt)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { PluginsPage } from "@/features/plugins/PluginsPage"
 import { ExtensionsPage } from "@/features/extensions/ExtensionsPage"
 import { ModulesPage } from "@/features/modules/ModulesPage"
 import { ThemesPage } from "@/features/themes/ThemesPage"
+import { TemplateProofPage } from "@/features/themetemplates/TemplateProofPage"
 import { CommunicationPage } from "@/features/communication/CommunicationPage"
 import { TeamchatPage } from "@/features/teamchat/TeamchatPage"
 import { VMsPage } from "@/features/vms/VMsPage"
@@ -103,6 +104,7 @@ export default function App() {
           <Route path="extensions" element={<AdminGuard><ExtensionsPage /></AdminGuard>} />
           <Route path="modules" element={<AdminGuard><ModulesPage /></AdminGuard>} />
           <Route path="themes" element={<AdminGuard><ThemesPage /></AdminGuard>} />
+          <Route path="template-proof" element={<AdminGuard><TemplateProofPage /></AdminGuard>} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="help" element={<HelpPage />} />
           <Route path="zahnfee" element={<AdminGuard><ZahnfeePage /></AdminGuard>} />

--- a/frontend/src/features/themetemplates/TemplateProofPage.tsx
+++ b/frontend/src/features/themetemplates/TemplateProofPage.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react"
+import { Code2, Eye } from "lucide-react"
+import { renderTemplate } from "./TemplateRenderer"
+import { SAMPLE_TEMPLATE } from "./_sampleTemplate"
+import { SLOT_BLOCKS } from "./registry"
+
+/** Proof-Seite für das Template-System (Weg: Mittelweg).
+ *  Zeigt: Designer-HTML mit <hh-…/>-Platzhaltern wird zu echtem UI, Bausteine
+ *  werden eingesetzt, Fremd-Scripts werden verworfen. Bearbeitbares Textfeld,
+ *  damit man live sieht wie ein Designer arbeiten würde. */
+export function TemplateProofPage() {
+  const [html, setHtml] = useState(SAMPLE_TEMPLATE.trim())
+  const [showSource, setShowSource] = useState(true)
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-bold text-white">Template-Proof</h1>
+        <p className="text-zinc-500 text-sm mt-0.5">
+          Freies HTML/CSS + <code className="text-zinc-400">&lt;hh-…/&gt;</code>-Platzhalter →
+          echte Bausteine. Scripts werden entfernt.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center text-xs text-zinc-400">
+        <span className="text-zinc-500">Verfügbare Bausteine:</span>
+        {SLOT_BLOCKS.map((b) => (
+          <code key={b.name} className="px-1.5 py-0.5 rounded bg-white/[6%] text-[var(--hh-accent-text)]">
+            &lt;hh-{b.name}/&gt;
+          </code>
+        ))}
+        <button
+          onClick={() => setShowSource((s) => !s)}
+          className="ml-auto flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-white/[5%] transition-colors"
+        >
+          {showSource ? <Eye size={13} /> : <Code2 size={13} />}
+          {showSource ? "Nur Vorschau" : "Quelltext zeigen"}
+        </button>
+      </div>
+
+      <div className={`grid gap-4 ${showSource ? "lg:grid-cols-2" : "grid-cols-1"}`}>
+        {showSource && (
+          <div className="flex flex-col">
+            <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-1.5">
+              <Code2 size={12} /> Designer-HTML (editierbar)
+            </div>
+            <textarea
+              value={html}
+              onChange={(e) => setHtml(e.target.value)}
+              spellCheck={false}
+              className="flex-1 min-h-[420px] p-3 rounded-xl bg-zinc-950/70 border border-white/[8%] font-mono text-[12px] leading-relaxed text-zinc-200 resize-none focus:outline-none focus:border-[var(--hh-accent-border)]"
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col">
+          <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-1.5">
+            <Eye size={12} /> Live-Vorschau
+          </div>
+          <div className="flex-1 p-4 rounded-xl bg-[#0b0e16] border border-white/[8%] overflow-y-auto">
+            {renderTemplate(html)}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/themetemplates/TemplateRenderer.tsx
+++ b/frontend/src/features/themetemplates/TemplateRenderer.tsx
@@ -1,0 +1,92 @@
+import { Fragment, type ReactNode } from "react"
+import { getBlock } from "./registry"
+
+/** Erlaubte HTML-Tags im Designer-Markup. Bewusst konservativ — alles was
+ *  Skripte/Styles einschleusen könnte (script, style, iframe, object, …) ist
+ *  NICHT dabei und wird verworfen. Layout/Text/Grafik ist erlaubt. */
+const ALLOWED_TAGS = new Set([
+  "div", "section", "article", "header", "footer", "main", "aside", "nav",
+  "h1", "h2", "h3", "h4", "h5", "h6", "p", "span", "a", "ul", "ol", "li",
+  "img", "figure", "figcaption", "blockquote", "hr", "br", "strong", "em",
+  "small", "b", "i", "button", "label",
+])
+
+/** Erlaubte Attribute. class/style für Design, href/src/alt für Inhalte.
+ *  KEINE on*-Handler (kein Fremd-JS), kein srcset-Tricks nötig fürs Proof. */
+const ALLOWED_ATTRS = new Set(["class", "style", "href", "src", "alt", "title", "id", "target", "rel"])
+
+let _key = 0
+function nextKey(): string {
+  _key += 1
+  return `t${_key}`
+}
+
+/** Wandelt einen DOM-Knoten rekursiv in React-Elemente.
+ *  - <hh-xxx/> → echter Baustein aus dem Register
+ *  - erlaubtes Tag → als React-Element mit gefilterten Attributen
+ *  - alles andere (script, unbekannt) → verworfen (nur Textinhalt bleibt) */
+function nodeToReact(node: Node): ReactNode {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return null
+  }
+  const el = node as Element
+  const tag = el.tagName.toLowerCase()
+
+  // Platzhalter: <hh-chatbox agent="buddy"/>  →  Baustein
+  if (tag.startsWith("hh-")) {
+    const blockName = tag.slice(3)
+    const block = getBlock(blockName)
+    const attrs: Record<string, string> = {}
+    for (const a of Array.from(el.attributes)) attrs[a.name] = a.value
+    if (!block) {
+      return (
+        <span key={nextKey()} className="inline-block px-2 py-1 rounded bg-rose-500/15 text-rose-300 text-xs font-mono">
+          unbekannter Baustein: &lt;{tag}/&gt;
+        </span>
+      )
+    }
+    return <Fragment key={nextKey()}>{block.render(attrs)}</Fragment>
+  }
+
+  // Nicht erlaubtes Tag (script/style/iframe/…): Inhalt behalten, Hülle weg.
+  if (!ALLOWED_TAGS.has(tag)) {
+    return <Fragment key={nextKey()}>{childrenToReact(el)}</Fragment>
+  }
+
+  // Erlaubtes Tag: Attribute filtern (class→className), Kinder rekursiv.
+  const props: Record<string, string> = { key: nextKey() }
+  for (const a of Array.from(el.attributes)) {
+    const name = a.name.toLowerCase()
+    if (name.startsWith("on")) continue // niemals Event-Handler aus Fremd-HTML
+    if (!ALLOWED_ATTRS.has(name)) continue
+    if (name === "class") props.className = a.value
+    else props[name] = a.value
+  }
+  const voidTags = new Set(["img", "hr", "br"])
+  if (voidTags.has(tag)) {
+    return createElementByTag(tag, props, null)
+  }
+  return createElementByTag(tag, props, childrenToReact(el))
+}
+
+function childrenToReact(el: Element): ReactNode[] {
+  return Array.from(el.childNodes).map((c) => nodeToReact(c))
+}
+
+/** Kleiner Tag-Dispatcher — hält den Renderer ohne dangerouslySetInnerHTML. */
+function createElementByTag(tag: string, props: Record<string, unknown>, children: ReactNode): ReactNode {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Tag = tag as any
+  return children === null ? <Tag {...props} /> : <Tag {...props}>{children}</Tag>
+}
+
+/** Parst Designer-HTML (String) zu sicheren React-Elementen mit eingesetzten
+ *  Bausteinen. Nutzt den Browser-Parser (DOMParser) — kein eigener HTML-Parser. */
+export function renderTemplate(html: string): ReactNode {
+  _key = 0
+  const doc = new DOMParser().parseFromString(html, "text/html")
+  return <>{Array.from(doc.body.childNodes).map((n) => nodeToReact(n))}</>
+}

--- a/frontend/src/features/themetemplates/_sampleTemplate.ts
+++ b/frontend/src/features/themetemplates/_sampleTemplate.ts
@@ -1,0 +1,28 @@
+/** Beispiel-Template wie es ein Designer schreiben würde. Freies HTML/CSS fürs
+ *  Aussehen, <hh-…/>-Platzhalter für die interaktiven Bausteine. Der <script>
+ *  am Ende beweist das Sanitizing: er wird NICHT ausgeführt (verworfen). */
+export const SAMPLE_TEMPLATE = `
+<section class="rounded-2xl p-6 mb-4"
+         style="background:linear-gradient(135deg,#1e1b4b,#0f172a);border:1px solid rgba(255,255,255,.08)">
+  <h2 class="text-2xl font-bold text-white mb-1">Mein Designer-Theme</h2>
+  <p class="text-indigo-200 text-sm">
+    Alles hier ist frei gestaltetes HTML/CSS. Die Kacheln unten sind Platzhalter,
+    die die App durch echte, lebende Bausteine ersetzt.
+  </p>
+</section>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+  <hh-tailscale/>
+  <hh-agentlink/>
+</div>
+
+<div class="mt-3">
+  <hh-minimax/>
+</div>
+
+<p class="text-center text-zinc-500 text-xs mt-6" style="letter-spacing:.05em">
+  ✦ vom Designer gestaltet ✦
+</p>
+
+<script>alert('dieser Code darf NIEMALS laufen')</script>
+`

--- a/frontend/src/features/themetemplates/registry.tsx
+++ b/frontend/src/features/themetemplates/registry.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react"
+import { TailscaleCard } from "@/features/system/TailscaleCard"
+import { AgentLinkCard } from "@/features/system/AgentLinkCard"
+import { MinimaxUsageCard } from "@/features/system/MinimaxUsageCard"
+
+/** Ein einsetzbarer Baustein. `render` bekommt die Attribute des Platzhalter-Tags
+ *  (z.B. <hh-chatbox agent="buddy"/> → { agent: "buddy" }) und gibt das echte
+ *  React-Element zurück. Bausteine sind self-contained: sie holen ihre Daten
+ *  selbst, brauchen keine Props von der Seite. */
+export interface SlotBlock {
+  /** Tag-Name ohne hh-Präfix, z.B. "chatbox". */
+  name: string
+  /** Menschliche Beschreibung (für Designer-Doku / Fehlermeldungen). */
+  label: string
+  render: (attrs: Record<string, string>) => ReactNode
+}
+
+/** Proof-Katalog v1 — bewusst self-contained Karten, die schon überall laufen.
+ *  Später kommen hier hh-menu, hh-chatbox, hh-videoeditor etc. dazu. */
+export const SLOT_BLOCKS: SlotBlock[] = [
+  {
+    name: "tailscale",
+    label: "Tailscale-Status",
+    render: () => <TailscaleCard />,
+  },
+  {
+    name: "agentlink",
+    label: "AgentLink-Status",
+    render: () => <AgentLinkCard />,
+  },
+  {
+    name: "minimax",
+    label: "MiniMax-Nutzung",
+    render: () => <MinimaxUsageCard />,
+  },
+]
+
+export function getBlock(name: string): SlotBlock | undefined {
+  return SLOT_BLOCKS.find((b) => b.name === name.toLowerCase())
+}


### PR DESCRIPTION
## Was
Erster Baustein des Template-Systems (**Mittelweg**): Designer schreibt freies
HTML/CSS + `<hh-…/>`-Platzhalter für interaktive Bausteine. Die App parst das
Markup, **filtert Gefährliches raus** (Scripts, `on*`-Handler, `script`/`style`/
`iframe`) und ersetzt die Platzhalter durch **echte React-Bausteine**.

Beweist das Prinzip end-to-end, bevor das große System (Theme-Ordner, Hub) gebaut wird.

## Dateien
- `registry.tsx` — Baustein-Katalog v1 (`hh-tailscale`/`hh-agentlink`/`hh-minimax`, self-contained)
- `TemplateRenderer.tsx` — Herzstück: DOMParser→React, Allowlist Tags/Attribute, **kein** `dangerouslySetInnerHTML`, **kein** Fremd-JS
- `TemplateProofPage.tsx` — Live-Editor auf Admin-Route `/template-proof`
- `_sampleTemplate.ts` — Beispiel inkl. bösem `<script>` (Sanitizing-Beweis)
- `docs/specs/theme-templates-brainstorm.md` — Anker-Doku (Mittelweg, **Sicherheitsregel 1: aktuelles Design bleibt Fallback**, Ausbaustufen, offene Fragen)

## Sicherheit
- Allowlist für Tags + Attribute, `on*`-Handler werden nie übernommen
- `script`/`style`/`iframe`/`object` verworfen (Inhalt bleibt, Hülle weg)
- Kein `dangerouslySetInnerHTML`

## Getestet
- `tsc` strict + `npm run build` grün, eslint clean, alle Dateien < 100 Zeilen
- Sanitizing-Logik isoliert **17/17**
- Browser-verifiziert: Designer-HTML + Bausteine gerendert, `<script>` **nicht** ausgeführt

## Kein Risiko
Additiv, eigene Admin-Route. **Ändert nichts am aktuellen Design.**

## Nächster Schritt (nicht in diesem PR)
Echte Chatbox als Platzhalter aus einer echten `theme/buddy.html` (Risiko zuerst),
dann Theme-Ordner + Hub.