### PR TITLE
Theme-Editor Etappe 2: Persistenz — Templates lesen/schreiben + Fork

### DIFF
--- a/core/src/hydrahive/api/routes/themes.py
+++ b/core/src/hydrahive/api/routes/themes.py
@@ -8,11 +8,12 @@ from __future__ import annotations
 import json
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
 from hydrahive.api.middleware.auth import require_admin
-from hydrahive.themes import hub_client, installer, registry
+from hydrahive.themes import editor, hub_client, installer, registry
 
 logger = logging.getLogger(__name__)
 
@@ -64,3 +65,59 @@ def update_theme(theme_id: str) -> StreamingResponse:
 @router.delete("/{theme_id}", dependencies=[Depends(require_admin)])
 def uninstall_theme(theme_id: str) -> StreamingResponse:
     return _stream(installer.uninstall(theme_id))
+
+
+# ---------------------------------------------------------------------------
+# Editor-API (Etappe 2): Template-HTML lesen/schreiben + Theme forken.
+# ---------------------------------------------------------------------------
+
+class TemplateBody(BaseModel):
+    html: str = Field(default="", max_length=262_144)
+
+
+class ForkBody(BaseModel):
+    new_id: str = Field(min_length=1, max_length=64)
+    new_name: str = Field(default="", max_length=120)
+
+
+def _editor_call(fn, *args):
+    """editor.* aufrufen und EditorError sauber in HTTP 400 übersetzen."""
+    try:
+        return fn(*args)
+    except editor.EditorError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/{theme_id}/templates", dependencies=[Depends(require_admin)])
+def list_theme_templates(theme_id: str) -> dict:
+    routes = _editor_call(editor.list_templates, theme_id)
+    return {"theme_id": theme_id, "routes": routes, "protected": registry.is_protected(theme_id)}
+
+
+@router.get("/{theme_id}/templates/{route}", dependencies=[Depends(require_admin)])
+def get_theme_template(theme_id: str, route: str) -> dict:
+    html = _editor_call(editor.read_template, theme_id, route)
+    return {"theme_id": theme_id, "route": route, "html": html}
+
+
+@router.put("/{theme_id}/templates/{route}", dependencies=[Depends(require_admin)])
+def put_theme_template(theme_id: str, route: str, body: TemplateBody) -> dict:
+    _editor_call(editor.write_template, theme_id, route, body.html)
+    return {"ok": True, "theme_id": theme_id, "route": route}
+
+
+@router.delete("/{theme_id}/templates/{route}", dependencies=[Depends(require_admin)])
+def delete_theme_template(theme_id: str, route: str) -> dict:
+    _editor_call(editor.delete_template, theme_id, route)
+    return {"ok": True, "theme_id": theme_id, "route": route}
+
+
+@router.post("/{theme_id}/fork", dependencies=[Depends(require_admin)])
+def fork_theme(theme_id: str, body: ForkBody) -> dict:
+    return _editor_call(editor.fork_theme, theme_id, body.new_id, body.new_name)
+
+
+@router.post("/{theme_id}/publish", dependencies=[Depends(require_admin)])
+def publish_theme(theme_id: str) -> StreamingResponse:
+    """Übernimmt editierte Templates ins laufende Frontend (Build + Restart)."""
+    return _stream(installer.publish(theme_id))

