### PR TITLE
Theme-Editor Etappe 3b: WYSIWYG-Editor-Seite (GrapesJS)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from "@/features/auth/useAuthStore"
 import { LoginPage } from "@/features/auth/LoginPage"
 import { Layout } from "@/shared/Layout"
 import type { ReactElement } from "react"
+import { lazy, Suspense } from "react"
 import { moduleRoutes } from "@/modules/index.generated"
 
 interface ModuleRoute { path: string; element: ReactElement }
@@ -26,6 +27,10 @@ import { PluginsPage } from "@/features/plugins/PluginsPage"
 import { ExtensionsPage } from "@/features/extensions/ExtensionsPage"
 import { ModulesPage } from "@/features/modules/ModulesPage"
 import { ThemesPage } from "@/features/themes/ThemesPage"
+// GrapesJS ist groß (~1 MB) → nur laden wenn der Editor wirklich geöffnet wird.
+const ThemeEditorPage = lazy(() =>
+  import("@/features/themeeditor/ThemeEditorPage").then((m) => ({ default: m.ThemeEditorPage })),
+)
 import { TemplateProofPage } from "@/features/themetemplates/TemplateProofPage"
 import { ThemedPage } from "@/features/themetemplates/ThemedPage"
 import { CommunicationPage } from "@/features/communication/CommunicationPage"
