### PR TITLE
fix(themetemplates): style-Attribut als Objekt parsen (behebt schwarze /template-proof)

### DIFF
--- a/frontend/src/features/themetemplates/TemplateBoundary.tsx
+++ b/frontend/src/features/themetemplates/TemplateBoundary.tsx
@@ -1,0 +1,19 @@
+import { Component, type ReactNode } from "react"
+
+/** Fehlergrenze fürs Template-Rendering. Bricht ein Baustein oder das Markup,
+ *  wird `fallback` gezeigt statt einer weißen/schwarzen Seite. */
+export class TemplateBoundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { failed: boolean; message: string }
+> {
+  state = { failed: false, message: "" }
+
+  static getDerivedStateFromError(err: unknown) {
+    return { failed: true, message: err instanceof Error ? err.message : String(err) }
+  }
+
+  render() {
+    if (this.state.failed) return this.props.fallback
+    return this.props.children
+  }
+}

--- a/frontend/src/features/themetemplates/TemplateProofPage.tsx
+++ b/frontend/src/features/themetemplates/TemplateProofPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { Code2, Eye } from "lucide-react"
 import { renderTemplate } from "./TemplateRenderer"
+import { TemplateBoundary } from "./TemplateBoundary"
 import { SAMPLE_TEMPLATE } from "./_sampleTemplate"
 import { SLOT_BLOCKS } from "./registry"
 
@@ -58,7 +59,16 @@ export function TemplateProofPage() {
             <Eye size={12} /> Live-Vorschau
           </div>
           <div className="flex-1 p-4 rounded-xl bg-[#0b0e16] border border-white/[8%] overflow-y-auto">
-            {renderTemplate(html)}
+            <TemplateBoundary
+              key={html}
+              fallback={
+                <div className="p-3 rounded-lg bg-rose-500/10 border border-rose-500/20 text-rose-300 text-xs">
+                  Dieses Template konnte nicht gerendert werden (fehlerhafter Baustein oder Markup).
+                </div>
+              }
+            >
+              {renderTemplate(html)}
+            </TemplateBoundary>
           </div>
         </div>
       </div>

--- a/frontend/src/features/themetemplates/TemplateRenderer.tsx
+++ b/frontend/src/features/themetemplates/TemplateRenderer.tsx
@@ -21,6 +21,26 @@ function nextKey(): string {
   return `t${_key}`
 }
 
+/** Wandelt einen CSS-style-String in ein React-Style-Objekt.
+ *  React akzeptiert kein style="…"-String, sondern {prop: value}. CSS-Property-
+ *  Namen werden zu camelCase (background-color → backgroundColor), CSS-Custom-
+ *  Properties (--hh-…) bleiben unverändert. */
+function parseStyle(css: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const decl of css.split(";")) {
+    const idx = decl.indexOf(":")
+    if (idx < 0) continue
+    const rawProp = decl.slice(0, idx).trim()
+    const value = decl.slice(idx + 1).trim()
+    if (!rawProp || !value) continue
+    const prop = rawProp.startsWith("--")
+      ? rawProp
+      : rawProp.toLowerCase().replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+    out[prop] = value
+  }
+  return out
+}
+
 /** Wandelt einen DOM-Knoten rekursiv in React-Elemente.
  *  - <hh-xxx/> → echter Baustein aus dem Register
  *  - erlaubtes Tag → als React-Element mit gefilterten Attributen
@@ -57,12 +77,13 @@ function nodeToReact(node: Node): ReactNode {
   }
 
   // Erlaubtes Tag: Attribute filtern (class→className), Kinder rekursiv.
-  const props: Record<string, string> = { key: nextKey() }
+  const props: Record<string, unknown> = { key: nextKey() }
   for (const a of Array.from(el.attributes)) {
     const name = a.name.toLowerCase()
     if (name.startsWith("on")) continue // niemals Event-Handler aus Fremd-HTML
     if (!ALLOWED_ATTRS.has(name)) continue
     if (name === "class") props.className = a.value
+    else if (name === "style") props.style = parseStyle(a.value) // React braucht ein Objekt, keinen String
     else props[name] = a.value
   }
   const voidTags = new Set(["img", "hr", "br"])

--- a/frontend/src/features/themetemplates/ThemedPage.tsx
+++ b/frontend/src/features/themetemplates/ThemedPage.tsx
@@ -1,22 +1,7 @@
-import { Component, type ReactNode } from "react"
+import type { ReactNode } from "react"
 import { getStoredThemeId, getTheme } from "@/shared/themes/registry"
 import { renderTemplate } from "./TemplateRenderer"
-
-/** Fehlergrenze: bricht das Template-Rendering (z.B. defekter Baustein), fällt
- *  die Seite auf die eingebaute React-Version zurück — Sicherheitsregel 1:
- *  das aktuelle Design geht nie verloren. */
-class TemplateBoundary extends Component<
-  { fallback: ReactNode; children: ReactNode },
-  { failed: boolean }
-> {
-  state = { failed: false }
-  static getDerivedStateFromError() {
-    return { failed: true }
-  }
-  render() {
-    return this.state.failed ? this.props.fallback : this.props.children
-  }
-}
+import { TemplateBoundary } from "./TemplateBoundary"
 
 /** Rendert für eine Route entweder das Theme-Template (falls das aktive Theme
  *  eines mitbringt) oder die eingebaute React-Seite (Fallback).


### PR DESCRIPTION
## Bug
`/template-proof` war **schwarz**, und die Buddy-Route (mit aktivem Aurora-Theme)
zeigte weiter die alte Seite statt des Templates.

## Root-Cause
Designer-HTML enthält `style="…"`-Strings (Verläufe im Buddy-Template). Der
Renderer reichte sie 1:1 als React-`style`-Prop durch — **React erwartet bei
`style` ein Objekt, keinen String**, und wirft dann einen Laufzeitfehler:
Component crasht → schwarze Seite. Die Buddy-Route fiel deshalb (korrekt, dank
Boundary) auf die eingebaute Seite zurück → „sieht aus wie vorher".

Beide Symptome = **eine** Ursache.

## Fix (an der Wurzel)
- `parseStyle(css)` — style-String → React-Style-Objekt (camelCase für CSS-Props,
  `--custom-properties` bleiben, `url()`-Werte mit Doppelpunkt robust)
- `TemplateBoundary` in eigene Datei extrahiert; `ThemedPage` nutzt sie weiter
- `TemplateProofPage` jetzt ebenfalls von `TemplateBoundary` umschlossen — ein
  kaputter Baustein zeigt eine Meldung statt die Seite zu schwärzen

## Getestet
- `tsc` + `npm run build` grün, eslint clean
- `parseStyle` **7/7** (inkl. echtem `buddy.html`-style + `url()`-Edge-Case)
- In echtem React verifiziert: style-Attribute greifen (Verlauf sichtbar), kein Render-Fehler