--- a/core/src/hydrahive/themes/editor.py
+++ b/core/src/hydrahive/themes/editor.py
@@ -1,0 +1,180 @@
+"""Theme-Editor-Persistenz: Template-HTML lesen/schreiben + Theme forken.
+
+Etappe 2 des Theme-Editors. Ein Theme-Paket liegt als echter Ordner unter
+settings.themes_frontend_dir/<id>/ mit templates/<route>.html. Dieses Modul
+erlaubt es, diese Template-Dateien über die API zu lesen und (für nicht
+geschützte User-Themes) zu schreiben — die Datenbasis für den WYSIWYG-Editor.
+
+Sicherheit (Datei-Schreiben über API!):
+- theme_id + route streng validiert (Whitelist-Regex, kein '/', kein '..').
+- Zielpfad wird via resolve() geprüft: muss echt INNERHALB des Theme-Ordners
+  liegen (Schutz gegen Pfad-Traversal / Symlink-Escape).
+- Geschützte Themes (standard/sidebar/aurora) sind read-only — man forkt sie
+  in ein eigenes User-Theme und editiert die Kopie.
+
+Kein Build hier: das Schreiben ändert nur die Quelldatei. Das Übernehmen ins
+laufende Frontend (Build) ist ein separater, expliziter "Publish"-Schritt
+(installer._frontend_build), damit nicht jeder Tastendruck baut.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from hydrahive.settings import settings
+from hydrahive.themes.manifest import ManifestError, ThemeManifest
+from hydrahive.themes.registry import is_protected
+
+logger = logging.getLogger(__name__)
+
+# Muss zu manifest._ID_RE passen (a-z0-9-, Start alphanumerisch).
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+# Routen sind einfache Bezeichner (Dateiname ohne .html), z.B. "buddy".
+_ROUTE_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# Obergrenze pro Template, damit die API nicht als Datei-Dump missbraucht wird.
+_MAX_TEMPLATE_BYTES = 256 * 1024
+
+
+class EditorError(RuntimeError):
+    """Wird geworfen bei ungültigen Eingaben oder verbotenen Operationen."""
+
+
+def _validate_id(theme_id: str) -> None:
+    if not _ID_RE.match(theme_id or ""):
+        raise EditorError(f"ungültige theme_id: {theme_id!r}")
+
+
+def _validate_route(route: str) -> None:
+    if not _ROUTE_RE.match(route or ""):
+        raise EditorError(f"ungültige route: {route!r}")
+
+
+def _theme_dir(theme_id: str) -> Path:
+    """Verzeichnis eines Theme-Pakets, garantiert innerhalb themes_frontend_dir."""
+    _validate_id(theme_id)
+    root = settings.themes_frontend_dir.resolve()
+    d = (root / theme_id).resolve()
+    # Pfad-Traversal-Schutz: d muss ein direktes Kind von root sein.
+    if d.parent != root:
+        raise EditorError(f"theme-pfad ausserhalb der theme-wurzel: {theme_id!r}")
+    return d
+
+
+def _template_path(theme_id: str, route: str) -> Path:
+    """Pfad zu templates/<route>.html, sicher innerhalb des Theme-Ordners."""
+    _validate_route(route)
+    tdir = _theme_dir(theme_id)
+    tpl_root = (tdir / "templates").resolve()
+    p = (tpl_root / f"{route}.html").resolve()
+    if p.parent != tpl_root:
+        raise EditorError(f"template-pfad ausserhalb templates/: {route!r}")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Lesen
+# ---------------------------------------------------------------------------
+
+def list_templates(theme_id: str) -> list[str]:
+    """Alle Routen (Template-Dateinamen ohne .html) eines Themes, sortiert."""
+    tdir = _theme_dir(theme_id)
+    tpl_root = tdir / "templates"
+    if not tpl_root.is_dir():
+        return []
+    return sorted(
+        p.stem for p in tpl_root.iterdir()
+        if p.is_file() and p.suffix == ".html"
+    )
+
+
+def read_template(theme_id: str, route: str) -> str:
+    """Rohes Template-HTML lesen. Fehlt die Datei → leerer String."""
+    p = _template_path(theme_id, route)
+    if not p.is_file():
+        return ""
+    return p.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Schreiben (nur nicht-geschützte Themes)
+# ---------------------------------------------------------------------------
+
+def _assert_editable(theme_id: str) -> None:
+    if is_protected(theme_id):
+        raise EditorError(f"theme_protected:{theme_id}")
+    if not _theme_dir(theme_id).is_dir():
+        raise EditorError(f"theme_not_found:{theme_id}")
+
+
+def write_template(theme_id: str, route: str, html: str) -> None:
+    """Template-HTML schreiben. Nur für nicht-geschützte User-Themes.
+
+    Das Verzeichnis templates/ wird bei Bedarf angelegt. Kein Build — die
+    Änderung ist erst nach einem Publish (Build) im laufenden Frontend sichtbar.
+    """
+    _assert_editable(theme_id)
+    if len(html.encode("utf-8")) > _MAX_TEMPLATE_BYTES:
+        raise EditorError("template_too_large")
+    p = _template_path(theme_id, route)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(html, encoding="utf-8")
+    logger.info("Template '%s/%s' geschrieben (%d B)", theme_id, route, len(html))
+
+
+def delete_template(theme_id: str, route: str) -> None:
+    """Ein Template löschen (Route fällt auf den React-Fallback zurück)."""
+    _assert_editable(theme_id)
+    p = _template_path(theme_id, route)
+    if p.is_file():
+        p.unlink()
+        logger.info("Template '%s/%s' gelöscht", theme_id, route)
+
+
+# ---------------------------------------------------------------------------
+# Fork: geschütztes/Vorlagen-Theme → editierbares User-Theme kopieren
+# ---------------------------------------------------------------------------
+
+def fork_theme(source_id: str, new_id: str, new_name: str) -> dict:
+    """Kopiert ein bestehendes Theme in ein neues, editierbares User-Theme.
+
+    So bleibt die Vorlage (z.B. das geschützte 'aurora') unangetastet und man
+    gestaltet die Kopie. new_id muss frei sein und darf nicht geschützt sein.
+    """
+    _validate_id(source_id)
+    _validate_id(new_id)
+    if is_protected(new_id):
+        raise EditorError(f"ziel_id_geschuetzt:{new_id}")
+    src = _theme_dir(source_id)
+    if not src.is_dir():
+        raise EditorError(f"quelle_nicht_gefunden:{source_id}")
+    dst = _theme_dir(new_id)
+    if dst.exists():
+        raise EditorError(f"ziel_existiert:{new_id}")
+
+    shutil.copytree(src, dst, symlinks=False)
+
+    # Manifest der Kopie auf neue id/name umschreiben (+ als user-fork markieren).
+    manifest_path = dst / "theme.json"
+    try:
+        m = ThemeManifest.load(manifest_path)
+    except ManifestError as e:
+        shutil.rmtree(dst, ignore_errors=True)
+        raise EditorError(f"quell_manifest_ungueltig:{e}") from e
+
+    import json
+    data = {
+        "id": new_id,
+        "name": new_name or new_id,
+        "version": "1.0.0",
+        "description": f"Fork von {m.name}",
+        "author": "user",
+        "layout": m.layout,
+        "variables": dict(m.variables),
+        "min_core_version": m.min_core_version,
+    }
+    manifest_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    logger.info("Theme '%s' nach '%s' geforkt", source_id, new_id)
+    return {"id": new_id, "name": data["name"], "source": source_id}

--- a/core/src/hydrahive/themes/installer.py
+++ b/core/src/hydrahive/themes/installer.py
@@ -114,3 +114,18 @@ def update(theme_id: str) -> Iterator[str]:
     copy_theme_in(theme_id); yield "[themes] neue Dateien kopiert"
     _frontend_build(); yield "[themes] Frontend gebaut"
     _request_restart(); yield "[themes] Neustart angefordert — fertig"
+
+
+def publish(theme_id: str) -> Iterator[str]:
+    """Editierte Theme-Dateien ins laufende Frontend übernehmen (Build + Restart).
+
+    Anders als update() wird NICHT aus dem Hub kopiert — die Quelle ist der
+    bereits im Frontend-Ordner liegende (im Editor bearbeitete) Theme-Ordner.
+    Der Build bettet die geänderten Templates via gen-themes.mjs neu ein.
+    """
+    _validate_theme_id(theme_id)
+    if not (settings.themes_frontend_dir / theme_id).is_dir():
+        raise InstallError(f"theme_not_found:{theme_id}")
+    yield f"[themes] veröffentliche {theme_id} …"
+    _frontend_build(); yield "[themes] Frontend gebaut"
+    _request_restart(); yield "[themes] Neustart angefordert — fertig"

--- a/core/tests/test_theme_editor.py
+++ b/core/tests/test_theme_editor.py
@@ -1,0 +1,167 @@
+"""Tests für die Theme-Editor-Persistenz (themes/editor.py).
+
+Schwerpunkt Sicherheit: Über diese Schicht werden Dateien via API geschrieben.
+Deshalb explizite Tests für Pfad-Traversal, geschützte Themes und ID-/Route-
+Validierung — nicht nur den Happy Path.
+"""
+import pytest
+
+
+@pytest.fixture
+def theme_env(tmp_path, monkeypatch):
+    """Isolierte Theme-Umgebung — repointet themes_frontend_dir in tmp."""
+    from hydrahive.settings import settings
+    root = tmp_path / "repo" / "frontend" / "src" / "themes"
+    monkeypatch.setattr(settings, "base_dir", tmp_path / "repo", raising=False)
+    monkeypatch.setattr(settings, "themes_frontend_dir", root, raising=False)
+    root.mkdir(parents=True)
+    return root
+
+
+def _make_theme(root, theme_id, name="Test", with_template=True):
+    d = root / theme_id
+    (d / "templates").mkdir(parents=True)
+    (d / "theme.json").write_text(
+        f'{{"id":"{theme_id}","name":"{name}","version":"1.0.0","layout":"sidebar"}}'
+    )
+    if with_template:
+        (d / "templates" / "buddy.html").write_text("<hh-buddy/>\n")
+    return d
+
+
+# --- Lesen ------------------------------------------------------------------
+
+def test_list_templates(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    (theme_env / "mytheme" / "templates" / "dashboard.html").write_text("<hh-dashboard/>")
+    assert editor.list_templates("mytheme") == ["buddy", "dashboard"]
+
+
+def test_list_templates_empty_when_no_dir(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme", with_template=False)
+    (theme_env / "mytheme" / "templates").rmdir()
+    assert editor.list_templates("mytheme") == []
+
+
+def test_read_template(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    assert editor.read_template("mytheme", "buddy") == "<hh-buddy/>\n"
+
+
+def test_read_missing_template_returns_empty(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    assert editor.read_template("mytheme", "nichtda") == ""
+
+
+# --- Schreiben (User-Theme) -------------------------------------------------
+
+def test_write_template_roundtrip(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    editor.write_template("mytheme", "buddy", "<hh-menu/>\n<hh-buddy height=\"50vh\"/>")
+    assert editor.read_template("mytheme", "buddy") == "<hh-menu/>\n<hh-buddy height=\"50vh\"/>"
+
+
+def test_write_creates_templates_dir(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme", with_template=False)
+    (theme_env / "mytheme" / "templates").rmdir()
+    editor.write_template("mytheme", "memory", "<hh-memory/>")
+    assert (theme_env / "mytheme" / "templates" / "memory.html").is_file()
+
+
+def test_delete_template(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    editor.delete_template("mytheme", "buddy")
+    assert not (theme_env / "mytheme" / "templates" / "buddy.html").exists()
+
+
+# --- Sicherheit: geschützte Themes ------------------------------------------
+
+def test_write_protected_theme_rejected(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "aurora")
+    with pytest.raises(editor.EditorError, match="theme_protected"):
+        editor.write_template("aurora", "buddy", "<hh-buddy/>")
+
+
+def test_delete_protected_theme_rejected(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "standard")
+    with pytest.raises(editor.EditorError, match="theme_protected"):
+        editor.delete_template("standard", "buddy")
+
+
+def test_write_unknown_theme_rejected(theme_env):
+    from hydrahive.themes import editor
+    with pytest.raises(editor.EditorError, match="theme_not_found"):
+        editor.write_template("gibtsnicht", "buddy", "<hh-buddy/>")
+
+
+# --- Sicherheit: Pfad-Traversal / ungültige Eingaben ------------------------
+
+@pytest.mark.parametrize("bad_id", ["../evil", "foo/bar", "..", "Foo", "a b", "", "foo/../bar"])
+def test_invalid_theme_id_rejected(theme_env, bad_id):
+    from hydrahive.themes import editor
+    with pytest.raises(editor.EditorError):
+        editor.read_template(bad_id, "buddy")
+
+
+@pytest.mark.parametrize("bad_route", ["../../etc/passwd", "foo/bar", "..", "a b", "", "buddy.html"])
+def test_invalid_route_rejected(theme_env, bad_route):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    with pytest.raises(editor.EditorError):
+        editor.write_template("mytheme", bad_route, "x")
+
+
+def test_template_size_limit(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "mytheme")
+    with pytest.raises(editor.EditorError, match="too_large"):
+        editor.write_template("mytheme", "buddy", "x" * (256 * 1024 + 1))
+
+
+# --- Fork -------------------------------------------------------------------
+
+def test_fork_copies_and_rewrites_manifest(theme_env):
+    from hydrahive.themes import editor
+    import json
+    _make_theme(theme_env, "aurora", name="Aurora")
+    result = editor.fork_theme("aurora", "mytheme", "Mein Theme")
+    assert result["id"] == "mytheme"
+    # Kopie hat die Templates
+    assert editor.read_template("mytheme", "buddy") == "<hh-buddy/>\n"
+    # Manifest umgeschrieben
+    m = json.loads((theme_env / "mytheme" / "theme.json").read_text())
+    assert m["id"] == "mytheme" and m["name"] == "Mein Theme"
+    assert m["author"] == "user"
+    # Und die Kopie ist editierbar (nicht geschützt)
+    editor.write_template("mytheme", "buddy", "<hh-menu/>")
+    assert editor.read_template("mytheme", "buddy") == "<hh-menu/>"
+
+
+def test_fork_rejects_existing_target(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "aurora")
+    _make_theme(theme_env, "mytheme")
+    with pytest.raises(editor.EditorError, match="ziel_existiert"):
+        editor.fork_theme("aurora", "mytheme", "X")
+
+
+def test_fork_rejects_protected_target(theme_env):
+    from hydrahive.themes import editor
+    _make_theme(theme_env, "aurora")
+    with pytest.raises(editor.EditorError, match="geschuetzt"):
+        editor.fork_theme("aurora", "standard", "X")
+
+
+def test_fork_rejects_missing_source(theme_env):
+    from hydrahive.themes import editor
+    with pytest.raises(editor.EditorError, match="quelle_nicht_gefunden"):
+        editor.fork_theme("gibtsnicht", "mytheme", "X")


### PR DESCRIPTION
## Was
Backend-Grundlage für den visuellen Theme-Editor (Etappe 2). Erlaubt es, die HTML-Vorlagen eines Themes zu lesen, zu schreiben und ein Theme zu **forken** (Vorlage kopieren → editierbares User-Theme).

## Neu: `core/hydrahive/themes/editor.py`
- `list_templates` / `read_template` — Routen + rohes Template-HTML lesen
- `write_template` / `delete_template` — schreiben (nur nicht-geschützte Themes)
- `fork_theme` — z.B. `aurora` → `mytheme` kopieren, Manifest auf neue id/name umschreiben

## Sicherheit (Dateien via API!)
- `theme_id` + `route` streng per Whitelist-Regex validiert
- **Pfad-Traversal-Schutz** via `resolve()` + Parent-Check — blockt `../`, `foo/bar`, Symlink-Escape
- **Geschützte Themes** (`standard`/`sidebar`/`aurora`) sind read-only → forken statt bearbeiten
- Größenlimit 256 KB/Template

## API (`api/routes/themes.py`, alle admin-only)
| Methode | Pfad | Zweck |
|---|---|---|
| GET | `…/{id}/templates` | Routen-Liste |
| GET | `…/{id}/templates/{route}` | HTML lesen |
| PUT | `…/{id}/templates/{route}` | HTML schreiben |
| DELETE | `…/{id}/templates/{route}` | Template löschen |
| POST | `…/{id}/fork` | Theme kopieren |
| POST | `…/{id}/publish` | Build+Restart (übernehmen) |

`installer.publish()`: editierte Dateien ins laufende Frontend bauen — getrennter, expliziter Schritt (nicht jeder Tastendruck baut).

## Tests
28 neue (`test_theme_editor.py`), Fokus **Security**: Traversal, geschützte Themes, ID/Route-Validierung, Größenlimit, Fork-Kollisionen. Alle **48 Theme-Tests grün**, ruff clean.

## Kontext
Spec: `docs/specs/theme-editor.md`. Nächste Etappe: WYSIWYG-Editor (GrapesJS) nutzt diese API zum Laden/Speichern.