### PR TITLE
Theme-Editor Etappe 3a: GrapesJS-Proof + deterministischer Export

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -33,3 +33,4 @@ src/modules/index.generated.ts
 src/themes/index.generated.ts
 src/themes/*/
 !src/themes/aurora/
+.npm-cache/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-markdown": "^0.12.11",
+        "@grapesjs/react": "^2.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@novnc/novnc": "^1.7.0",
         "@types/d3": "^7.4.3",
@@ -20,6 +21,7 @@
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
         "epubjs": "^0.3.93",
+        "grapesjs": "^0.22.16",
         "i18next": "^26.0.8",
         "i18next-browser-languagedetector": "^8.2.1",
         "lucide-react": "^1.11.0",
@@ -690,6 +692,23 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@grapesjs/react": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@grapesjs/react/-/react-2.0.0.tgz",
+      "integrity": "sha512-RpQhLqqr+6PjPB6bonQ4GgANfc9eoKyqa3SplLKPBoWX8OrzYUg62q5taTbyL7MTT+OzrmAHPOLyPGdqux9+Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "peerDependencies": {
+        "grapesjs": "^0.22.5",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -4806,6 +4825,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/backbone": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.15.tgz",
+      "integrity": "sha512-WWeKtYlsIMtDyLbbhkb96taJMEbfQBnuz7yw1u0pkphCOtksemoWhIXhK74VRCY9hbjnsH3rsJu2uUiFtnsEYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*",
+        "@types/underscore": "*"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -5105,6 +5134,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-4.0.1.tgz",
+      "integrity": "sha512-9a59A/tycXgYuPABcp6/3spSShn0NT2UOM4EfHvMumjYi4lJWTsK5SZWjhx3yRm9IHGCeWXdV2YfNsrWrft/CA==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5166,7 +5201,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5207,6 +5241,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/underscore": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.13.0.tgz",
+      "integrity": "sha512-L6LBgy1f0EFQZ+7uSA57+n2g/s4Qs5r06Vwrwn0/nuK1de+adz00NWaztRQ30aEqw5qOaWbPI8u2cGQ52lj6VA==",
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5764,6 +5804,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/backbone": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.1.tgz",
+      "integrity": "sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==",
+      "license": "MIT",
+      "dependencies": {
+        "underscore": ">=1.8.3"
+      }
+    },
+    "node_modules/backbone-undo": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/backbone-undo/-/backbone-undo-0.2.6.tgz",
+      "integrity": "sha512-AsfpNiljLXlk7TcffDUu3EAUq7CxWbyTNwARWrql5XTzN4vh6WzEEBZYaKK4kTTz+iW1tSzqUooaGRIwO83kWA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "backbone": ">=1.0.0",
+        "underscore": ">=1.4.4"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -6021,6 +6081,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.63.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.0.tgz",
+      "integrity": "sha512-KlLWRPggDg2rBD1Mx7/EqEhaBdy+ybBCVh/efgjBDsPpMeEu6MbTAJzIT4TuCzvmbTEgvKOGzVT6wdBTNusqrg==",
+      "license": "MIT"
+    },
+    "node_modules/codemirror-formatting": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/codemirror-formatting/-/codemirror-formatting-1.0.0.tgz",
+      "integrity": "sha512-br9yM6eJI3pJHekEnoyHaBEb1B7XxxDjju+vRyBe8QGLp5saTIXXkZ+eFCTqXSAtI8QEZDFVEX2/SOjH2sVWRQ==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -7302,6 +7374,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/grapesjs": {
+      "version": "0.22.16",
+      "resolved": "https://registry.npmjs.org/grapesjs/-/grapesjs-0.22.16.tgz",
+      "integrity": "sha512-kCfphgpC7pqJPuMYmIhMR6ueyB3+V67isdpMZOvmuGeWDMomkgzqRWOMH3matfdqIJW7LUivHZo9GeyVQAGmLw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/backbone": "1.4.15",
+        "backbone": "1.4.1",
+        "backbone-undo": "0.2.6",
+        "codemirror": "5.63.0",
+        "codemirror-formatting": "1.0.0",
+        "html-entities": "~1.4.0",
+        "promise-polyfill": "8.3.0",
+        "underscore": "1.13.8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -7416,6 +7504,12 @@
       "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
       "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -9614,6 +9708,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10819,6 +10919,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@assistant-ui/react": "^0.12.28",
     "@assistant-ui/react-markdown": "^0.12.11",
+    "@grapesjs/react": "^2.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@novnc/novnc": "^1.7.0",
     "@types/d3": "^7.4.3",
@@ -25,6 +26,7 @@
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
     "epubjs": "^0.3.93",
+    "grapesjs": "^0.22.16",
     "i18next": "^26.0.8",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.11.0",

--- a/frontend/src/features/themeeditor/exportTemplate.ts
+++ b/frontend/src/features/themeeditor/exportTemplate.ts
@@ -1,0 +1,53 @@
+/** Deterministischer GrapesJS-Export → HydraHive-Template-HTML.
+ *
+ *  GrapesJS zieht beim Import inline `style="…"` in generierte CSS-Klassen
+ *  (`.c483 { … }`, abrufbar über editor.getCss()). Unser Template-Format will
+ *  die Styles aber wieder inline am Element haben. Diese Funktion faltet die
+ *  generierten Klassen zurück in `style=""` — dadurch entspricht der Export
+ *  exakt dem handgeschriebenen Vorlagen-Format:
+ *    <hh-…/>-Bausteine + Tailwind-Klassen + inline styles.
+ *
+ *  Verifiziert im Proof (generated/gjs-proof.html): buddy.html import→export
+ *  bleibt strukturgleich, hh-Tags + Attribute + Gradients erhalten.
+ */
+
+/** Extrahiert `.cNNN { decl }`-Regeln aus dem GrapesJS-CSS in eine Map. */
+export function parseGeneratedRules(css: string): Record<string, string> {
+  const map: Record<string, string> = {}
+  css.replace(/\.(c\d+)\s*\{([^}]*)\}/g, (_m, cls: string, decl: string) => {
+    map[cls] = decl.trim().replace(/\s+/g, " ")
+    return ""
+  })
+  return map
+}
+
+/** Merged GrapesJS-HTML + generierte CSS-Klassen zu inline-style-HTML.
+ *
+ *  @param html  Ausgabe von editor.getHtml()
+ *  @param css   Ausgabe von editor.getCss()
+ *  @param doc   Document-Factory (Tests reichen ihr eigenes DOM rein)
+ */
+export function mergeInlineStyles(
+  html: string,
+  css: string,
+  parse: (h: string) => Document = (h) => new DOMParser().parseFromString(h, "text/html"),
+): string {
+  const rules = parseGeneratedRules(css)
+  const doc = parse(html)
+  doc.querySelectorAll("[class]").forEach((el) => {
+    const keep: string[] = []
+    let extra = ""
+    for (const c of (el.getAttribute("class") || "").split(/\s+/).filter(Boolean)) {
+      if (rules[c]) extra += (extra && !extra.endsWith(";") ? ";" : "") + rules[c]
+      else keep.push(c)
+    }
+    if (extra) {
+      const existing = el.getAttribute("style") || ""
+      const sep = existing && !existing.trim().endsWith(";") ? ";" : ""
+      el.setAttribute("style", (existing + sep + extra).replace(/;;+/g, ";"))
+    }
+    if (keep.length) el.setAttribute("class", keep.join(" "))
+    else el.removeAttribute("class")
+  })
+  return doc.body.innerHTML
+}


