### PR TITLE
feat(media): Video-Modelle tragen durations + aspect_ratios mit

### DIFF
--- a/core/src/hydrahive/llm/media_models.py
+++ b/core/src/hydrahive/llm/media_models.py
@@ -215,7 +215,14 @@ async def list_video_models(force: bool = False) -> list[dict]:
     # OpenRouter gibt entweder {"data": [...]} oder direkt eine Liste
     items = data.get("data") or (data if isinstance(data, list) else [])
     out = [
-        {"id": m.get("id", ""), "name": m.get("name") or m.get("id", "")}
+        {
+            "id": m.get("id", ""),
+            "name": m.get("name") or m.get("id", ""),
+            # Pro-Modell erlaubte Werte — der Client darf nur diese anbieten,
+            # sonst quittiert OpenRouter mit HTTP 400.
+            "durations": m.get("supported_durations") or [],
+            "aspect_ratios": m.get("supported_aspect_ratios") or [],
+        }
         for m in items if m.get("id")
     ]
     _video_cache = (now, out)

--- a/core/tests/test_media_models.py
+++ b/core/tests/test_media_models.py
@@ -204,3 +204,30 @@ async def test_list_audio_models_leer_ohne_key():
     mm._audio_cache_clear()
     with patch("hydrahive.llm.media_models.openrouter_key", return_value=""):
         assert await mm.list_audio_models(force=True) == []
+
+
+# ---------------------------------------------------------------- Video-Modelle (/videos/models)
+
+_VIDEO_RESPONSE = {
+    "data": [
+        {"id": "google/veo-3.1", "name": "Veo 3.1",
+         "supported_durations": [4, 6, 8], "supported_aspect_ratios": ["16:9", "9:16"]},
+        {"id": "minimax/hailuo-2.3"},  # ohne Metadaten → leere Listen
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_list_video_models_traegt_durations_und_aspects():
+    mm._video_cache_clear()
+    with (
+        patch("hydrahive.llm.media_models.httpx.AsyncClient", return_value=_client_returning(_VIDEO_RESPONSE)),
+        patch("hydrahive.llm.media_models.openrouter_key", return_value="sk-or-v1-test"),
+    ):
+        models = await mm.list_video_models(force=True)
+    by_id = {m["id"]: m for m in models}
+    assert by_id["google/veo-3.1"]["durations"] == [4, 6, 8]
+    assert by_id["google/veo-3.1"]["aspect_ratios"] == ["16:9", "9:16"]
+    # ohne Metadaten → leere Listen (Client fällt auf Freitext/Defaults zurück)
+    assert by_id["minimax/hailuo-2.3"]["durations"] == []
+    assert by_id["minimax/hailuo-2.3"]["aspect_ratios"] == []


### PR DESCRIPTION
Ergänzt `list_video_models()` um `supported_durations` + `supported_aspect_ratios` je Modell. Damit kann der Atelier-Video-Picker alle 16 Modelle anbieten und pro Modell nur gültige Dauern/Formate zeigen (verhindert HTTP 400 von OpenRouter). Ohne Metadaten → leere Listen (Client-Fallback).

Folge-Arbeit zu #263. Test ergänzt (21 media-Tests grün, ruff clean).