### PR TITLE
Template-System: restliche Grundseiten nachgezogen — Satz vollständig

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,20 +80,20 @@ export default function App() {
           {/* Agenten & Projekte leben jetzt im Settings-Hub (eine Config-Stelle). */}
           <Route path="agents" element={<Navigate to="/settings/agents" replace />} />
           <Route path="projects" element={<Navigate to="/settings/projects" replace />} />
-          <Route path="communication" element={<CommunicationPage />} />
-          <Route path="teamchat" element={<TeamchatPage />} />
-          <Route path="vms" element={<VMsPage />} />
-          <Route path="containers" element={<ContainersPage />} />
+          <Route path="communication" element={<ThemedPage route="communication" fallback={<CommunicationPage />} />} />
+          <Route path="teamchat" element={<ThemedPage route="teamchat" fallback={<TeamchatPage />} />} />
+          <Route path="vms" element={<ThemedPage route="vms" fallback={<VMsPage />} />} />
+          <Route path="containers" element={<ThemedPage route="containers" fallback={<ContainersPage />} />} />
           <Route path="containers/:id" element={<ContainerDetailPage />} />
           <Route path="butler" element={<ThemedPage route="butler" fallback={<ButlerPage />} />} />
-          <Route path="federation" element={<FederationPage />} />
-          <Route path="streaming" element={<StreamingPage />} />
-          <Route path="datamining" element={<DataminingPage />} />
+          <Route path="federation" element={<ThemedPage route="federation" fallback={<FederationPage />} />} />
+          <Route path="streaming" element={<ThemedPage route="streaming" fallback={<StreamingPage />} />} />
+          <Route path="datamining" element={<ThemedPage route="datamining" fallback={<DataminingPage />} />} />
           <Route path="memory" element={<ThemedPage route="memory" fallback={<MemoryPage />} />} />
           <Route path="llm" element={<LlmPage />} />
           <Route path="llm/catalog" element={<CatalogPage />} />
-          <Route path="mcp" element={<McpPage />} />
-          <Route path="skills" element={<SkillsPage />} />
+          <Route path="mcp" element={<ThemedPage route="mcp" fallback={<McpPage />} />} />
+          <Route path="skills" element={<ThemedPage route="skills" fallback={<SkillsPage />} />} />
           <Route path="ui-kit" element={<UiKitPage />} />
           <Route path="credentials" element={<CredentialsPage />} />
           <Route path="settings" element={<SettingsHubPage />} />
@@ -108,7 +108,7 @@ export default function App() {
           <Route path="template-proof" element={<AdminGuard><TemplateProofPage /></AdminGuard>} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="help" element={<HelpPage />} />
-          <Route path="zahnfee" element={<AdminGuard><ZahnfeePage /></AdminGuard>} />
+          <Route path="zahnfee" element={<AdminGuard><ThemedPage route="zahnfee" fallback={<ZahnfeePage />} /></AdminGuard>} />
           {appModuleRoutes.map((r) => (
             <Route key={r.path} path={r.path} element={r.element} />
           ))}

--- a/frontend/src/features/themetemplates/registry.tsx
+++ b/frontend/src/features/themetemplates/registry.tsx
@@ -9,6 +9,11 @@ import { SkillsPage } from "@/features/skills/SkillsPage"
 import { VMsPage } from "@/features/vms/VMsPage"
 import { DataminingPage } from "@/features/datamining/DataminingPage"
 import { DashboardPage } from "@/features/dashboard/DashboardPage"
+import { ContainersPage } from "@/features/containers/ContainersPage"
+import { FederationPage } from "@/features/federation/FederationPage"
+import { StreamingPage } from "@/features/streaming/StreamingPage"
+import { McpPage } from "@/features/mcp/McpPage"
+import { ZahnfeePage } from "@/features/zahnfee/ZahnfeePage"
 import { AtelierPage } from "@/modules/atelier/AtelierPage"
 import { TailscaleCard } from "@/features/system/TailscaleCard"
 import { AgentLinkCard } from "@/features/system/AgentLinkCard"
@@ -61,6 +66,11 @@ export const SLOT_BLOCKS: SlotBlock[] = [
 
   // Infrastruktur
   { name: "vms", label: "VMs", render: flowPage(VMsPage) },
+  { name: "containers", label: "Container", render: flowPage(ContainersPage) },
+  { name: "federation", label: "Föderation", render: flowPage(FederationPage) },
+  { name: "streaming", label: "Streaming", render: flowPage(StreamingPage) },
+  { name: "mcp", label: "MCP-Server", render: flowPage(McpPage) },
+  { name: "zahnfee", label: "Zahnfee", render: flowPage(ZahnfeePage) },
 
   // Kleine Status-Karten (self-contained)
   { name: "tailscale", label: "Tailscale-Status", render: () => <TailscaleCard /> },

--- a/frontend/src/themes/aurora/templates/communication.html
+++ b/frontend/src/themes/aurora/templates/communication.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#0d9488,#0f172a);border:1px solid rgba(45,212,191,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Kommunikation</h2>
+  <p class="text-zinc-300 text-sm">Nachrichten über alle Kanäle.</p>
+</section>
+
+<hh-communication/>

--- a/frontend/src/themes/aurora/templates/containers.html
+++ b/frontend/src/themes/aurora/templates/containers.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#0369a1,#0f172a);border:1px solid rgba(56,189,248,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Container</h2>
+  <p class="text-zinc-300 text-sm">Docker-Container im Blick.</p>
+</section>
+
+<hh-containers/>

--- a/frontend/src/themes/aurora/templates/datamining.html
+++ b/frontend/src/themes/aurora/templates/datamining.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#b45309,#0f172a);border:1px solid rgba(251,191,36,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Datamining</h2>
+  <p class="text-zinc-300 text-sm">Auswertung des Langzeitgedächtnisses.</p>
+</section>
+
+<hh-datamining/>

--- a/frontend/src/themes/aurora/templates/federation.html
+++ b/frontend/src/themes/aurora/templates/federation.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#155e75,#0f172a);border:1px solid rgba(45,212,191,.25)">
+  <h2 class="text-xl font-bold text-white mb-1">Föderation</h2>
+  <p class="text-zinc-300 text-sm">Verbundene HydraHive-Instanzen.</p>
+</section>
+
+<hh-federation/>

--- a/frontend/src/themes/aurora/templates/mcp.html
+++ b/frontend/src/themes/aurora/templates/mcp.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#6d28d9,#0f172a);border:1px solid rgba(167,139,250,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">MCP-Server</h2>
+  <p class="text-zinc-300 text-sm">Model-Context-Protocol-Anbindungen.</p>
+</section>
+
+<hh-mcp/>

--- a/frontend/src/themes/aurora/templates/skills.html
+++ b/frontend/src/themes/aurora/templates/skills.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#7c3aed,#0f172a);border:1px solid rgba(167,139,250,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Skills</h2>
+  <p class="text-zinc-300 text-sm">Fähigkeiten deiner Agenten.</p>
+</section>
+
+<hh-skills/>

--- a/frontend/src/themes/aurora/templates/streaming.html
+++ b/frontend/src/themes/aurora/templates/streaming.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#be123c,#0f172a);border:1px solid rgba(251,113,133,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Streaming</h2>
+  <p class="text-zinc-300 text-sm">Medien-Streaming-Dienste.</p>
+</section>
+
+<hh-streaming/>

--- a/frontend/src/themes/aurora/templates/teamchat.html
+++ b/frontend/src/themes/aurora/templates/teamchat.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#0891b2,#0f172a);border:1px solid rgba(34,211,238,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Teamchat</h2>
+  <p class="text-zinc-300 text-sm">Gemeinsamer Chat mit Agenten und Team.</p>
+</section>
+
+<hh-teamchat height="64vh"/>

--- a/frontend/src/themes/aurora/templates/vms.html
+++ b/frontend/src/themes/aurora/templates/vms.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#0e7490,#0f172a);border:1px solid rgba(45,212,191,.25)">
+  <h2 class="text-xl font-bold text-white mb-1">VMs</h2>
+  <p class="text-zinc-300 text-sm">Virtuelle Maschinen verwalten.</p>
+</section>
+
+<hh-vms/>

--- a/frontend/src/themes/aurora/templates/zahnfee.html
+++ b/frontend/src/themes/aurora/templates/zahnfee.html
@@ -1,0 +1,13 @@
+<div class="mb-4 flex items-center gap-4 rounded-2xl px-4 py-2.5"
+     style="background:linear-gradient(135deg,#0f766e22,#0f172a);border:1px solid rgba(45,212,191,.18)">
+  <span class="text-sm font-bold text-teal-200 shrink-0">HydraHive</span>
+  <hh-menu type="horizontal"/>
+</div>
+
+<section class="rounded-2xl p-5 mb-4"
+         style="background:linear-gradient(135deg,#4338ca,#0f172a);border:1px solid rgba(129,140,248,.28)">
+  <h2 class="text-xl font-bold text-white mb-1">Zahnfee</h2>
+  <p class="text-zinc-300 text-sm">Nächtliche Automatik-Läufe.</p>
+</section>
+
+<hh-zahnfee/>


### PR DESCRIPTION
## Was
Zieht die verbliebenen Haupt-Content-Seiten nach. **Jetzt hat jede Menü-Seite ein aurora-Template** — der komplette Satz ist wirklich komplett.

Baut direkt auf #253 auf.

## Neue Bausteine (`registry.tsx`, alle self-contained)
`hh-containers`, `hh-federation`, `hh-streaming`, `hh-mcp`, `hh-zahnfee`

## Neue Templates (10)
`teamchat`, `communication`, `skills`, `mcp`, `zahnfee`, `datamining`, `vms`, `containers`, `federation`, `streaming` — einheitliches Muster (Menü oben + Designer-Header + Baustein), je eigene Akzentfarbe.

## Routen (`App.tsx`)
Alle 10 über `<ThemedPage route=… fallback=…>`. `zahnfee` bleibt hinter `AdminGuard`.

## Bewusst OHNE Template
Settings/Admin-Bereich (keine Content-Seiten): `agents`, `projects` (beide `/settings/*`), `plugins`, `help`.

## Getestet
- `tsc` strict + `npm run build` grün (Generator erfasst **16 Templates**), eslint clean, keine Import-Zyklen
- **Konsistenz-Check:** jeder in Templates verwendete `<hh-…>`-Tag ist registriert (keine Waisen); alle 16 Menü-Content-Seiten haben ein Template
- **Vollständigkeits-Check:** Nav-Seiten ↔ ThemedPage-Routen abgeglichen

## Sicherheit
Rein additiv: ohne aktives Template → exakt die bisherigen Seiten (Fallback).

## Damit ist der Satz komplett
16 Content-Seiten, 21 Bausteine im Inventar, ein vollständiges Referenz-Theme zum Kopieren & Umgestalten.