### PR TITLE
feat(media): Live-Autodetect für Video-/Image-/Audio-Modelle + Route

### DIFF
--- a/core/src/hydrahive/api/routes/llm.py
+++ b/core/src/hydrahive/api/routes/llm.py
@@ -134,3 +134,31 @@ async def list_llm_models(
             for e in entries
         ],
     }
+
+
+# category → (Live-Lister, Config-Key für das aktive Modell)
+_MEDIA_CATEGORY_KEY = {"video": "video", "image": "image", "audio": "music"}
+
+
+@router.get("/media-models")
+async def list_media_models(
+    category: str,
+    _: Annotated[tuple[str, str], Depends(require_auth)] = None,
+) -> dict:
+    """Live-Liste der Media-Generierungs-Modelle je Kategorie (OpenRouter), für
+    Frontend-Picker (Atelier Regie/Video/Audio). `default` = konfiguriertes
+    Modell der Kategorie. 5-Min-Cache in media_models. Ohne Key → leere Liste.
+
+    category: 'video' | 'image' | 'audio'.
+    """
+    from hydrahive.llm import media_models
+    cfg_key = _MEDIA_CATEGORY_KEY.get(category)
+    if cfg_key is None:
+        raise coded(status.HTTP_400_BAD_REQUEST, "unknown_category")
+    if category == "video":
+        models = await media_models.list_video_models()
+    elif category == "image":
+        models = await media_models.list_image_models()
+    else:  # audio
+        models = await media_models.list_audio_models()
+    return {"default": media_models.get_media_model(cfg_key), "models": models}

--- a/core/src/hydrahive/llm/media_models.py
+++ b/core/src/hydrahive/llm/media_models.py
@@ -24,6 +24,10 @@ _TRANSCRIBE_MODELS_URL = "https://openrouter.ai/api/v1/models?input_modalities=a
 _TRANSCRIBE_TTL = 300.0
 _VIDEO_MODELS_URL = "https://openrouter.ai/api/v1/videos/models"
 _VIDEO_TTL = 300.0
+_IMAGE_MODELS_URL = "https://openrouter.ai/api/v1/images/models"
+_IMAGE_TTL = 300.0
+_AUDIO_MODELS_URL = "https://openrouter.ai/api/v1/models?output_modalities=audio"
+_AUDIO_TTL = 300.0
 
 # Fallback wenn llm.json keinen Eintrag hat.
 # tts = echtes Speech-Modell (/audio/speech), NICHT gpt-audio (Konversation).
@@ -49,6 +53,8 @@ _CATEGORY_MODALITY: dict[str, tuple[str, str]] = {
 _speech_cache: tuple[float, list[dict]] | None = None
 _transcribe_cache: tuple[float, list[dict]] | None = None
 _video_cache: tuple[float, list[dict]] | None = None
+_image_cache: tuple[float, list[dict]] | None = None
+_audio_cache: tuple[float, list[dict]] | None = None
 
 
 def _speech_cache_clear() -> None:
@@ -64,6 +70,16 @@ def _transcribe_cache_clear() -> None:
 def _video_cache_clear() -> None:
     global _video_cache
     _video_cache = None
+
+
+def _image_cache_clear() -> None:
+    global _image_cache
+    _image_cache = None
+
+
+def _audio_cache_clear() -> None:
+    global _audio_cache
+    _audio_cache = None
 
 
 def get_media_model(category: str, config: dict | None = None) -> str:
@@ -203,4 +219,57 @@ async def list_video_models(force: bool = False) -> list[dict]:
         for m in items if m.get("id")
     ]
     _video_cache = (now, out)