### PR DESCRIPTION
## Was
Verifiziert, dass **GrapesJS** als visueller Editor mit unseren `<hh-…/>`-Bausteinen funktioniert — **bevor** die volle Editor-Seite gebaut wird (Proof-first, wie beim Template-System).

## Deps
`grapesjs@0.22.16` + `@grapesjs/react@2.0.0` (offizieller Wrapper). 0.22.16 statt 0.23, weil der Wrapper `grapesjs@^0.22.5` als Peer verlangt — echte Kompatibilität ohne `--force`.

## Proof-Ergebnis
Headless in echtem Chromium verifiziert (`generated/gjs-proof.html`):
- `<hh-menu type="horizontal"/>` + `<hh-buddy height="62vh"/>` als GrapesJS **Custom Component Types** registriert → Import→Export erhält **Tag UND Attribute** ✅
- Bausteine erscheinen als **Palette-Blöcke** + sichtbare **Canvas-Platzhalter** ✅
- **Tailwind-Klassen** erhalten ✅
- Echtes `buddy.html` als Testinput → strukturgleicher Export ✅

## Der eine Stolperstein (gelöst)
GrapesJS zieht inline `style=""` beim Import in generierte `.cNNN`-CSS-Klassen (`getCss()`). Statt dagegen zu kämpfen: ein **kontrollierter Merge-Schritt** faltet sie zurück in inline `style=""` → Export = exakt unser handgeschriebenes Vorlagen-Format.

## Neu: `src/features/themeeditor/exportTemplate.ts`
- `parseGeneratedRules(css)` — `.cNNN{…}`-Regeln einsammeln
- `mergeInlineStyles(html, css)` — GrapesJS-Output → inline-style-Template-HTML

**Verifiziert:** `parseGeneratedRules` 5/5 (node), `mergeInlineStyles` mit echtem DOM alle Checks grün (hh-Tags+Attribute+Gradient inline, keine `cNN`-Restklassen).

## Status
tsc / eslint / build grün. **Etappe 3a abgeschlossen.**
Nächste Etappe **3b**: Editor-Seite (Palette / Canvas / Attribute-Panel) + Laden/Speichern über die Etappe-2-API (Fork → editieren → publish).