@@ -105,6 +110,7 @@ export default function App() {
           <Route path="extensions" element={<AdminGuard><ExtensionsPage /></AdminGuard>} />
           <Route path="modules" element={<AdminGuard><ModulesPage /></AdminGuard>} />
           <Route path="themes" element={<AdminGuard><ThemesPage /></AdminGuard>} />
+          <Route path="theme-editor" element={<AdminGuard><Suspense fallback={<div className="p-8 text-sm text-zinc-500">Editor lädt …</div>}><ThemeEditorPage /></Suspense></AdminGuard>} />
           <Route path="template-proof" element={<AdminGuard><TemplateProofPage /></AdminGuard>} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="help" element={<HelpPage />} />

--- a/frontend/src/features/themeeditor/GrapesEditor.tsx
+++ b/frontend/src/features/themeeditor/GrapesEditor.tsx
@@ -1,0 +1,67 @@
+/** GrapesJS-Canvas als React-Komponente.
+ *
+ *  Kapselt den GrapesJS-Lifecycle: init beim Mount, destroy beim Unmount.
+ *  Nutzt GrapesJS' eingebaute Panels (Blocks links, Traits/Settings rechts),
+ *  damit wir kein eigenes Palette-/Attribut-UI bauen müssen.
+ *
+ *  - `initialHtml`  wird beim Laden in den Canvas gesetzt
+ *  - `onReady`      liefert die Editor-Instanz nach oben (für Export/Save)
+ */
+import { useEffect, useRef } from "react"
+import grapesjs, { type Editor } from "grapesjs"
+import "grapesjs/dist/css/grapes.min.css"
+import { registerHhBlocks } from "./setupEditor"
+
+interface Props {
+  initialHtml: string
+  onReady: (editor: Editor) => void
+}
+
+export function GrapesEditor({ initialHtml, onReady }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const editorRef = useRef<Editor | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const editor = grapesjs.init({
+      container: containerRef.current,
+      height: "100%",
+      width: "auto",
+      storageManager: false,
+      // Eingebaute Panels: Blocks + Settings (Traits) einblenden.
+      blockManager: { appendTo: "#hh-gjs-blocks" },
+      traitManager: { appendTo: "#hh-gjs-traits" },
+      panels: { defaults: [] },
+      // Kein Style-Manager-Sektor nötig — wir editieren Layout/Bausteine, nicht
+      // Feindesign (das kommt aus Tailwind/Theme-Variablen).
+      styleManager: { sectors: [] },
+    })
+
+    registerHhBlocks(editor)
+    editor.setComponents(initialHtml || "")
+    editorRef.current = editor
+    onReady(editor)
+
+    return () => {
+      editor.destroy()
+      editorRef.current = null
+    }
+    // Nur einmal beim Mount initialisieren; initialHtml-Wechsel via key-Prop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div className="flex h-full min-h-0 w-full">
+      <div
+        id="hh-gjs-blocks"
+        className="w-52 shrink-0 overflow-y-auto border-r border-white/10 bg-black/20"
+      />
+      <div ref={containerRef} className="min-w-0 flex-1" />
+      <div
+        id="hh-gjs-traits"
+        className="w-60 shrink-0 overflow-y-auto border-l border-white/10 bg-black/20"
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/themeeditor/ThemeEditorPage.tsx
+++ b/frontend/src/features/themeeditor/ThemeEditorPage.tsx
@@ -1,0 +1,126 @@
+/** Theme-Editor-Seite (Admin): visuell Theme-Vorlagen bauen.
+ *
+ *  Toolbar: Theme + Route wählen, Forken (geschützte Vorlage → editierbare
+ *  Kopie), Speichern (Export → Editor-API), Veröffentlichen (Build+Restart).
+ *  Darunter der GrapesJS-Canvas mit Baustein-Palette + Attribut-Panel.
+ */
+import { useState } from "react"
+import { Blocks, Save, Upload, Copy } from "lucide-react"
+import { Button, Select } from "@/shared/ui"
+import { GrapesEditor } from "./GrapesEditor"
+import { useThemeEditor } from "./useThemeEditor"
+
+export function ThemeEditorPage() {
+  const s = useThemeEditor()
+  const [forkOpen, setForkOpen] = useState(false)
+
+  return (
+    <div className="flex h-[calc(100vh-8rem)] min-h-0 flex-col gap-3">
+      <header className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <Blocks className="text-teal-400" size={20} />
+          <h1 className="text-xl font-semibold text-zinc-100">Theme-Editor</h1>
+        </div>
+
+        <Select
+          className="ml-auto w-44"
+          value={s.themeId}
+          onChange={(e) => s.setThemeId(e.target.value)}
+        >
+          {s.themes.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}{t.protected ? " (Vorlage)" : ""}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          className="w-40"
+          value={s.route}
+          onChange={(e) => s.setRoute(e.target.value)}
+          disabled={!s.routes.length}
+        >
+          {s.routes.map((r) => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </Select>
+
+        <Button variant="ghost" onClick={() => setForkOpen(true)} title="Als editierbare Kopie forken">
+          <Copy size={15} /> Kopie
+        </Button>
+        <Button
+          onClick={s.save}
+          disabled={s.busy || s.isProtected || !s.route}
+          title={s.isProtected ? "Vorlage ist schreibgeschützt — erst forken" : "Speichern"}
+        >
+          <Save size={15} /> Speichern
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={s.publish}
+          disabled={s.busy || s.isProtected}
+          title="Ins laufende Frontend übernehmen (Build + Neustart)"
+        >
+          <Upload size={15} /> Veröffentlichen
+        </Button>
+      </header>
+
+      {s.isProtected && (
+        <p className="rounded-lg bg-amber-500/10 px-3 py-1.5 text-xs text-amber-300">
+          Dies ist eine geschützte Vorlage. Zum Bearbeiten oben „Kopie" anlegen.
+        </p>
+      )}
+      {s.status && (
+        <p className="rounded-lg bg-white/5 px-3 py-1.5 text-xs text-zinc-300">{s.status}</p>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-white/10">
+        {s.route ? (
+          <GrapesEditor
+            key={`${s.themeId}:${s.route}:${s.html.length}`}
+            initialHtml={s.html}
+            onReady={s.setEditor}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-zinc-500">
+            Kein Template gewählt.
+          </div>
+        )}
+      </div>
+
+      {forkOpen && (
+        <ForkDialog
+          onClose={() => setForkOpen(false)}
+          onFork={(id, name) => { s.fork(id, name); setForkOpen(false) }}
+        />
+      )}
+    </div>
+  )
+}
+
+function ForkDialog({ onClose, onFork }: { onClose: () => void; onFork: (id: string, name: string) => void }) {
+  const [name, setName] = useState("")
+  const id = name.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "")
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+      <div className="w-80 rounded-xl border border-white/10 bg-zinc-900 p-4" onClick={(e) => e.stopPropagation()}>
+        <h2 className="mb-2 text-sm font-semibold text-zinc-100">Als Kopie forken</h2>
+        <p className="mb-3 text-xs text-zinc-400">
+          Legt ein neues, editierbares Theme aus der aktuellen Vorlage an.
+        </p>
+        <input
+          autoFocus
+          className="mb-1 w-full rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-zinc-100"
+          placeholder="Name des neuen Themes"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <p className="mb-3 text-[11px] text-zinc-500">ID: {id || "—"}</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose}>Abbrechen</Button>
+          <Button onClick={() => id && onFork(id, name)} disabled={!id}>Forken</Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/themeeditor/blocks.ts
+++ b/frontend/src/features/themeeditor/blocks.ts
@@ -1,0 +1,50 @@
+/** Baustein-Katalog für den GrapesJS-Theme-Editor.
+ *
+ *  Spiegelt das <hh-…/>-Inventar aus features/themetemplates/registry.tsx als
+ *  editierbare Bausteine. Jeder Eintrag wird im Editor zu:
+ *   - einem Custom Component Type (Import/Export erhält Tag + Attribute)
+ *   - einem Palette-Block (Drag-Quelle)
+ *   - einem sichtbaren Canvas-Platzhalter (man SIEHT den Baustein beim Bauen)
+ *
+ *  attrs = am Baustein editierbare Attribute (werden zu GrapesJS-Traits).
+ */
+export interface HhBlockDef {
+  tag: string
+  label: string
+  category: string
+  attrs: { name: string; default?: string }[]
+}
+
+export const HH_BLOCKS: HhBlockDef[] = [
+  // Navigation
+  { tag: "hh-menu", label: "Menü", category: "Navigation", attrs: [{ name: "type", default: "horizontal" }] },
+  // Seiten (Chat-artige haben eine Höhe)
+  { tag: "hh-buddy", label: "Buddy", category: "Seiten", attrs: [{ name: "height", default: "62vh" }] },
+  { tag: "hh-werkstatt", label: "Werkstatt", category: "Seiten", attrs: [{ name: "height", default: "64vh" }] },
+  { tag: "hh-teamchat", label: "Teamchat", category: "Seiten", attrs: [{ name: "height", default: "64vh" }] },
+  { tag: "hh-butler", label: "Butler", category: "Seiten", attrs: [{ name: "height", default: "64vh" }] },
+  { tag: "hh-communication", label: "Kommunikation", category: "Seiten", attrs: [] },
+  { tag: "hh-atelier", label: "Atelier", category: "Seiten", attrs: [] },
+  { tag: "hh-dashboard", label: "Dashboard", category: "Seiten", attrs: [] },
+  { tag: "hh-memory", label: "Gedächtnis", category: "Seiten", attrs: [] },
+  { tag: "hh-skills", label: "Skills", category: "Seiten", attrs: [] },
+  { tag: "hh-datamining", label: "Datamining", category: "Seiten", attrs: [] },
+  { tag: "hh-vms", label: "VMs", category: "Seiten", attrs: [] },
+  { tag: "hh-containers", label: "Container", category: "Seiten", attrs: [] },
+  { tag: "hh-federation", label: "Föderation", category: "Seiten", attrs: [] },
+  { tag: "hh-streaming", label: "Streaming", category: "Seiten", attrs: [] },
+  { tag: "hh-mcp", label: "MCP-Server", category: "Seiten", attrs: [] },
+  { tag: "hh-zahnfee", label: "Zahnfee", category: "Seiten", attrs: [] },
+  // Status-Karten
+  { tag: "hh-tailscale", label: "Tailscale", category: "Karten", attrs: [] },
+  { tag: "hh-agentlink", label: "AgentLink", category: "Karten", attrs: [] },
+  { tag: "hh-minimax", label: "Minimax-Usage", category: "Karten", attrs: [] },
+]
+
+/** Ein Attribut-String für einen Palette-Block, z.B. ' type="horizontal"'. */
+export function defaultAttrString(def: HhBlockDef): string {
+  return def.attrs
+    .filter((a) => a.default)
+    .map((a) => ` ${a.name}="${a.default}"`)
+    .join("")
+}

--- a/frontend/src/features/themeeditor/exportTemplate.ts
+++ b/frontend/src/features/themeeditor/exportTemplate.ts
@@ -1,53 +1,81 @@
 /** Deterministischer GrapesJS-Export → HydraHive-Template-HTML.
  *
- *  GrapesJS zieht beim Import inline `style="…"` in generierte CSS-Klassen
- *  (`.c483 { … }`, abrufbar über editor.getCss()). Unser Template-Format will
- *  die Styles aber wieder inline am Element haben. Diese Funktion faltet die
- *  generierten Klassen zurück in `style=""` — dadurch entspricht der Export
- *  exakt dem handgeschriebenen Vorlagen-Format:
- *    <hh-…/>-Bausteine + Tailwind-Klassen + inline styles.
+ *  GrapesJS lagert inline `style="…"` beim Import in generiertes CSS aus —
+ *  je nach Kontext als KLASSE (`.c483 { … }`) ODER als ID-Selektor
+ *  (`#iqhv { … }`, abrufbar über editor.getCss()). Unser Template-Format will
+ *  die Styles aber wieder inline am Element. Diese Funktion faltet BEIDE
+ *  Varianten zurück in `style=""` und entfernt die von GrapesJS erzeugten
+ *  id/class-Reste — dadurch entspricht der Export exakt dem handgeschriebenen
+ *  Vorlagen-Format: <hh-…/>-Bausteine + Tailwind-Klassen + inline styles.
  *
- *  Verifiziert im Proof (generated/gjs-proof.html): buddy.html import→export
- *  bleibt strukturgleich, hh-Tags + Attribute + Gradients erhalten.
+ *  Verifiziert im Editor-Roundtrip (generated/gjs-editor-verify.html) mit dem
+ *  echten registerHhBlocks: hh-Tags + Attribute + Gradient bleiben erhalten,
+ *  keine generierten id/cNN-Reste.
  */
 
-/** Extrahiert `.cNNN { decl }`-Regeln aus dem GrapesJS-CSS in eine Map. */
-export function parseGeneratedRules(css: string): Record<string, string> {
-  const map: Record<string, string> = {}
-  css.replace(/\.(c\d+)\s*\{([^}]*)\}/g, (_m, cls: string, decl: string) => {
-    map[cls] = decl.trim().replace(/\s+/g, " ")
-    return ""
-  })
-  return map
+interface GeneratedRules {
+  byClass: Record<string, string>
+  byId: Record<string, string>
 }
 
-/** Merged GrapesJS-HTML + generierte CSS-Klassen zu inline-style-HTML.
+/** Extrahiert `.cNNN{…}`- UND `#id{…}`-Regeln aus dem GrapesJS-CSS. */
+export function parseGeneratedRules(css: string): GeneratedRules {
+  const byClass: Record<string, string> = {}
+  const byId: Record<string, string> = {}
+  // Klassen: .cNNN { … }  (nur GrapesJS-generierte cNNN, nicht Tailwind)
+  css.replace(/\.(c\d+)\s*\{([^}]*)\}/g, (_m, cls: string, decl: string) => {
+    byClass[cls] = decl.trim().replace(/\s+/g, " ")
+    return ""
+  })
+  // ID-Selektoren: #id { … }
+  css.replace(/#([\w-]+)\s*\{([^}]*)\}/g, (_m, id: string, decl: string) => {
+    byId[id] = decl.trim().replace(/\s+/g, " ")
+    return ""
+  })
+  return { byClass, byId }
+}
+
+function appendStyle(el: Element, extra: string): void {
+  if (!extra) return
+  const existing = el.getAttribute("style") || ""
+  const sep = existing && !existing.trim().endsWith(";") ? ";" : ""
+  el.setAttribute("style", (existing + sep + extra).replace(/;;+/g, ";"))
+}
+
+/** Merged GrapesJS-HTML + generiertes CSS zu inline-style-HTML.
  *
  *  @param html  Ausgabe von editor.getHtml()
  *  @param css   Ausgabe von editor.getCss()
- *  @param doc   Document-Factory (Tests reichen ihr eigenes DOM rein)
+ *  @param parse Document-Factory (Tests reichen ihr eigenes DOM rein)
  */
 export function mergeInlineStyles(
   html: string,
   css: string,
   parse: (h: string) => Document = (h) => new DOMParser().parseFromString(h, "text/html"),
 ): string {
-  const rules = parseGeneratedRules(css)
+  const { byClass, byId } = parseGeneratedRules(css)
   const doc = parse(html)
+
+  // 1) Klassen-basierte Regeln (.cNNN) zurück inline, cNNN aus class entfernen.
   doc.querySelectorAll("[class]").forEach((el) => {
     const keep: string[] = []
     let extra = ""
     for (const c of (el.getAttribute("class") || "").split(/\s+/).filter(Boolean)) {
-      if (rules[c]) extra += (extra && !extra.endsWith(";") ? ";" : "") + rules[c]
+      if (byClass[c]) extra += (extra && !extra.endsWith(";") ? ";" : "") + byClass[c]
       else keep.push(c)
     }
-    if (extra) {
-      const existing = el.getAttribute("style") || ""
-      const sep = existing && !existing.trim().endsWith(";") ? ";" : ""
-      el.setAttribute("style", (existing + sep + extra).replace(/;;+/g, ";"))
-    }
+    appendStyle(el, extra)
     if (keep.length) el.setAttribute("class", keep.join(" "))
     else el.removeAttribute("class")
   })
+
+  // 2) ID-basierte Regeln (#id) zurück inline. GrapesJS-IDs sind Zufalls-
+  //    Kürzel → immer entfernen (nicht Teil unseres Template-Formats).
+  doc.querySelectorAll("[id]").forEach((el) => {
+    const id = el.getAttribute("id") || ""
+    if (byId[id]) appendStyle(el, byId[id])
+    el.removeAttribute("id")
+  })
+
   return doc.body.innerHTML
 }

--- a/frontend/src/features/themeeditor/setupEditor.ts
+++ b/frontend/src/features/themeeditor/setupEditor.ts
@@ -1,0 +1,63 @@
+/** GrapesJS-Setup für den Theme-Editor: Bausteine registrieren + Export.
+ *
+ *  Kapselt die im Proof (PR #257) verifizierte Logik:
+ *   - jeder <hh-…/> wird ein Custom Component Type → Import/Export erhält Tag
+ *     UND Attribute (statt gerendert/zerstört zu werden)
+ *   - Palette-Block je Baustein (Drag-Quelle)
+ *   - sichtbarer Canvas-Platzhalter (man sieht den Baustein beim Bauen)
+ *   - Export via mergeInlineStyles → exakt unser Vorlagen-Format
+ */
+import type { Editor } from "grapesjs"
+import { HH_BLOCKS, defaultAttrString, type HhBlockDef } from "./blocks"
+import { mergeInlineStyles } from "./exportTemplate"
+
+/** Registriert alle hh-Bausteine als Component-Types + Palette-Blöcke. */
+export function registerHhBlocks(editor: Editor): void {
+  for (const def of HH_BLOCKS) {
+    registerType(editor, def)
+    editor.BlockManager.add(def.tag, {
+      label: def.label,
+      content: `<${def.tag}${defaultAttrString(def)}/>`,
+      category: def.category,
+      media: '<svg viewBox="0 0 24 24" width="22" height="22"><rect x="3" y="3" width="18" height="18" rx="4" fill="none" stroke="currentColor" stroke-width="2"/></svg>',
+    })
+  }
+}
+
+function registerType(editor: Editor, def: HhBlockDef): void {
+  editor.DomComponents.addType(def.tag, {
+    isComponent: (el: HTMLElement) =>
+      !!el.tagName && el.tagName.toLowerCase() === def.tag,
+    model: {
+      defaults: {
+        tagName: def.tag,
+        draggable: true,
+        droppable: false,
+        // Attribute → editierbare Traits im rechten Panel:
+        traits: def.attrs.map((a) => ({ type: "text", name: a.name, label: a.name })),
+      },
+      // Export: eigener Tag mit Attributen, self-closing, kein Inhalt.
+      toHTML(this: { getAttributes: () => Record<string, string> }) {
+        const attrs = this.getAttributes()
+        const parts = Object.entries(attrs)
+          .filter(([k, v]) => v !== "" && v != null && k !== "id")
+          .map(([k, v]) => `${k}="${v}"`)
+        return `<${def.tag}${parts.length ? " " + parts.join(" ") : ""}/>`
+      },
+    },
+    view: {
+      onRender(this: { el: HTMLElement }) {
+        this.el.style.cssText =
+          "display:block;padding:16px;margin:6px 0;border:2px dashed #2dd4bf;" +
+          "border-radius:12px;background:rgba(45,212,191,.10);color:#5eead4;" +
+          "font:600 13px system-ui;text-align:center"
+        this.el.textContent = `▣ ${def.label}  (${def.tag})`
+      },
+    },
+  })
+}
+
+/** Exportiert den Editor-Inhalt als HydraHive-Template-HTML. */
+export function exportTemplateHtml(editor: Editor): string {
+  return mergeInlineStyles(editor.getHtml(), editor.getCss() || "")
+}

--- a/frontend/src/features/themeeditor/useThemeEditor.ts
+++ b/frontend/src/features/themeeditor/useThemeEditor.ts
@@ -1,0 +1,121 @@
+/** State + Aktionen für die Theme-Editor-Seite.
+ *
+ *  Hält das aktive Theme/die Route, lädt Template-HTML, speichert und
+ *  publisht über die Editor-API (Etappe 2). Die eigentliche GrapesJS-Instanz
+ *  lebt in der Komponente; dieser Hook kennt sie nur über eine Ref-Setzfunktion.
+ */
+import { useCallback, useEffect, useState } from "react"
+import type { Editor } from "grapesjs"
+import {
+  listThemes,
+  listTemplates,
+  getTemplate,
+  saveTemplate,
+  forkTheme,
+  publishTheme,
+} from "@/features/themes/api"
+import { exportTemplateHtml } from "./setupEditor"
+
+export interface EditorTheme {
+  id: string
+  name: string
+  protected: boolean
+}
+
+export function useThemeEditor() {
+  const [themes, setThemes] = useState<EditorTheme[]>([])
+  const [themeId, setThemeId] = useState<string>("")
+  const [routes, setRoutes] = useState<string[]>([])
+  const [route, setRoute] = useState<string>("")
+  const [html, setHtml] = useState<string>("")
+  const [isProtected, setIsProtected] = useState(false)
+  const [status, setStatus] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [editor, setEditor] = useState<Editor | null>(null)
+
+  // Installierte (Ordner-)Themes laden — nur die haben Templates.
+  useEffect(() => {
+    listThemes()
+      .then((idx) => {
+        const list = idx.installed
+          .filter((t) => t.loaded)
+          .map((t) => ({ id: t.id, name: t.name ?? t.id, protected: !!t.protected }))
+        setThemes(list)
+        if (list.length && !themeId) setThemeId(list[0].id)
+      })
+      .catch((e) => setStatus(String(e)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Bei Theme-Wechsel: Routen laden.
+  useEffect(() => {
+    if (!themeId) return
+    listTemplates(themeId)
+      .then((r) => {
+        setRoutes(r.routes)
+        setIsProtected(r.protected)
+        setRoute(r.routes[0] ?? "")
+      })
+      .catch((e) => setStatus(String(e)))
+  }, [themeId])
+
+  // Bei Route-Wechsel: Template-HTML laden.
+  useEffect(() => {
+    if (!themeId || !route) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setHtml("")
+      return
+    }
+    getTemplate(themeId, route)
+      .then((r) => setHtml(r.html))
+      .catch((e) => setStatus(String(e)))
+  }, [themeId, route])
+
+  const save = useCallback(async () => {
+    if (!editor || !themeId || !route) return
+    setBusy(true)
+    setStatus(null)
+    try {
+      const out = exportTemplateHtml(editor)
+      await saveTemplate(themeId, route, out)
+      setStatus(`„${route}" gespeichert.`)
+    } catch (e) {
+      setStatus(String(e))
+    }
+    setBusy(false)
+  }, [editor, themeId, route])
+
+  const fork = useCallback(async (newId: string, newName: string) => {
+    setBusy(true)
+    setStatus(null)
+    try {
+      const r = await forkTheme(themeId, newId, newName)
+      const nt = { id: r.id, name: r.name, protected: false }
+      setThemes((prev) => [...prev, nt])
+      setThemeId(r.id)
+      setStatus(`Kopie „${r.name}" angelegt — jetzt editierbar.`)
+    } catch (e) {
+      setStatus(String(e))
+    }
+    setBusy(false)
+  }, [themeId])
+
+  const publish = useCallback(() => {
+    if (!themeId) return
+    setBusy(true)
+    setStatus("Veröffentliche …")
+    publishTheme(
+      themeId,
+      (line) => setStatus(line),
+      () => { setStatus("Veröffentlicht — Neustart läuft."); setBusy(false) },
+      (msg) => { setStatus(`Fehler: ${msg}`); setBusy(false) },
+    )
+  }, [themeId])
+
+  return {
+    themes, themeId, setThemeId,
+    routes, route, setRoute,
+    html, isProtected, status, busy,
+    setEditor, save, fork, publish,
+  }
+}

--- a/frontend/src/features/themes/ThemesPage.tsx
+++ b/frontend/src/features/themes/ThemesPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
-import { Palette, RefreshCw } from "lucide-react"
+import { Palette, RefreshCw, Blocks } from "lucide-react"
 import type { ThemesIndex } from "./types"
 import { listThemes } from "./api"
 import { InstalledThemeCard, AvailableThemeCard } from "./ThemeCard"
@@ -41,6 +41,12 @@ export function ThemesPage() {
           className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors">
           <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
         </button>
+        <a
+          href="/theme-editor"
+          className="ml-1 inline-flex items-center gap-1.5 rounded-lg border border-teal-500/30 bg-teal-500/10 px-2.5 py-1.5 text-xs font-medium text-teal-300 hover:bg-teal-500/20 transition-colors"
+        >
+          <Blocks size={14} /> Theme-Editor
+        </a>
       </div>
 
       <p className="text-sm text-zinc-500 -mt-3">

--- a/frontend/src/features/themes/api.ts
+++ b/frontend/src/features/themes/api.ts
@@ -81,3 +81,45 @@ export function updateTheme(
 ): () => void {
   return stream(`/${id}/update`, "POST", onLine, onDone, onError)
 }
+
+// --- Editor-API (Etappe 2/3): Templates lesen/schreiben, forken, publishen ---
+
+export interface TemplateList {
+  theme_id: string
+  routes: string[]
+  protected: boolean
+}
+export interface TemplateContent {
+  theme_id: string
+  route: string
+  html: string
+}
+
+export function listTemplates(themeId: string): Promise<TemplateList> {
+  return api.get<TemplateList>(`${BASE}/${themeId}/templates`)
+}
+
+export function getTemplate(themeId: string, route: string): Promise<TemplateContent> {
+  return api.get<TemplateContent>(`${BASE}/${themeId}/templates/${route}`)
+}
+
+export function saveTemplate(themeId: string, route: string, html: string): Promise<unknown> {
+  return api.put(`${BASE}/${themeId}/templates/${route}`, { html })
+}
+
+export function forkTheme(
+  sourceId: string,
+  newId: string,
+  newName: string,
+): Promise<{ id: string; name: string; source: string }> {
+  return api.post(`${BASE}/${sourceId}/fork`, { new_id: newId, new_name: newName })
+}
+
+export function publishTheme(
+  id: string,
+  onLine: (line: string) => void,
+  onDone: () => void,
+  onError: (msg: string) => void,
+): () => void {
+  return stream(`/${id}/publish`, "POST", onLine, onDone, onError)
+}


### PR DESCRIPTION
## Was
Die **visuelle Editor-Seite** — Theme-Vorlagen per Drag & Drop bauen statt HTML tippen. Verbindet Backend-Persistenz (#256) + Proof-Export-Logik (#257) zur fertigen UI.

## Neu unter `features/themeeditor/`
| Datei | Zweck |
|---|---|
| `blocks.ts` | Baustein-Katalog (20 `<hh-…/>` aus dem Inventar) |
| `setupEditor.ts` | `registerHhBlocks` (Component-Types + Palette + Canvas-Platzhalter) + Export |
| `GrapesEditor.tsx` | GrapesJS-Canvas als React-Komponente (Lifecycle, eingebaute Panels) |
| `useThemeEditor.ts` | State/Aktionen: Theme+Route wählen, laden, speichern, forken, publishen |
| `ThemeEditorPage.tsx` | Toolbar + Canvas + Fork-Dialog |

## Route & Performance
- `/theme-editor` (AdminGuard), **lazy geladen** → GrapesJS (~1 MB) in eigenem Chunk statt Haupt-Bundle (`index` 2,4 → 1,4 MB)
- Zugang via „Theme-Editor"-Button auf der Themes-Seite

## API (`features/themes/api.ts`)
`listTemplates` / `getTemplate` / `saveTemplate` / `forkTheme` / `publishTheme` gegen die Etappe-2-Endpoints.

## Wichtiger Fix (durch Verifikation gefunden)
Roundtrip-Test mit dem **echten** `registerHhBlocks` deckte auf: GrapesJS lagert Styles je nach Kontext als **ID-Selektor** (`#iqhv{…}`) statt Klasse (`.cNNN{…}`) aus. Der ursprüngliche Proof sah nur den Klassen-Fall. `mergeInlineStyles` behandelt jetzt **beide** + entfernt generierte `id`/`class`-Reste.

**Verifiziert** (`generated/gjs-editor-verify.html`, echter Code, echtes Chromium): 20/20 Palette-Blöcke, `hh`-Tags + Attribute + Gradient inline erhalten, keine `id`/`cNN`-Reste.

## Workflow
Vorlage (z.B. Aurora) im Editor öffnen → „Kopie" forken → visuell bauen → Speichern → Veröffentlichen (Build+Restart).

## Status
tsc / eslint / build grün, alle Dateien < 130 Zeilen. **Damit ist der Theme-Editor funktional komplett.**