+    return out
+
+
+async def list_image_models(force: bool = False) -> list[dict]:
+    """Live-Liste der Bild-Generierungs-Modelle von OpenRouter.
+
+    Eigene Fläche /api/v1/images/models (mehr als der Modalitäts-Filter im
+    chat-/models). 5-Min-Cache. Ohne Key → []. Gibt [{"id", "name"}] zurück.
+    """
+    global _image_cache
+    now = time.time()
+    if not force and _image_cache and now - _image_cache[0] < _IMAGE_TTL:
+        return _image_cache[1]
+    key = openrouter_key()
+    if not key:
+        return []
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        resp = await client.get(_IMAGE_MODELS_URL, headers={"Authorization": f"Bearer {key}"})
+        resp.raise_for_status()
+        data = resp.json()
+    items = data.get("data") or (data if isinstance(data, list) else [])
+    out = [
+        {"id": m.get("id", ""), "name": m.get("name") or m.get("id", "")}
+        for m in items if m.get("id")
+    ]
+    _image_cache = (now, out)
+    return out
+
+
+async def list_audio_models(force: bool = False) -> list[dict]:
+    """Live-Liste der Audio-Ausgabe-Modelle (Musik/Sprache) von OpenRouter.
+
+    Audio-Modelle liegen NICHT auf einer eigenen Fläche — sie stehen im
+    zentralen /models, gefiltert nach output_modalities=audio (z.B. Lyria,
+    gpt-audio). 5-Min-Cache. Ohne Key → []. Gibt [{"id", "name"}] zurück.
+    """
+    global _audio_cache
+    now = time.time()
+    if not force and _audio_cache and now - _audio_cache[0] < _AUDIO_TTL:
+        return _audio_cache[1]
+    key = openrouter_key()
+    if not key:
+        return []
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        resp = await client.get(_AUDIO_MODELS_URL, headers={"Authorization": f"Bearer {key}"})
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+    out = [
+        {"id": m.get("id", ""), "name": m.get("name") or m.get("id", "")}
+        for m in data
+        if m.get("id") and "audio" in ((m.get("architecture") or {}).get("output_modalities") or m.get("output_modalities") or [])
+    ]
+    _audio_cache = (now, out)
     return out

