### PR TITLE
fix(health): ?key=-Query-Pfad beim Ingest entfernen (#207)

### DIFF
--- a/modules/patientenakte/backend/health_routes.py
+++ b/modules/patientenakte/backend/health_routes.py
@@ -20,7 +20,6 @@ router = APIRouter(prefix="/health-data", tags=["health"])
 def _check_key(
     x_hh_health_key: str | None,
     authorization: str | None,
-    query_key: str | None = None,
 ) -> None:
     expected = settings.health_api_key
     if not expected:
@@ -28,9 +27,11 @@ def _check_key(
     bearer = None
     if authorization and authorization.lower().startswith("bearer "):
         bearer = authorization[7:].strip()
+    # #207: Der ?key=-Query-Pfad wurde entfernt — Secrets landen sonst in
+    # Access-/Proxy-Logs und Referer-Headern. Nur Header X-HH-Health-Key oder
+    # Authorization: Bearer <key> werden akzeptiert.
     if not (verify_secret(x_hh_health_key, expected)
-            or verify_secret(bearer, expected)
-            or verify_secret(query_key, expected)):
+            or verify_secret(bearer, expected)):
         raise HTTPException(status_code=401, detail="bad_key")
 
 
@@ -40,7 +41,6 @@ async def ingest(
     request: Request,
     x_hh_health_key: Annotated[str | None, Header(alias="X-HH-Health-Key")] = None,
     authorization: Annotated[str | None, Header()] = None,
-    key: str | None = Query(default=None),
     x_automation_name: Annotated[str | None, Header(alias="automation-name")] = None,
     x_automation_id: Annotated[str | None, Header(alias="automation-id")] = None,
     x_session_id: Annotated[str | None, Header(alias="session-id")] = None,
@@ -51,16 +51,7 @@ async def ingest(
     if not allowed:
         raise HTTPException(status_code=429, detail="rate_limited",
                             headers={"Retry-After": str(retry_after)})
-    _check_key(x_hh_health_key, authorization, key)
-
-    if key is not None:
-        # #207: Key im ?key=-Query landet in Access-/Proxy-Logs. Noch akzeptiert
-        # (kein Bruch), aber der Pfad wird entfernt sobald der Client umgestellt ist.
-        logger.warning(
-            "health-ingest: Key via ?key=-Query empfangen — landet in Access-Logs. "
-            "Client bitte auf Header 'X-HH-Health-Key' umstellen; der Query-Pfad "
-            "wird danach entfernt (#207).",
-        )
+    _check_key(x_hh_health_key, authorization)
 
     # user_id kommt NICHT aus dem Request — der Key bindet an genau einen
     # konfigurierten User (Single-Device-Ingest). Verhindert Cross-User-PHI-Schreiben.

--- a/modules/patientenakte/tests/test_health_ingest_user.py
+++ b/modules/patientenakte/tests/test_health_ingest_user.py
@@ -64,40 +64,51 @@ def test_ingest_falscher_key_401(client, monkeypatch):
     assert r.status_code == 401
 
 
-# --- #207 Schritt 1: ?key=-Query loggt Deprecation, bricht aber nicht --------
+# --- #207 Schritt 2: ?key=-Query entfernt — Secret darf nicht in Access-Logs --
 
-def test_ingest_query_key_logs_deprecation_warning(client, monkeypatch, caplog):
-    import logging
-
+def test_ingest_query_key_wird_abgelehnt(client, monkeypatch):
+    """#207: Der ?key=-Query-Pfad ist entfernt. Ein Key im Query authentifiziert
+    nicht mehr → 401 (verhindert Secret-Leak in Access-/Proxy-Logs)."""
     from hydrahive.settings import settings
     monkeypatch.setattr(settings, "health_api_key", "k")
     monkeypatch.setattr(settings, "health_ingest_user", "till")
     import backend.health_routes as mod
     monkeypatch.setattr(mod.health_db, "insert", lambda **kw: "rec1")
 
-    with caplog.at_level(logging.WARNING, logger="backend.health_routes"):
-        r = client.post(
-            "/api/modules/patientenakte/health-data/ingest?key=k",
-            json={"data": {"metrics": [], "workouts": []}},
-        )
-    assert r.status_code == 200  # weiter funktionsfähig — kein Bruch
-    assert any("?key=" in rec.message for rec in caplog.records)
+    r = client.post(
+        "/api/modules/patientenakte/health-data/ingest?key=k",
+        json={"data": {"metrics": [], "workouts": []}},
+    )
+    assert r.status_code == 401
 
 
-def test_ingest_header_key_no_deprecation_warning(client, monkeypatch, caplog):
-    import logging
-
+def test_ingest_header_key_funktioniert_weiter(client, monkeypatch):
+    """#207: Der etablierte Header-Weg bleibt unverändert funktionsfähig."""
     from hydrahive.settings import settings
     monkeypatch.setattr(settings, "health_api_key", "k")
     monkeypatch.setattr(settings, "health_ingest_user", "till")
     import backend.health_routes as mod
     monkeypatch.setattr(mod.health_db, "insert", lambda **kw: "rec1")
 
-    with caplog.at_level(logging.WARNING, logger="backend.health_routes"):
-        r = client.post(
-            "/api/modules/patientenakte/health-data/ingest",
-            json={"data": {"metrics": [], "workouts": []}},
-            headers={"X-HH-Health-Key": "k"},
-        )
+    r = client.post(
+        "/api/modules/patientenakte/health-data/ingest",
+        json={"data": {"metrics": [], "workouts": []}},
+        headers={"X-HH-Health-Key": "k"},
+    )
     assert r.status_code == 200
-    assert not any("?key=" in rec.message for rec in caplog.records)
+
+
+def test_ingest_bearer_key_funktioniert_weiter(client, monkeypatch):
+    """#207: Der Bearer-Weg (Authorization-Header) bleibt als Alternative erhalten."""
+    from hydrahive.settings import settings
+    monkeypatch.setattr(settings, "health_api_key", "k")
+    monkeypatch.setattr(settings, "health_ingest_user", "till")
+    import backend.health_routes as mod
+    monkeypatch.setattr(mod.health_db, "insert", lambda **kw: "rec1")
+
+    r = client.post(
+        "/api/modules/patientenakte/health-data/ingest",
+        json={"data": {"metrics": [], "workouts": []}},
+        headers={"Authorization": "Bearer k"},
+    )
+    assert r.status_code == 200


### PR DESCRIPTION
## Was
Schließt #207. Der Health-Ingest-Endpoint akzeptierte das Secret weiterhin als `?key=`-Query-Parameter — das landet in Access-/Proxy-Logs und Referer-Headern (Secret-Leak).

Dies ist **Schritt 2** des im Code angelegten zweistufigen Plans (Schritt 1 = Deprecation-Warnung war bereits umgesetzt):
- `?key=`-Query-Pfad entfernt (Parameter + `_check_key`-Argument + Warn-Block)
- Authentifizierung nur noch über Header `X-HH-Health-Key` **oder** `Authorization: Bearer <key>`

## Warum sicher (kein Bruch)
- Kein Ingest-Traffic in den Logs → kein Live-Client betroffen
- Bestehende Tests nutzten bereits durchgängig den Header-Weg

## Test
- [x] Query-Key → **401** (neuer Test)
- [x] Header-Key → **200** (weiter funktionsfähig)
- [x] Bearer-Key → **200** (Alternative erhalten)
- [x] `pytest` health-Modul: 12 passed
- [x] `ruff`: clean

Closes #207