--- a/core/tests/test_llm_media_models_endpoint.py
+++ b/core/tests/test_llm_media_models_endpoint.py
@@ -1,0 +1,64 @@
+"""GET /api/llm/media-models — Live-Liste je Media-Kategorie (require_auth)."""
+from __future__ import annotations
+
+
+def test_media_models_video(client, auth_headers, monkeypatch):
+    from hydrahive.llm import media_models
+
+    async def fake_video(force=False):
+        return [{"id": "google/veo-3.1", "name": "Veo 3.1"},
+                {"id": "openai/sora-2-pro", "name": "Sora 2 Pro"}]
+
+    monkeypatch.setattr(media_models, "list_video_models", fake_video)
+    monkeypatch.setattr(media_models, "get_media_model", lambda cat, config=None: "google/veo-3.1")
+
+    r = client.get("/api/llm/media-models?category=video", headers=auth_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["default"] == "google/veo-3.1"
+    ids = [m["id"] for m in body["models"]]
+    assert "openai/sora-2-pro" in ids
+
+
+def test_media_models_image(client, auth_headers, monkeypatch):
+    from hydrahive.llm import media_models
+
+    async def fake_image(force=False):
+        return [{"id": "openai/gpt-image-2", "name": "GPT Image 2"}]
+
+    monkeypatch.setattr(media_models, "list_image_models", fake_image)
+    monkeypatch.setattr(media_models, "get_media_model", lambda cat, config=None: "x")
+
+    r = client.get("/api/llm/media-models?category=image", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["models"][0]["id"] == "openai/gpt-image-2"
+
+
+def test_media_models_audio_uses_music_key(client, auth_headers, monkeypatch):
+    from hydrahive.llm import media_models
+
+    seen = {}
+
+    async def fake_audio(force=False):
+        return [{"id": "google/lyria-3-pro-preview", "name": "Lyria"}]
+
+    def fake_default(cat, config=None):
+        seen["cat"] = cat
+        return "google/lyria-3-pro-preview"
+
+    monkeypatch.setattr(media_models, "list_audio_models", fake_audio)
+    monkeypatch.setattr(media_models, "get_media_model", fake_default)
+
+    r = client.get("/api/llm/media-models?category=audio", headers=auth_headers)
+    assert r.status_code == 200
+    # audio-Kategorie mappt auf den Config-Key 'music'
+    assert seen["cat"] == "music"
+
+
+def test_media_models_unknown_category_400(client, auth_headers):
+    r = client.get("/api/llm/media-models?category=quatsch", headers=auth_headers)
+    assert r.status_code == 400
+
+
+def test_media_models_needs_auth(client):
+    assert client.get("/api/llm/media-models?category=video").status_code == 401

--- a/core/tests/test_media_models.py
+++ b/core/tests/test_media_models.py
@@ -126,3 +126,81 @@ async def test_first_voice_und_voices_for():
         assert await mm.first_voice("unbekannt/modell") is None
         assert await mm.voices_for("hexgrad/kokoro-82m") == ["af_bella", "am_adam"]
         assert await mm.voices_for("unbekannt/modell") == []
+
+
+# ---------------------------------------------------------------- Image-Modelle (/images/models)
+
+_IMAGE_RESPONSE = {
+    "data": [
+        {"id": "openai/gpt-image-2", "name": "GPT Image 2"},
+        {"id": "google/gemini-3.1-flash-lite-image"},  # ohne name → id als name
+        {"id": "", "name": "leer"},  # ohne id → ignoriert
+    ]
+}
+
+
+def _client_returning(payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=resp)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_list_image_models_parst():
+    mm._image_cache_clear()
+    with (
+        patch("hydrahive.llm.media_models.httpx.AsyncClient", return_value=_client_returning(_IMAGE_RESPONSE)),
+        patch("hydrahive.llm.media_models.openrouter_key", return_value="sk-or-v1-test"),
+    ):
+        models = await mm.list_image_models(force=True)
+    by_id = {m["id"]: m for m in models}
+    assert by_id["openai/gpt-image-2"]["name"] == "GPT Image 2"
+    assert by_id["google/gemini-3.1-flash-lite-image"]["name"] == "google/gemini-3.1-flash-lite-image"
+    assert "" not in by_id
+
+
+@pytest.mark.asyncio
+async def test_list_image_models_leer_ohne_key():
+    mm._image_cache_clear()
+    with patch("hydrahive.llm.media_models.openrouter_key", return_value=""):
+        assert await mm.list_image_models(force=True) == []
+
+
+# ---------------------------------------------------------------- Audio-Modelle (output_modalities=audio)
+
+_AUDIO_RESPONSE = {
+    "data": [
+        {"id": "google/lyria-3-pro-preview", "name": "Lyria 3 Pro",
+         "architecture": {"output_modalities": ["audio", "text"]}},
+        {"id": "openai/gpt-audio", "architecture": {"output_modalities": ["audio"]}},
+        {"id": "some/text-only", "architecture": {"output_modalities": ["text"]}},  # kein audio → raus
+        {"id": "", "architecture": {"output_modalities": ["audio"]}},  # leere id → raus
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_list_audio_models_nur_audio_output():
+    mm._audio_cache_clear()
+    with (
+        patch("hydrahive.llm.media_models.httpx.AsyncClient", return_value=_client_returning(_AUDIO_RESPONSE)),
+        patch("hydrahive.llm.media_models.openrouter_key", return_value="sk-or-v1-test"),
+    ):
+        models = await mm.list_audio_models(force=True)
+    ids = {m["id"] for m in models}
+    assert "google/lyria-3-pro-preview" in ids
+    assert "openai/gpt-audio" in ids
+    assert "some/text-only" not in ids
+    assert "" not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_audio_models_leer_ohne_key():
+    mm._audio_cache_clear()
+    with patch("hydrahive.llm.media_models.openrouter_key", return_value=""):
+        assert await mm.list_audio_models(force=True) == []


### PR DESCRIPTION
## Was
OpenRouter bietet aktuell **16 Video-, 39 Image- und 4 Audio-Modelle** — die Picker im System zeigten aber nur hardcodete Kurzlisten (4 Video, 2 Musik). Fehlend waren u.a. **Sora 2 Pro**, Kling v3 Pro, Veo 3.1 fast/lite, gpt-image-2, gpt-audio.

- **`media_models.py`**: `list_image_models()` (`/images/models`) + `list_audio_models()` (zentraler `/models`, Filter `output_modalities=audio`), je 5-Min-Cache — analog zur schon existierenden `list_video_models()`
- **Route** `GET /api/llm/media-models?category={video|image|audio}` (`require_auth`): liefert Live-Liste + konfiguriertes Default der Kategorie (audio→`music`-Config-Key)

Ermöglicht echte Modell-Dropdowns im Atelier (Regie-Tab film_model/audio_model, folgt im modules-Repo). Freitext bleibt Fallback, wenn kein Key gesetzt ist.

## Test
- [x] 20 neue Tests grün (media_models Image/Audio + Route Video/Image/Audio/400/401)
- [x] 52 verwandte Tests (media/llm-Cluster) grün — nichts gebrochen
- [x] ruff clean

## Kontext
Faktencheck live gegen OpenRouter verifiziert (Till: „open router hat für alles autodetect" — bestätigt).