### PR TITLE
docs(help): Deep-Dive-Hilfe für neue User — 10 Artikel + HelpButtons

### DIFF
--- a/docs/HELP-COVERAGE.md
+++ b/docs/HELP-COVERAGE.md
@@ -18,23 +18,23 @@
 | Seite | Pfad | Artikel | HelpButton | Loader-Topic | Prio |
 |-------|------|---------|-----------|--------------|------|
 | Dashboard | /dashboard | ✅ (dünn, 1.4k) | ✅ | ✅ | hoch |
-| Buddy | / | ❌ | ❌ | ❌ | **sehr hoch** (Startseite) |
+| Buddy | / | ✅ | ✅ | ✅ | **sehr hoch** (Startseite) |
 | Werkstatt | /werkstatt | 🟡 (chat.md passt teils) | ✅ (im ChatHeader) | ✅ (chat) | **sehr hoch** |
-| Agenten | /settings/agents | ✅ (3.6k) | ❌ | ✅ | hoch |
-| Projekte | /settings/projects | ✅ (3.1k) | ❌ | ✅ | hoch |
-| Communication | /communication | ❌ | ❌ | ❌ | mittel |
-| Teamchat | /teamchat | ❌ | ❌ | ❌ | mittel |
-| Butler | /butler | ❌ | ❌ | ❌ | mittel |
-| Zahnfee | /zahnfee | ❌ | ❌ | ❌ | niedrig (admin) |
-| Skills | /skills | ❌ | ❌ | ❌ | mittel |
+| Agenten | /settings/agents | ✅ (3.6k) | ✅ (Empty-State) | ✅ | hoch |
+| Projekte | /settings/projects | ✅ (3.1k) | ✅ (Empty-State) | ✅ | hoch |
+| Communication | /communication | ✅ | ✅ | ✅ | mittel |
+| Teamchat | /teamchat | ✅ | ✅ | ✅ | mittel |
+| Butler | /butler | ✅ | ✅ | ✅ | mittel |
+| Zahnfee | /zahnfee | ❌ | ❌ | ✅ | niedrig (admin) |
+| Skills | /skills | ✅ | ✅ | ✅ | mittel |
 | MCP | /mcp | ✅ (3.9k) | ✅ | ✅ | hoch |
-| Plugins | /plugins | ❌ | ❌ | ❌ | niedrig (admin) |
-| VMs | /vms | ❌ | ❌ | ❌ | mittel |
-| Container | /containers | ❌ | ❌ | ❌ | mittel |
-| Federation | /federation | ❌ | ❌ | ❌ | niedrig |
-| Streaming | /streaming | ❌ | ❌ | ❌ | niedrig |
-| Datamining | /datamining | ❌ | ❌ | ❌ | mittel |
-| Memory | /memory | ❌ | ❌ | ❌ | mittel |
+| Plugins | /plugins | ❌ | ❌ | ✅ | niedrig (admin) |
+| VMs | /vms | ❌ | ❌ | ✅ | mittel |
+| Container | /containers | ❌ | ❌ | ✅ | mittel |
+| Federation | /federation | ❌ | ❌ | ✅ | niedrig |
+| Streaming | /streaming | ❌ | ❌ | ✅ | niedrig |
+| Datamining | /datamining | ✅ | ✅ | ✅ | mittel |
+| Memory | /memory | ✅ | ✅ | ✅ | mittel |
 | System | /settings → System | ✅ (2.3k) | ✅ | ✅ | hoch |
 | LLM | /settings → LLM | ✅ (3.3k) | ✅ | ✅ | hoch |
 | Hilfe/Handbuch | /help | (Meta) | — | — | — |
@@ -42,7 +42,7 @@
 ## Settings-Hub (Zahnrad → /settings, keine eigenen Nav-Items)
 | Bereich | Artikel | Prio |
 |---------|---------|------|
-| Credentials | ❌ | hoch (Keys/Secrets — kritisch für Einstieg) |
+| Credentials | ✅ (Artikel + Button) | hoch (Keys/Secrets — kritisch für Einstieg) |
 | Extensions | ❌ | niedrig |
 | Module (Verwaltung) | ❌ | mittel |
 | Benutzer/Users | ❌ | mittel |
@@ -51,7 +51,7 @@
 ## Module (frontend/src/modules/*)
 | Modul | Pfad | Artikel | Prio |
 |-------|------|---------|------|
-| Atelier | /atelier | ❌ | mittel (groß, viel Erklärbedarf) |
+| Atelier | /atelier | ✅ (Artikel + Button, Button im modules-Repo) | mittel (groß, viel Erklärbedarf) |
 | Patientenakte | /akte | ❌ | mittel |
 | Cryptoboard | /cryptoboard | ❌ | niedrig |
 | Notizbuch | /notizbuch | ❌ | niedrig |
@@ -64,16 +64,28 @@
 | Musicplayer | /musicplayer | ❌ | niedrig |
 | Tasks | (Widget) | ❌ | niedrig |
 
-## Zusammenfassung
-- **49 Bereiche** (34 Features + 15 Module), aber nur **7 Artikel** und **5 HelpButtons**.
-- Loader kennt nur **7 Topics** → technische Erweiterung nötig, bevor neue Artikel greifen.
-- Bestehende Artikel sind teils **zu dünn** (Dashboard 1.4k) → im Deep-Dive überarbeiten.
+## Zusammenfassung (Stand: Deep-Dive-Chargen 1–5)
+- **Loader** kennt jetzt **alle** geplanten Topics (Typ + Glob) — neue Artikel greifen sofort.
+- **Neu geschrieben (de+en, ausführlich)**: onboarding, buddy, credentials, butler,
+  skills, memory, datamining, communication, teamchat, atelier → **10 neue Artikel-Paare**.
+- **HelpButtons neu**: Buddy, Credentials, Butler, Skills, Memory, Datamining,
+  Communication, Teamchat, Atelier (modules-Repo), Agenten+Projekte (Empty-State).
+- Bestehende Artikel (dashboard, agents, projects, llm, mcp, system, chat) unverändert;
+  Dashboard weiterhin dünn → Kandidat für Überarbeitung.
 
-## Fahrplan
-1. **Loader + HelpTopic-Typ** auf alle Topics erweitern (sonst 404 für neue Artikel).
-2. **Onboarding-Artikel** „Erste Schritte" — roter Faden für neue User.
-3. **Sehr hoch + hoch**: Buddy, Werkstatt, Agenten, Projekte, LLM, Credentials, Dashboard, MCP, System (überarbeiten/neu).
-4. **Mittel**: Communication, Teamchat, Butler, Skills, Datamining, Memory, VMs, Container, Module-Verwaltung, Users, Atelier, Akte.
+## Noch offen (nächste Chargen)
+- **Mittel**: VMs, Container, Module-Verwaltung, Users, Patientenakte.
+- **Dünn überarbeiten**: Dashboard.
+- **Niedrig**: Zahnfee, Plugins, Federation, Streaming, Extensions, Cryptoboard,
+  Notizbuch, Scratchpad, Deepresearch, Homeassistant, Archiver, Blueprint, Spiele.
+- **Werkstatt**: chat.md ggf. um werkstatt-spezifische Aspekte ergänzen.
+- **Phase 3**: Feld-Tooltips an unklaren Eingabefeldern.
+
+## Fahrplan (Original)
+1. ✅ **Loader + HelpTopic-Typ** auf alle Topics erweitern.
+2. ✅ **Onboarding-Artikel** „Erste Schritte".
+3. ✅ **Sehr hoch + hoch**: Buddy, Credentials (Agenten/Projekte-Buttons ergänzt; LLM/MCP/System/Dashboard bestanden schon).
+4. 🟡 **Mittel**: Communication, Teamchat, Butler, Skills, Datamining, Memory, Atelier ✅ · VMs, Container, Module-Verwaltung, Users, Akte offen.
 5. **Niedrig**: Rest.
-6. **HelpButton** überall nachrüsten.
+6. 🟡 **HelpButton** überall nachrüsten (Kern-Seiten erledigt).
 7. **Phase 3**: Feld-Tooltips an unklaren Eingabefeldern.

--- a/docs/HELP-COVERAGE.md
+++ b/docs/HELP-COVERAGE.md
@@ -1,0 +1,79 @@
+# Hilfe-Doku — Lückenliste & Fahrplan
+
+> Stand der In-App-Hilfe (HelpDrawer + `frontend/src/i18n/help/<lang>/<topic>.md`).
+> Ziel: jede Nav-Seite und jedes Modul hat (1) einen HelpButton, (2) einen
+> ausführlichen, einsteigerfreundlichen Deep-Dive-Artikel, (3) ein registriertes
+> Loader-Topic. Feld-Tooltips sind Phase 3.
+>
+> Legende: ✅ vorhanden · 🟡 dünn/unvollständig · ❌ fehlt
+
+## Technische Basis
+- Artikel: `frontend/src/i18n/help/de/<topic>.md` + `.../en/<topic>.md`
+- Loader-Typ `HelpTopic` in `frontend/src/i18n/help/loader.ts` — **muss jedes Topic kennen** (aktuell nur 7!)
+- Einbau je Seite: `<HelpButton topic="…" />` (aus `@/i18n/HelpButton`)
+- Handbuch-Übersicht: `frontend/src/i18n/locales/{de,en}/help.json` → `manual.topics`
+
+## Kern-Nav (NAV_ITEMS)
+
+| Seite | Pfad | Artikel | HelpButton | Loader-Topic | Prio |
+|-------|------|---------|-----------|--------------|------|
+| Dashboard | /dashboard | ✅ (dünn, 1.4k) | ✅ | ✅ | hoch |
+| Buddy | / | ❌ | ❌ | ❌ | **sehr hoch** (Startseite) |
+| Werkstatt | /werkstatt | 🟡 (chat.md passt teils) | ✅ (im ChatHeader) | ✅ (chat) | **sehr hoch** |
+| Agenten | /settings/agents | ✅ (3.6k) | ❌ | ✅ | hoch |
+| Projekte | /settings/projects | ✅ (3.1k) | ❌ | ✅ | hoch |
+| Communication | /communication | ❌ | ❌ | ❌ | mittel |
+| Teamchat | /teamchat | ❌ | ❌ | ❌ | mittel |
+| Butler | /butler | ❌ | ❌ | ❌ | mittel |
+| Zahnfee | /zahnfee | ❌ | ❌ | ❌ | niedrig (admin) |
+| Skills | /skills | ❌ | ❌ | ❌ | mittel |
+| MCP | /mcp | ✅ (3.9k) | ✅ | ✅ | hoch |
+| Plugins | /plugins | ❌ | ❌ | ❌ | niedrig (admin) |
+| VMs | /vms | ❌ | ❌ | ❌ | mittel |
+| Container | /containers | ❌ | ❌ | ❌ | mittel |
+| Federation | /federation | ❌ | ❌ | ❌ | niedrig |
+| Streaming | /streaming | ❌ | ❌ | ❌ | niedrig |
+| Datamining | /datamining | ❌ | ❌ | ❌ | mittel |
+| Memory | /memory | ❌ | ❌ | ❌ | mittel |
+| System | /settings → System | ✅ (2.3k) | ✅ | ✅ | hoch |
+| LLM | /settings → LLM | ✅ (3.3k) | ✅ | ✅ | hoch |
+| Hilfe/Handbuch | /help | (Meta) | — | — | — |
+
+## Settings-Hub (Zahnrad → /settings, keine eigenen Nav-Items)
+| Bereich | Artikel | Prio |
+|---------|---------|------|
+| Credentials | ❌ | hoch (Keys/Secrets — kritisch für Einstieg) |
+| Extensions | ❌ | niedrig |
+| Module (Verwaltung) | ❌ | mittel |
+| Benutzer/Users | ❌ | mittel |
+| Einstellungen (Mail, SearXNG, …) | ❌ | mittel |
+
+## Module (frontend/src/modules/*)
+| Modul | Pfad | Artikel | Prio |
+|-------|------|---------|------|
+| Atelier | /atelier | ❌ | mittel (groß, viel Erklärbedarf) |
+| Patientenakte | /akte | ❌ | mittel |
+| Cryptoboard | /cryptoboard | ❌ | niedrig |
+| Notizbuch | /notizbuch | ❌ | niedrig |
+| Scratchpad | /scratchpad | ❌ | niedrig |
+| Deepresearch | /deepresearch | ❌ | niedrig |
+| Homeassistant | /homeassistant | ❌ | niedrig |
+| Archiver | /archiver | ❌ | niedrig |
+| Blueprint | /blueprint | ❌ | niedrig |
+| Boardgames/Minigames | /boardgames, /minigames | ❌ | sehr niedrig (Spiele) |
+| Musicplayer | /musicplayer | ❌ | niedrig |
+| Tasks | (Widget) | ❌ | niedrig |
+
+## Zusammenfassung
+- **49 Bereiche** (34 Features + 15 Module), aber nur **7 Artikel** und **5 HelpButtons**.
+- Loader kennt nur **7 Topics** → technische Erweiterung nötig, bevor neue Artikel greifen.
+- Bestehende Artikel sind teils **zu dünn** (Dashboard 1.4k) → im Deep-Dive überarbeiten.
+
+## Fahrplan
+1. **Loader + HelpTopic-Typ** auf alle Topics erweitern (sonst 404 für neue Artikel).
+2. **Onboarding-Artikel** „Erste Schritte" — roter Faden für neue User.
+3. **Sehr hoch + hoch**: Buddy, Werkstatt, Agenten, Projekte, LLM, Credentials, Dashboard, MCP, System (überarbeiten/neu).
+4. **Mittel**: Communication, Teamchat, Butler, Skills, Datamining, Memory, VMs, Container, Module-Verwaltung, Users, Atelier, Akte.
+5. **Niedrig**: Rest.
+6. **HelpButton** überall nachrüsten.
+7. **Phase 3**: Feld-Tooltips an unklaren Eingabefeldern.

--- a/frontend/src/features/buddy/BuddyPage.tsx
+++ b/frontend/src/features/buddy/BuddyPage.tsx
@@ -4,6 +4,7 @@ import { Cpu, Dice5, Download, FileText, GitMerge, HelpCircle, Loader2, RotateCc
 import { useNavigate } from "react-router-dom"
 import { AssistantRuntimeProvider } from "@assistant-ui/react"
 import { MessageInput } from "@/features/chat/MessageInput"
+import { HelpButton } from "@/i18n/HelpButton"
 import { ToolConfirmBanner } from "@/features/chat/ToolConfirmBanner"
 import { useChat } from "@/features/chat/useChat"
 import { useVoiceOutput } from "@/features/chat/useVoiceOutput"
@@ -188,6 +189,7 @@ export function BuddyPage() {
                 )
               )}
               <div className="flex-1" />
+              <HelpButton topic="buddy" />
               <button
                 onClick={() => navigate("/buddy/settings")}
                 title={t("boxes.buddy_settings")}

--- a/frontend/src/features/butler/_ButlerTopBar.tsx
+++ b/frontend/src/features/butler/_ButlerTopBar.tsx
@@ -1,6 +1,7 @@
 import { Play, Plus, Save, ToggleLeft, ToggleRight, Trash2, Workflow } from "lucide-react"
 import { cn } from "@/shared/cn"
 import { useTranslation } from "react-i18next"
+import { HelpButton } from "@/i18n/HelpButton"
 import type { ButlerFlow } from "./types"
 
 interface Props {
@@ -29,6 +30,7 @@ export function ButlerTopBar({
     <div className="flex flex-wrap items-center gap-2 border-b border-white/10 px-4 py-2.5 shrink-0">
       <Workflow className="h-5 w-5 text-indigo-400 shrink-0" />
       <h1 className="text-base font-semibold text-white mr-1">Butler</h1>
+      <HelpButton topic="butler" />
       {projectId && (
         <span className="rounded-full bg-indigo-500/20 px-2.5 py-0.5 text-[11px] font-medium text-indigo-300">
           {projectId}

--- a/frontend/src/features/communication/CommunicationPage.tsx
+++ b/frontend/src/features/communication/CommunicationPage.tsx
@@ -5,6 +5,7 @@ import { MessageCircle } from "lucide-react"
 import { communicationApi } from "./api"
 import { WhatsAppCard } from "./WhatsAppCard"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { DiscordCard } from "./DiscordCard"
 
 export function CommunicationPage() {
@@ -26,6 +27,7 @@ export function CommunicationPage() {
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
           <p className="text-xs text-zinc-500 mt-0.5">{t("subtitle")}</p>
         </div>
+        <HelpButton topic="communication" />
       </div>
 
       <div className="grid grid-cols-1 gap-3">

--- a/frontend/src/features/credentials/CredentialsPage.tsx
+++ b/frontend/src/features/credentials/CredentialsPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import { Key, Loader2, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { credentialsApi } from "./api"
 import { CredentialEditor } from "./CredentialEditor"
@@ -31,9 +32,12 @@ export function CredentialsPage() {
   return (
     <div className="space-y-5 max-w-4xl">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-white">{t("title")}</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+        <div className="flex items-center gap-1">
+          <div>
+            <h1 className="text-xl font-bold text-white">{t("title")}</h1>
+            <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+          </div>
+          <HelpButton topic="credentials" />
         </div>
         {tab === "http" && (
           <button onClick={() => setEditor("new")}

--- a/frontend/src/features/datamining/DataminingPage.tsx
+++ b/frontend/src/features/datamining/DataminingPage.tsx
@@ -10,6 +10,7 @@ import { dataminingApi } from "./api"
 import { EmbedStatusBar, type EmbedStatus } from "./_EmbedStatusBar"
 import { IssueImportButtons, IssueImportForm } from "./_IssueImportForm"
 import { SourceImportButtons } from "./_SourceImportButtons"
+import { HelpButton } from "@/i18n/HelpButton"
 
 const TABS = ["feed", "search", "sessions", "stats", "graph"] as const
 type Tab = typeof TABS[number]
@@ -129,6 +130,7 @@ export function DataminingPage() {
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
           <p className="text-xs text-zinc-500 mt-0.5">{t("subtitle")}</p>
         </div>
+        <HelpButton topic="datamining" />
       </div>
 
       <div className="flex gap-1 border-b border-white/[6%]">

--- a/frontend/src/features/memory/MemoryPage.tsx
+++ b/frontend/src/features/memory/MemoryPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { BrainCircuit } from "lucide-react"
 import { CollapsibleSidebar } from "@/shared/CollapsibleSidebar"
+import { HelpButton } from "@/i18n/HelpButton"
 import { agentsApi } from "@/features/agents/api"
 import { AgentTabBar } from "@/features/agents/_AgentTabBar"
 import type { Agent } from "@/features/agents/types"
@@ -45,6 +46,7 @@ export function MemoryPage() {
               {active ? active.name : t("no_agent_selected")}
             </p>
           </div>
+          <HelpButton topic="memory" />
         </div>
 
         {active ? (

--- a/frontend/src/features/settings/detail/AgentSettings.tsx
+++ b/frontend/src/features/settings/detail/AgentSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { Loader2 } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
 import { agentsApi } from "@/features/agents/api"
 import { AgentFormTabs } from "./AgentFormTabs"
 import { llmModelsApi, type RegistryModel } from "@/features/llm/api"
@@ -39,9 +40,15 @@ export function AgentSettings({ itemId }: { itemId: string | null }) {
 
   if (!itemId) {
     return (
-      <p className="py-16 text-center text-sm text-zinc-500">
-        Rechts einen Agenten wählen, um seine Einstellungen zu bearbeiten.
-      </p>
+      <div className="flex flex-col items-center gap-2 py-16">
+        <p className="text-center text-sm text-zinc-500">
+          Rechts einen Agenten wählen, um seine Einstellungen zu bearbeiten.
+        </p>
+        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+          <span>Neu hier? Erst die Hilfe lesen:</span>
+          <HelpButton topic="agents" />
+        </div>
+      </div>
     )
   }
   if (loading || !agent) {

--- a/frontend/src/features/settings/detail/ProjectSettings.tsx
+++ b/frontend/src/features/settings/detail/ProjectSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { Loader2 } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
 import { projectsApi } from "@/features/projects/api"
 import { ProjectFormTabs } from "./ProjectFormTabs"
 import type { Project } from "@/features/projects/types"
@@ -23,9 +24,15 @@ export function ProjectSettings({ itemId }: { itemId: string | null }) {
 
   if (!itemId) {
     return (
-      <p className="py-16 text-center text-sm text-zinc-500">
-        Rechts ein Projekt wählen, um seine Einstellungen zu bearbeiten.
-      </p>
+      <div className="flex flex-col items-center gap-2 py-16">
+        <p className="text-center text-sm text-zinc-500">
+          Rechts ein Projekt wählen, um seine Einstellungen zu bearbeiten.
+        </p>
+        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+          <span>Neu hier? Erst die Hilfe lesen:</span>
+          <HelpButton topic="projects" />
+        </div>
+      </div>
     )
   }
   if (loading || !project) {

--- a/frontend/src/features/skills/SkillsPage.tsx
+++ b/frontend/src/features/skills/SkillsPage.tsx
@@ -4,6 +4,7 @@ import { Loader2, Plus, Sparkles } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { skillsApi } from "./api"
 import { SkillEditor } from "./SkillEditor"
 import type { Skill } from "./types"
@@ -30,9 +31,12 @@ export function SkillsPage() {
   return (
     <div className="space-y-5 max-w-4xl">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-white">{t("title")}</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+        <div className="flex items-center gap-1">
+          <div>
+            <h1 className="text-xl font-bold text-white">{t("title")}</h1>
+            <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+          </div>
+          <HelpButton topic="skills" />
         </div>
         <button onClick={() => setEditor("new")}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-xs font-medium">

--- a/frontend/src/features/teamchat/_RoomList.tsx
+++ b/frontend/src/features/teamchat/_RoomList.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, type CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 import { Globe, Hash, Lock, Pencil, Plus, Trash2, UserPlus, Users, X } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
 import { mxidToName } from "./_format"
 import type { RoomAgent, RoomVisibility, TeamRoom } from "./types"
 
@@ -96,10 +97,11 @@ export function RoomList(props: RoomListProps) {
         <div className="box-h">
           <span className="ic"><Hash size={14} /></span>
           <span className="t">{t("rooms")}</span>
+          <HelpButton topic="teamchat" className="r" />
           <button
             onClick={() => setAdding((v) => !v)}
             title={t("new_room")}
-            className="r p-1 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[6%] transition-all"
+            className="p-1 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[6%] transition-all"
           >
             <Plus size={14} />
           </button>

--- a/frontend/src/i18n/HelpButton.tsx
+++ b/frontend/src/i18n/HelpButton.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { HelpDrawer } from "./HelpDrawer"
 import type { HelpTopic } from "./help/loader"
 
-export function HelpButton({ topic }: { topic: HelpTopic }) {
+export function HelpButton({ topic, className = "" }: { topic: HelpTopic; className?: string }) {
   const [open, setOpen] = useState(false)
   const { t } = useTranslation("nav")
   return (
@@ -12,7 +12,7 @@ export function HelpButton({ topic }: { topic: HelpTopic }) {
       <button
         onClick={() => setOpen(true)}
         title={t("help_button")}
-        className="p-2 rounded-lg text-zinc-500 hover:text-violet-300 hover:bg-violet-500/10 transition-colors"
+        className={`${className} p-2 rounded-lg text-zinc-500 hover:text-violet-300 hover:bg-violet-500/10 transition-colors`.trim()}
       >
         <HelpCircle size={15} />
       </button>

--- a/frontend/src/i18n/help/de/atelier.md
+++ b/frontend/src/i18n/help/de/atelier.md
@@ -1,0 +1,89 @@
+# Atelier — Bilder, Videos, Audio und ganze Filme erzeugen
+
+## Was ist das?
+
+Das **Atelier** ist deine Medien-Werkstatt. Hier lässt du per KI **Bilder**,
+**Videos**, **Musik/Sprache** und sogar **ganze Kurzfilme** erzeugen — alles an
+ein **Projekt** gebunden, damit deine Werke sauber getrennt bleiben. Das
+Besondere: Über **Charaktere** und einen **Stil-Anker** bleibt der Look über viele
+Bilder hinweg **konsistent** (dieselbe Figur sieht immer gleich aus).
+
+Ganz oben wählst du das **Projekt**, in dem du arbeitest. Alle erzeugten Medien
+landen in dessen Ablage.
+
+## Die Reiter
+
+### Generieren
+Der Ausgangspunkt: Du beschreibst per **Prompt**, was entstehen soll, wählst ein
+**Modell** und Format, und erzeugst ein Bild. Wählst du eine **Figur** (Charakter)
+aus, wird deren Steckbrief automatisch in den Prompt übernommen — so bleibt sie
+wiedererkennbar.
+
+### Galerie
+Alle erzeugten **Bilder** des Projekts. Von hier aus kannst du Bilder ansehen,
+wiederverwenden (als Referenz/Startbild für Videos) oder löschen. Auch der genaue
+Prompt eines Bildes ist einsehbar und kopierbar.
+
+### Videos
+Aus einem Prompt — oder aus einem vorhandenen Bild als **Startbild** — entstehen
+kurze **Videoclips**. Pro Modell stehen unterschiedliche **Dauern** und **Formate**
+zur Verfügung (die Auswahl passt sich automatisch dem gewählten Modell an, damit
+keine ungültige Kombination entsteht). Jeder Clip zeigt Modell, Dauer, Format und
+Quelle als kleine Info-Marken.
+
+### Audio
+Erzeugt **Musik** oder **Sprache** (Voiceover) — nützlich, um Filme zu vertonen.
+
+### Regie (Drehbuch → Film)
+Der ambitionierteste Teil: Du schreibst ein **Drehbuch** (Titel, Logline,
+Beschreibung), und ein **Regie-Agent** zerlegt es in **Szenen** und **Shots**
+(einzelne Kameraeinstellungen). Zu jedem Shot lassen sich Bild und Video erzeugen,
+Schritt für Schritt bis zum fertigen Film. Kameraeinstellungen (Nahaufnahme,
+Totale, Vogelperspektive …) helfen, den Look gezielt zu steuern.
+
+## Charaktere & Stil — der Schlüssel zur Konsistenz
+
+- **Charakter (Figur)** — hat einen **Steckbrief** (Aussehen, Merkmale), der
+  **wörtlich in jeden Prompt** übernommen wird, sowie optional **Stil-Anker**,
+  **Palette** (Hex-Farben) und **Seed**. So sieht dieselbe Figur in jedem Bild
+  gleich aus.
+- **Stil-Anker** — ein fester Stilblock (z.B. *„flat vector, thick outlines"*), der
+  bei einer Bildserie gleich bleibt.
+- **Referenzbilder** — hochgeladene Vorlagen, an denen sich die Generierung
+  orientiert.
+
+## Schritt-für-Schritt: vom Bild zum Film
+
+1. Oben ein **Projekt** wählen (oder erst eins anlegen).
+2. Optional unter **Charaktere** eine Figur mit Steckbrief + Stil-Anker anlegen.
+3. Reiter **Generieren**: Prompt schreiben, Figur/Modell/Format wählen → Bild
+   erzeugen.
+4. Reiter **Videos**: aus dem Bild (Startbild) oder einem Prompt einen Clip
+   erzeugen — Dauer/Format je Modell.
+5. Reiter **Audio**: passende Musik oder ein Voiceover erzeugen.
+6. **Film schneiden**: mehrere Clips in Reihenfolge anklicken und **rendern**
+   (gemischte Formate werden eingepasst), optional Musik unterlegen.
+7. Für strukturierte Projekte: Reiter **Regie** — Drehbuch schreiben, vom
+   Regie-Agent in Szenen/Shots zerlegen lassen und abarbeiten.
+
+## Typische Fehler
+
+- **„Keine Projekte vorhanden"** — Das Atelier ist projekt-gebunden. Lege zuerst
+  unter *Projekte* eins an.
+- **Video schlägt fehl / Format abgelehnt** — Nutze die vom Modell angebotenen
+  **Dauern/Formate**; die Auswahl ist bereits auf das Modell abgestimmt.
+- **Figur sieht uneinheitlich aus** — Steckbrief zu vage. Beschreibe Aussehen
+  konkret und nutze **Stil-Anker** + **Seed** für Wiederholbarkeit.
+- **Film-Reiter leer** — Erst **Videos** erzeugen; der Film setzt vorhandene Clips
+  zusammen.
+
+## Tipps
+
+- **Erst die Figur, dann die Serie**: ein guter Charakter-Steckbrief spart später
+  viel Nachbessern.
+- **Bild als Startbild** für Videos nutzt du am besten aus der **Galerie** heraus —
+  so bleibt der Look erhalten.
+- **Prompt wiederverwenden**: Über die Prompt-Ansicht kannst du erfolgreiche
+  Prompts kopieren und leicht abgewandelt erneut nutzen.
+- **Regie für längere Geschichten**: Statt Clips einzeln zu jonglieren, gibt dir
+  der Drehbuch-Ansatz Struktur (Szenen → Shots) und einen roten Faden.

--- a/frontend/src/i18n/help/de/buddy.md
+++ b/frontend/src/i18n/help/de/buddy.md
@@ -1,0 +1,90 @@
+# Buddy — dein persönlicher Assistent
+
+## Was ist das?
+
+Buddy ist die **Startseite** von HydraHive und dein persönlicher KI-Assistent. Anders als die **Werkstatt** (wo du gezielt mit spezialisierten Agenten arbeitest) ist Buddy dein ständiger Begleiter für alles Alltägliche: Fragen stellen, Dinge notieren lassen, Aufgaben anstoßen, den Überblick behalten.
+
+Buddy hat eine **eigene, durchgehende Konversation** (eine Session), die erhalten bleibt — du kannst also jederzeit weiterreden, wo ihr aufgehört habt. Das animierte **Hydra-Maskottchen** links zeigt dir seinen Zustand: ruhig (wartet), arbeitend (denkt/nutzt Werkzeuge) oder sprechend (Sprachausgabe läuft).
+
+Buddy ist ein vollwertiger Agent: Er kann **Werkzeuge benutzen** (Dateien lesen, im Web suchen, E-Mails senden, Bilder generieren …) — welche genau, legst du in den Einstellungen fest.
+
+## Was kann ich hier tun?
+
+- **Einfach lostippen** — stell eine Frage oder gib einen Auftrag, Enter drücken. Die Antwort erscheint live.
+- **Befehle nutzen** — Nachrichten, die mit `/` beginnen, sind Kurzbefehle (siehe unten).
+- **Modell wählen** — oben der Modell-Auswähler: welches KI-Modell Buddy gerade benutzt.
+- **Projekt-Kontext setzen** — mit dem Projekt-Auswähler bindest du Buddy an ein Projekt; dann arbeiten seine Datei-Werkzeuge im Projekt-Ordner.
+- **Denk-Tiefe steuern** — die „Reasoning Effort"-Pille bestimmt, wie gründlich das Modell nachdenkt (mehr Tiefe = langsamer, aber durchdachter; nur bei Modellen, die das können).
+- **Modul-Widgets** — installierte Module blenden rechts kleine Helfer ein (z.B. Gesundheits-Box der Patientenakte), die per Klick etwas an Buddy schicken.
+- **Buddy anpassen** — über das Zahnrad kommst du zu den Buddy-Einstellungen (Name, Charakter, Werkzeuge …).
+
+## Wichtige Begriffe
+
+- **Buddy-Session** — die eine, fortlaufende Konversation mit deinem Assistenten. Sie bleibt gespeichert, bis du sie mit `/clear` frisch startest.
+- **Werkzeuge (Tools)** — Fähigkeiten, die Buddy über reines Reden hinaus hat (Web-Suche, Dateizugriff, Mail, Medien erzeugen …).
+- **Compaction** — ältere Nachrichten werden zu einer Zusammenfassung verdichtet, damit die Konversation nicht zu lang (und teuer) wird.
+- **Reasoning Effort** — Denk-Aufwand des Modells pro Antwort (minimal/niedrig/mittel/hoch).
+- **Soul / Charakter** — Buddys Persönlichkeit: Name, Ton (locker/professionell/knapp) und ein frei formulierbarer Charaktertext.
+
+## Kurzbefehle (Slash-Commands)
+
+Tippe einen dieser Befehle als Nachricht:
+
+| Befehl | Wirkung |
+|--------|---------|
+| `/help` | Zeigt diese Befehlsliste im Chat |
+| `/clear` (oder `/reset`) | Startet einen frischen Chat — die alte Session bleibt im Verlauf erhalten |
+| `/remember [name]` | Speichert den aktuellen Verlauf als dauerhafte Notiz (Memory) |
+| `/model [name]` | Zeigt das aktuelle Buddy-Modell oder wechselt es |
+| `/character` | Würfelt Buddy einen neuen Charakter |
+| `/compact` | Verdichtet die aktuelle Session manuell (spart Tokens) |
+| `/tokens` | Zeigt Token-Stand und wie voll das Kontextfenster ist |
+| `/title <text>` | Benennt die Buddy-Session um |
+| `/system` | Zeigt den aktuellen System-Prompt |
+| `/tools` | Listet die im Backend verfügbaren Werkzeuge |
+| `/agent` | Zeigt Infos zum Buddy-Agenten |
+| `/soul` | Zeigt die Bausteine von Buddys Persönlichkeit |
+| `/export` | Gibt den Verlauf als Markdown aus |
+
+## Schritt-für-Schritt
+
+### Das erste Gespräch
+
+1. Buddy ist beim Öffnen von HydraHive schon da (Startseite `/`).
+2. Tippe unten deine Nachricht — z.B. *„Fasse mir zusammen, was HydraHive kann"* — und drücke **Enter**.
+3. Beobachte, wie die Antwort live erscheint. Nutzt Buddy dabei ein Werkzeug (z.B. Web-Suche), siehst du das im Verlauf.
+
+### Buddy an ein Projekt binden
+
+1. Oben den **Projekt-Auswähler** öffnen.
+2. Ein Projekt wählen — ab jetzt arbeiten Buddys Datei-Werkzeuge im Ordner dieses Projekts.
+3. Zum Lösen der Bindung wieder auf „kein Projekt" stellen.
+
+### Buddys Persönlichkeit & Werkzeuge einstellen
+
+1. Oben rechts auf das **Zahnrad** (Buddy-Einstellungen).
+2. Tabs:
+   - **Identität** — Name, Charaktertext, Sprache (de/en/automatisch), Ton (locker/professionell/knapp).
+   - **Kontext** — was Buddy dauerhaft über dich/deine Umgebung wissen soll.
+   - **Werkzeuge** — welche Tools Buddy nutzen darf (nur aktivieren, was du wirklich brauchst).
+   - **Mail** — erscheint nur, wenn die Mail-Werkzeuge aktiv sind (Postfach-Zugang).
+   - **Compaction** — ab wann automatisch verdichtet wird.
+3. **Speichern**. Änderst du Grundlegendes an der Identität, startet Buddy ggf. eine frische Session.
+
+### Einen langen Verlauf aufräumen
+
+- Wird die Konversation sehr lang, tippe `/compact` — ältere Teile werden zusammengefasst, der rote Faden bleibt.
+- Willst du komplett neu anfangen: `/clear`. Der alte Verlauf geht nicht verloren, er rückt nur in den Hintergrund.
+
+## Typische Fragen
+
+- **„Buddy oder Werkstatt — was nehme ich?"** Buddy = dein persönlicher Alltags-Assistent (eine durchgehende Unterhaltung). Werkstatt = gezieltes Arbeiten mit mehreren spezialisierten Agenten in getrennten Sessions.
+- **„Buddy antwortet nicht / lädt ewig"** — Prüfe, ob unter **LLM-Konfiguration** ein Modell eingerichtet und ein gültiger Schlüssel hinterlegt ist. Ohne konfiguriertes Modell kann Buddy nicht denken.
+- **„Buddy kann X nicht (z.B. keine Mail senden)"** — Das Werkzeug ist wahrscheinlich nicht aktiviert. Zahnrad → **Werkzeuge** → passendes Tool einschalten.
+- **„Wie merkt sich Buddy etwas dauerhaft?"** — Mit `/remember` oder indem du es im Tab **Kontext** hinterlegst.
+
+## Tipps
+
+- **Werkzeuge sparsam aktivieren**: Je weniger, desto treffsicherer wählt Buddy das richtige. Aktiviere nur, was du regelmäßig brauchst.
+- **Reasoning Effort dosieren**: Für schnelle Fragen niedrig lassen, für knifflige Aufgaben hochdrehen.
+- **Kontext pflegen**: Was Buddy dauerhaft wissen soll (dein Name, Vorlieben, Projektumfeld), gehört in den **Kontext**-Tab — dann musst du es nicht in jeder Nachricht wiederholen.

--- a/frontend/src/i18n/help/de/butler.md
+++ b/frontend/src/i18n/help/de/butler.md
@@ -1,0 +1,95 @@
+# Butler — Automationen ohne Programmieren
+
+## Was ist das?
+
+Der **Butler** ist dein Automatisierungs-Baukasten. Du baust auf einer Fläche
+per **Ziehen und Verbinden** von Knoten eine Regel zusammen: *„Wenn X passiert,
+und Y zutrifft, dann tue Z."* Kein Code — du steckst die Bausteine wie ein
+Flussdiagramm zusammen.
+
+Beispiel: *„Wenn eine E-Mail von meinem Chef kommt (Trigger), und sie das Wort
+‚dringend' enthält (Bedingung), dann lass Agent ‚Assistent' antworten (Aktion)."*
+
+Eine solche Regel heißt **Flow**. Du kannst mehrere Flows haben, jeden einzeln
+**aktiv** oder **inaktiv** schalten.
+
+## Die drei Bausteine
+
+Ein Flow liest sich immer von links nach rechts: **Trigger → Bedingung(en) →
+Aktion(en)**. Nur der Trigger ist Pflicht — Bedingungen sind optional.
+
+### 1. Trigger (der Auslöser — „Wenn …")
+
+Womit soll es losgehen?
+
+- **Nachricht empfangen** — eine eingehende Nachricht an einen Agenten.
+- **Webhook empfangen** — ein externer Dienst ruft eine URL auf (du bekommst eine
+  Hook-URL zum Kopieren).
+- **Heartbeat ausgelöst** — zeitgesteuert/wiederkehrend (für regelmäßige Aufgaben).
+- **Git-Ereignis** — z.B. ein Push oder eine Änderung in einem Repository.
+- **Discord-Ereignis** — z.B. eine Reaktion oder Nachricht in einem Kanal.
+- **E-Mail empfangen** — eine eingehende E-Mail.
+
+### 2. Bedingungen (die Filter — „… und wenn zutrifft …")
+
+Verfeinern, wann der Flow wirklich greifen soll. Jede Bedingung hat einen
+**Ja/Nein**-Ausgang:
+
+- **Zeitfenster** / **Wochentag** — nur zu bestimmten Zeiten.
+- **Kontakt bekannt** — nur von bekannten Absendern.
+- **Nachricht enthält** / **Feld enthält** — Textfilter auf Inhalt.
+- **Git: Branch / Autor / Aktion ist …** — Filter auf Git-Ereignisse.
+- **E-Mail: Absender / Betreff / Text enthält …** — Filter auf E-Mails.
+- **Discord: Ereignis-Typ / Emoji ist …** — Filter auf Discord.
+
+### 3. Aktionen (das Ergebnis — „… dann tue …")
+
+Was soll passieren?
+
+- **Agent antworten lassen** — ein Agent bearbeitet die Nachricht frei.
+- **Agent mit Anweisung** — Agent antwortet, geführt durch deine Vorgabe.
+- **Feste Antwort** — immer derselbe vordefinierte Text.
+- **In Warteschlange** / **Ignorieren** — zur späteren Bearbeitung ablegen oder
+  verwerfen.
+- **Weiterleiten** — an einen anderen Agenten geben.
+- **HTTP POST** — eine externe URL aufrufen (mit JSON-Body).
+- **E-Mail senden**.
+- **Git: Issue anlegen / Kommentar** — im Repository etwas erzeugen.
+- **Discord posten** — Nachricht in einen Kanal schreiben.
+
+## Schritt-für-Schritt: Ersten Flow bauen
+
+1. Ziehe einen **Trigger** aus der Palette (links) auf die Fläche.
+2. Ziehe eine **Aktion** dazu und **verbinde** beide (vom Ausgangspunkt des
+   Triggers zum Eingang der Aktion ziehen).
+3. Optional: eine **Bedingung** dazwischenhängen — verbinde ihren **Ja**-Ausgang
+   mit der Aktion.
+4. Klicke einen Knoten an → rechts im **Eigenschaften-Panel** die Details setzen
+   (z.B. welcher Agent, welcher Kanal, welcher Textfilter).
+5. Gib dem Flow oben einen **Namen** und klicke **Speichern**.
+6. Teste gefahrlos mit **Probelauf**: der Flow wird mit einem Test-Ereignis
+   durchgespielt — es werden **keine echten Aktionen** ausgeführt. Du siehst, ob
+   der Trigger zutrifft und wie viele Aktionen laufen würden.
+7. Wenn alles passt: den Flow auf **Aktiv** schalten.
+
+## Typische Fehler
+
+- **„Noch nicht aktiv — kein Backend-Event-Sender vorhanden"** — Der gewählte
+  Trigger ist in deiner Installation (noch) nicht mit einer echten Ereignis-Quelle
+  verbunden. Der Flow speichert zwar, feuert aber nicht, bis die Quelle existiert.
+- **„Flow zuerst speichern, dann Probelauf"** — Probelauf geht nur mit einem
+  gespeicherten Flow.
+- **Aktion läuft nie** — Prüfe die **Verbindungen**: ist der Trigger wirklich mit
+  der Aktion verbunden? Bei Bedingungen: hängt die Aktion am **Ja**-Ausgang?
+- **Discord-Kanal fehlt** — Du brauchst die **numerische Kanal-ID** (in Discord:
+  Rechtsklick auf den Kanal → ID kopieren).
+
+## Tipps
+
+- **Erst Probelauf, dann aktiv.** Der Probelauf ist gefahrlos — nutze ihn immer,
+  bevor du scharf schaltest.
+- **Klein anfangen**: Trigger + eine Aktion. Bedingungen später ergänzen.
+- **Mehrere Flows** statt eines Riesen-Flows — pro Zweck einer, einzeln
+  ein-/ausschaltbar, viel übersichtlicher.
+- **Projekt-Kontext**: Flows gehören zum aktuellen Projekt — achte darauf, im
+  richtigen Projekt zu sein.

--- a/frontend/src/i18n/help/de/communication.md
+++ b/frontend/src/i18n/help/de/communication.md
@@ -1,0 +1,49 @@
+# Kommunikation — Messenger, die deinen Agenten erreichen
+
+## Was ist das?
+
+Auf dieser Seite verbindest du **externe Messenger** mit HydraHive, damit du
+deinen persönlichen (Master-)Agenten auch **von unterwegs** erreichst — ohne die
+Weboberfläche zu öffnen. Schreibst du z.B. auf WhatsApp, landet die Nachricht
+direkt bei deinem Agenten, und seine Antwort kommt auf demselben Weg zurück.
+
+Kurz: Dein Agent bekommt ein „Telefon", über das du ihm schreiben kannst.
+
+## Verfügbare Kanäle
+
+- **WhatsApp** — eingehende Nachrichten gehen direkt an deinen Master-Agenten.
+- **Discord** — Direktnachrichten (DMs) und **@Erwähnungen** gehen an deinen
+  Master-Agenten.
+
+(Welche Kanäle einsatzbereit sind, hängt von deiner Installation und den
+hinterlegten Zugangsdaten ab.)
+
+## Wozu ist das gut?
+
+- Du kannst deinem Agenten **von unterwegs** Aufgaben geben („Fass mir die Mails
+  zusammen", „Wie läuft der Server?").
+- Der Agent kann dich **proaktiv benachrichtigen** (z.B. über eine Butler-Automation,
+  die eine Discord-Nachricht postet).
+- Kein ständiges Einloggen im Browser nötig — der vertraute Messenger reicht.
+
+## Zusammenspiel mit anderen Bereichen
+
+- **Butler**: Die eingehenden Nachrichten können als **Trigger** für Automationen
+  dienen („Wenn Discord-Nachricht mit … → Agent antworten lassen").
+- **Credentials**: Für die Anbindung mancher Dienste werden Tokens/Zugänge
+  gebraucht — die liegen unter *Credentials* bzw. in den System-Einstellungen.
+
+## Typische Fragen
+
+- **„Meine WhatsApp-Nachricht kommt nicht an"** — Die Anbindung ist nicht
+  vollständig eingerichtet (Zugang/Token fehlt oder ist abgelaufen). Prüfe die
+  Verbindungseinstellungen des Kanals.
+- **„Discord: Agent reagiert nicht auf normale Nachrichten"** — Standardmäßig
+  reagiert er auf **DMs** und **@Erwähnungen**. Sprich ihn direkt an.
+
+## Tipps
+
+- **Fang mit einem Kanal an** (z.B. Discord), bis der Weg zuverlässig läuft, bevor
+  du weitere anbindest.
+- **Kombiniere mit Butler**, wenn du automatische Reaktionen auf eingehende
+  Nachrichten möchtest.

--- a/frontend/src/i18n/help/de/credentials.md
+++ b/frontend/src/i18n/help/de/credentials.md
@@ -1,0 +1,72 @@
+# Credentials — Zugangsdaten für Web-Zugriffe
+
+## Was ist das?
+
+Hier hinterlegst du **Zugangsdaten (Tokens, Passwörter, Schlüssel)**, die deine Agenten brauchen, um auf geschützte Webseiten oder Dienste zuzugreifen. Der Clou: Du speicherst einen Zugang **einmal** und legst per **URL-Muster** fest, wofür er gilt. Ruft ein Agent dann eine passende Adresse auf, wird der Zugang **automatisch eingehängt** — der Agent muss (und kann) das Token nicht selbst kennen.
+
+**Sicherheit (wichtig):** Tokens tauchen **niemals** im KI-Kontext oder in Tool-Ergebnissen auf. Sie werden ausschließlich beim tatsächlichen Netzwerk-Aufruf serverseitig eingesetzt und verschlüsselt gespeichert. Das Modell „sieht" dein Passwort nie.
+
+## Wozu brauche ich das?
+
+Beispiele:
+- Ein Agent soll ein **privates Forum** oder eine **API mit Token** abfragen.
+- Ein Agent soll sich per **SSH** auf einen Server verbinden (z.B. um dort Befehle auszuführen).
+- Eine Seite verlangt ein **Cookie** oder einen **Custom-Header**, um Inhalte auszuliefern.
+
+Ohne passenden Credential bekäme der Agent nur „401 Unauthorized" oder eine Login-Seite zu sehen.
+
+## Credential-Typen
+
+| Typ | Wofür | Wie es gesendet wird |
+|-----|-------|----------------------|
+| **Bearer Token** | API-Token, moderne Web-APIs | `Authorization: Bearer <wert>` |
+| **Basic Auth** | klassischer Benutzer/Passwort-Login | `Authorization: Basic <base64 von user:pass>` |
+| **Cookie** | Seiten, die Session-Cookies erwarten | `Cookie: <wert>` (z.B. `session=abc123`) |
+| **Custom Header** | eigene Header-Namen (z.B. `X-API-Key`) | dein Header-Name + Wert |
+| **Query Parameter** | Token, das an die URL angehängt wird | `…?<param>=<wert>` |
+| **SSH-Key** | SSH-Zugriff auf einen Server | privater Schlüssel + Host + User |
+
+## Felder erklärt
+
+- **Name** — frei wählbar (nur `a-z`, `0-9`, `_`, `-`), damit du den Zugang wiedererkennst.
+- **Typ** — einer der oben genannten. Je nach Typ erscheinen passende Zusatzfelder.
+- **Wert** — das eigentliche Geheimnis (Token, `user:passwort`, Cookie-String …).
+- **URL-Pattern** — bestimmt, für welche Adressen der Zugang gilt. Ein **Glob-Muster**:
+  - `*` = für **alle** URLs (mit Vorsicht nutzen!)
+  - `https://forum.example.de/*` = nur für diesen Host und alles darunter
+- **Header-Name** / **Query-Param-Name** — nur bei den Typen „Custom Header" bzw. „Query Parameter": wie das Feld heißen soll.
+- **Beschreibung** — optionale Notiz für dich.
+
+### Für SSH-Keys zusätzlich
+- **Private Key (PEM)** — dein privater Schlüssel im OpenSSH- oder PEM-Format. Wird verschlüsselt gespeichert und **nie** an das Modell weitergegeben.
+- **Hostname / IP** — der Server, auf den zugegriffen werden soll.
+- **SSH-Username** — der Login-Name auf dem Server.
+
+## Schritt-für-Schritt
+
+### Ein API-Token hinterlegen (Bearer)
+
+1. **Neuer Credential** klicken.
+2. **Name** vergeben (z.B. `github-api`).
+3. **Typ** = Bearer Token.
+4. **Wert** = dein Token einfügen.
+5. **URL-Pattern** = z.B. `https://api.github.com/*`.
+6. Speichern. Ab jetzt hängt sich das Token bei Aufrufen dieser API automatisch ein.
+
+### Einen SSH-Zugang anlegen
+
+1. **Neuer Credential** → **Typ** = SSH-Key.
+2. **Private Key** einfügen (PEM/OpenSSH), **Host** und **Username** setzen.
+3. Speichern. Der Agent kann sich nun per SSH mit diesem Host verbinden, ohne den Schlüssel zu kennen.
+
+## Typische Fehler
+
+- **Agent bekommt weiter 401/Login-Seite** — Das **URL-Pattern** passt nicht auf die tatsächlich aufgerufene Adresse. Prüfe Schreibweise und `*`-Platzierung.
+- **„Name ungültig"** — Nur `a-z`, `0-9`, `_`, `-`, maximal 50 Zeichen.
+- **Zu weit gefasstes Pattern** — `*` schickt den Zugang an **jede** URL. Fasse es so eng wie möglich (nur den einen Host), damit ein Token nicht versehentlich an fremde Server geht.
+
+## Tipps
+
+- **So eng wie möglich**: Ein URL-Pattern sollte nur die Hosts abdecken, für die der Zugang wirklich gedacht ist.
+- **Ein Zugang, viele Agenten**: Alle Agenten profitieren automatisch — du pflegst das Token nur an einer Stelle.
+- **Trennung Credentials vs. LLM-Keys**: Hier geht es um Zugänge zu **externen Diensten**. Die Schlüssel für die KI-Modelle selbst liegen unter **LLM-Konfiguration**, nicht hier.

--- a/frontend/src/i18n/help/de/datamining.md
+++ b/frontend/src/i18n/help/de/datamining.md
@@ -1,0 +1,71 @@
+# Datamining — durchsuchen, was deine Agenten getan haben
+
+## Was ist das?
+
+Datamining ist dein **Archiv und deine Lupe** für alles, was in HydraHive
+passiert ist: jede Konversation, jeder Werkzeug-Aufruf, jede Sitzung. Du kannst
+darin suchen, Verläufe nachvollziehen und auswerten, wie viel „gearbeitet" (und
+verbraucht) wurde.
+
+Kurz: Der normale Chat zeigt dir das *Jetzt* — Datamining zeigt dir die *gesamte
+Vergangenheit* durchsuchbar.
+
+## Die Reiter
+
+### Live-Feed
+Ein Live-Strom der aktuellen Ereignisse — du siehst quasi in Echtzeit, was die
+Agenten gerade tun (Nachrichten, Werkzeug-Aufrufe). Gut, um im Betrieb
+mitzuschauen.
+
+### Suche
+Volltextsuche über **alle** Konversationen. Du kannst:
+- nach einem **Suchbegriff** filtern,
+- nach **Ereignis-Typ** einschränken (z.B. nur Nutzer-Eingaben, nur
+  Werkzeug-Aufrufe),
+- die **semantische Suche** einschalten — dann wird nicht nur nach exakten Wörtern
+  gesucht, sondern nach **inhaltlicher Ähnlichkeit** (findet Passendes auch, wenn
+  andere Wörter benutzt wurden).
+
+### Sessions
+Die Liste aller vergangenen **Sitzungen** mit Datum, Agent und Benutzer. Ein Klick
+öffnet die Detailansicht mit allen **Events** der Sitzung — praktisch, um einen
+kompletten Verlauf Schritt für Schritt nachzulesen.
+
+### Token-Statistik
+Auswertung des **Verbrauchs**: erstellt/zuletzt aktiv, Anzahl Nachrichten und
+Token-Kennzahlen. Hier siehst du, welche Sitzungen besonders „teuer" waren.
+
+### Graph
+Eine visuelle Darstellung der Zusammenhänge (z.B. Sitzungen und die beteiligten
+Benutzer). Über **Graph laden** wird die Ansicht aufgebaut.
+
+## Import
+
+Über die **Importieren**-Funktion lassen sich zusätzliche Datenquellen ins Archiv
+holen (z.B. aus Extensions/Issues). Ist ein Import konfiguriert, siehst du den
+Status **Mirror aktiv**.
+
+## Schritt-für-Schritt: etwas Vergangenes finden
+
+1. Reiter **Suche** öffnen.
+2. Suchbegriff eingeben — bei ungenauer Erinnerung die **semantische Suche**
+   einschalten.
+3. Optional den **Ereignis-Typ** einschränken.
+4. Treffer anklicken → im Reiter **Sessions** die zugehörige Sitzung im Detail
+   ansehen.
+
+## Typische Fragen
+
+- **„Wann haben wir über X gesprochen?"** → Suche (ggf. semantisch), dann Session
+  öffnen.
+- **„Welche Sitzung war so teuer?"** → Reiter **Token-Statistik**.
+- **„Was macht der Agent gerade?"** → **Live-Feed**.
+- **„Mirror inaktiv / nicht konfiguriert"** → Der Datenbank-Spiegel
+  (`HH_PG_MIRROR_DSN`) ist nicht eingerichtet; das ist eine System-Einstellung.
+
+## Tipps
+
+- **Semantische Suche** ist dein Freund, wenn du dich nur ungefähr erinnerst.
+- **Ereignis-Typ-Filter** grenzt Rauschen aus — z.B. nur „Nutzer-Eingaben", um
+  schnell den Gesprächsfaden zu finden.
+- **Token-Statistik regelmäßig prüfen**, wenn du Kosten im Blick behalten willst.

--- a/frontend/src/i18n/help/de/memory.md
+++ b/frontend/src/i18n/help/de/memory.md
@@ -1,0 +1,76 @@
+# Gedächtnis — was deine Agenten sich merken
+
+## Was ist das?
+
+Hier siehst du, woran sich ein Agent **über einzelne Gespräche hinaus** erinnert.
+Ein normaler Chat ist nach dem Schließen „vergessen" — das Gedächtnis ist der
+Ort, an dem wichtige Dinge dauerhaft bleiben: Notizen, gelernte Fakten und die
+verdichtete Essenz vergangener Sitzungen.
+
+Du wählst rechts einen **Agenten** aus und siehst dann seinen Erinnerungsstand in
+drei Reitern.
+
+## Die drei Reiter
+
+### 1. Memory (Notizen)
+
+Konkrete Merk-Einträge, die der Agent selbst anlegt oder die du ihm gibst. Jeder
+Eintrag hat:
+
+- **Schlüssel** — der Name/das Stichwort, unter dem die Notiz abgelegt ist
+  (z.B. `projekt.deployment-weg`).
+- **Inhalt** — der eigentliche Merktext.
+- **Konfidenz** — wie verlässlich der Agent diese Notiz einschätzt (0–1). Wird ein
+  Eintrag mehrfach bestätigt, steigt die Konfidenz; widersprüchliche neue Infos
+  können alte Einträge als veraltet markieren.
+- **Projekt** — zu welchem Projekt die Notiz gehört (oder global).
+- **Aktualisiert** — wann zuletzt geändert.
+
+### 2. Kristalle
+
+Ein **Kristall** ist die automatisch verdichtete Essenz einer abgeschlossenen
+Sitzung — das „Destillat", damit nicht jedes Detail, aber das Wesentliche erhalten
+bleibt. Ein Kristall enthält typischerweise:
+
+- **Key Outcomes** — was dabei herauskam.
+- **Lessons Learned** — was gelernt wurde.
+- **Betroffene Dateien** — womit gearbeitet wurde.
+
+So bleibt der rote Faden über viele Sitzungen erhalten, ohne dass der Agent den
+kompletten alten Chat mitschleppen muss.
+
+### 3. Sessions
+
+Die Liste der vergangenen **Sitzungen** dieses Agenten — mit dem ursprünglichen
+Prompt und den festgehaltenen Beobachtungen. Nützlich, um nachzuvollziehen, was
+wann passiert ist.
+
+## Suchen und Filtern
+
+- **Suche** — durchsucht **Schlüssel und Inhalt** der Einträge.
+- **Projekt** — auf ein bestimmtes Projekt einschränken (Projekt-ID).
+- **Abgelaufene anzeigen** — auch Einträge einblenden, die ein Ablaufdatum
+  erreicht haben (normalerweise ausgeblendet).
+
+## Schritt-für-Schritt: Erinnerungen ansehen
+
+1. Rechts den **Agenten** wählen.
+2. Reiter **Memory** öffnen — die aktiven Notizen erscheinen.
+3. Über die **Suche** nach einem Stichwort filtern.
+4. Nicht mehr gewünschte Einträge lassen sich einzeln **löschen**.
+
+## Typische Fragen
+
+- **„Warum weiß der Agent das noch?"** — Weil es als Memory-Eintrag oder Kristall
+  gespeichert ist. Hier kannst du es einsehen und bei Bedarf löschen.
+- **„Ein Eintrag ist veraltet/falsch"** — Löschen. Der Agent kann bei Bedarf eine
+  neue, korrekte Notiz anlegen.
+- **„Wo ist mein alter Chat?"** — Im Reiter **Sessions**; die verdichtete Fassung
+  unter **Kristalle**.
+
+## Tipps
+
+- **Konfidenz als Hinweis lesen**: niedrige Konfidenz = der Agent ist sich unsicher.
+- **Projekt-Filter nutzen**, wenn ein Agent in mehreren Projekten arbeitet — sonst
+  vermischen sich die Notizen optisch.
+- **Aufräumen erlaubt**: veraltete Einträge zu löschen hält den Agenten fokussiert.

--- a/frontend/src/i18n/help/de/onboarding.md
+++ b/frontend/src/i18n/help/de/onboarding.md
@@ -1,0 +1,94 @@
+# Erste Schritte mit HydraHive
+
+Willkommen! Diese Seite ist dein roter Faden. HydraHive ist groß — aber du musst
+nicht alles auf einmal verstehen. Hier ist der kürzeste Weg von „gerade
+eingeloggt" zu „es läuft".
+
+## Was ist HydraHive überhaupt?
+
+HydraHive ist eine Plattform, auf der **KI-Agenten** für dich arbeiten. Ein Agent
+ist ein KI-Assistent mit einer Rolle, eigenen Werkzeugen und Zugriff auf das, was
+du ihm erlaubst. Du kannst mit ihnen reden, ihnen Aufgaben geben, und sie
+automatisiert Dinge im Hintergrund erledigen lassen.
+
+Es gibt zwei Haupt-Arbeitsorte:
+
+- **Buddy** (die Startseite 🫀) — dein **persönlicher Assistent** für den Alltag.
+  Eine durchgehende Unterhaltung, immer für dich da.
+- **Werkstatt** (💬) — für **gezieltes Arbeiten** mit spezialisierten Agenten in
+  getrennten Sitzungen (z.B. ein Coding-Agent für ein Projekt).
+
+## Schritt 1 — Ein KI-Modell einrichten (Pflicht!)
+
+Ohne ein hinterlegtes Sprachmodell kann kein Agent denken. Das ist der
+allererste Schritt.
+
+1. Gehe zu **Einstellungen → LLM-Konfiguration** (Zahnrad oben).
+2. Trage bei einem Anbieter deinen **API-Schlüssel** ein (z.B. Anthropic, OpenAI,
+   OpenRouter — je nachdem, was du hast).
+3. Wähle ein **Standard-Modell**.
+4. Fertig — jetzt können Buddy und die Agenten antworten.
+
+> Kommt später überall „kein Modell konfiguriert" oder es passiert nichts, fehlt
+> meist genau dieser Schritt.
+
+## Schritt 2 — Mit Buddy reden
+
+1. Klick oben links auf **Buddy** (das Herz-Symbol, Startseite).
+2. Tippe unten eine Nachricht, z.B. *„Was kannst du für mich tun?"* → **Enter**.
+3. Die Antwort erscheint live. Buddy kann Werkzeuge benutzen (Web-Suche, Dateien …)
+   — welche, stellst du über das Zahnrad bei Buddy ein.
+
+Buddy ist der einfachste Einstieg. Alles Weitere baut darauf auf.
+
+## Schritt 3 — Ein Projekt anlegen (wenn du an etwas Konkretem arbeitest)
+
+Ein **Projekt** ist ein abgegrenzter Arbeitsbereich mit eigenem Datei-Ordner
+(Workspace). Agenten, die in einem Projekt arbeiten, „sehen" nur dessen Dateien —
+sauber getrennt von allem anderen.
+
+1. **Einstellungen → Projekte → Neu**.
+2. Namen vergeben, optional ein Git-Repo verknüpfen.
+3. In **Buddy** oder der **Werkstatt** kannst du dann dieses Projekt als Kontext
+   wählen — die Datei-Werkzeuge arbeiten ab dann in seinem Workspace.
+
+## Schritt 4 — Eigene Agenten (wenn Buddy nicht reicht)
+
+Brauchst du einen Spezialisten (z.B. „Code-Reviewer", „Recherche-Agent"), legst
+du unter **Einstellungen → Agenten** einen eigenen an: Rolle, Modell, erlaubte
+Werkzeuge. In der **Werkstatt** startest du dann Sitzungen mit ihm.
+
+## Wo finde ich was?
+
+Die Navigation links ist in Gruppen sortiert:
+
+- **Überblick** — Dashboard (Systemzustand, Aktivität).
+- **Arbeiten** — Buddy, Werkstatt, Agenten, Projekte, Kommunikation, Teamchat.
+- **Automatisierung** — Butler (Automationen), Skills, MCP, Plugins.
+- **Infrastruktur** — VMs, Container, Datamining, Gedächtnis u.a.
+- **Einstellungen** (Zahnrad) — LLM, Credentials, Module, Benutzer, System.
+
+Auf vielen Seiten findest du oben ein **? -Symbol** — das öffnet die Hilfe genau
+zu dieser Seite. Nutze es großzügig.
+
+## Häufige Stolpersteine für Neue
+
+- **„Es antwortet nichts / lädt ewig"** → Schritt 1 prüfen: Modell + gültiger
+  API-Schlüssel unter LLM-Konfiguration.
+- **„Der Agent kann X nicht"** → Das Werkzeug ist nicht aktiviert. Beim Agenten
+  bzw. bei Buddy unter **Werkzeuge** einschalten.
+- **„Der Agent kommt nicht auf eine geschützte Seite"** → Zugang unter
+  **Credentials** hinterlegen (mit passendem URL-Muster).
+- **„Wo sind meine Dateien?"** → Im **Workspace** des jeweiligen Projekts.
+
+## Empfohlene Reihenfolge zum Einlesen
+
+1. **Buddy** — dein Assistent (Startseite)
+2. **LLM-Konfiguration** — damit alles funktioniert
+3. **Projekte** — wenn du an etwas Konkretem arbeitest
+4. **Agenten** — für Spezialisten
+5. **Werkstatt** — gezieltes Arbeiten
+6. **Credentials** — sobald externe Zugänge nötig werden
+
+Viel Erfolg — und keine Sorge, du musst nicht alles auf einmal können. Fang mit
+Buddy an.

--- a/frontend/src/i18n/help/de/skills.md
+++ b/frontend/src/i18n/help/de/skills.md
@@ -1,0 +1,82 @@
+# Skills — Wissen und Anleitungen für deine Agenten
+
+## Was ist das?
+
+Ein **Skill** ist eine wiederverwendbare **Anleitung**, die ein Agent bei Bedarf
+lädt. Statt einem Agenten jedes Mal aufs Neue zu erklären, *wie* er etwas tun
+soll („so machst du ein Code-Review", „so schreibst du eine Commit-Nachricht"),
+schreibst du das einmal als Skill auf. Der Agent zieht sich diese Anleitung dann
+selbstständig heran, wenn die Situation passt.
+
+Denk an ein Skill wie an einen **Spickzettel** oder eine **Checkliste**, die im
+Regal liegt und im richtigen Moment aufgeschlagen wird.
+
+## Warum ist das nützlich?
+
+- **Konsistenz**: Der Agent macht eine Aufgabe jedes Mal gleich (nach deiner
+  Vorgabe), nicht mal so, mal so.
+- **Weniger wiederholen**: Du musst dein Vorgehen nicht in jedem Gespräch neu
+  erklären.
+- **Kontext sparen**: Der Skill wird nur geladen, wenn er wirklich gebraucht wird
+  — er belastet den Agenten nicht ständig.
+
+## Zwei Arten von Skills
+
+- **Eigene Skills** — die du selbst anlegst und pflegst.
+- **System-Skills** — mitgelieferte Vorlagen (z.B. für Code-Review, Debugging,
+  Git-Workflow). Diese sind fertig nutzbar.
+
+## Die Felder eines Skills
+
+- **Name** — Kurzbezeichnung (nur `a-z`, `0-9`, `_`, `-`). **Achtung:** kann nach
+  dem Anlegen **nicht mehr geändert** werden.
+- **Beschreibung** — worum es im Skill geht (eine Zeile).
+- **Wann nutzen?** — der wichtigste Teil: ein Satz, der der KI sagt, **in welcher
+  Situation** sie diesen Skill laden soll. Beispiel: *„Wenn der User um ein
+  Code-Review bittet."* Je klarer, desto zuverlässiger greift der Agent zum
+  richtigen Skill.
+- **Benötigte Tools** — kommagetrennte Liste von Werkzeugen, die der Skill
+  voraussetzt (optional).
+- **Anweisungen (Markdown)** — der eigentliche Inhalt: die Schritt-für-Schritt-
+  Anleitung, die der Agent beim Laden bekommt.
+- **Quellen / URLs** — optionale Adressen (Foren, APIs, Dokus), die der Agent im
+  Rahmen des Skills abrufen darf. Braucht eine Quelle Zugangsdaten, gibst du den
+  Namen eines **Credential-Profils** an (siehe Hilfe zu *Credentials*) — die Auth
+  wird dann automatisch eingehängt.
+
+## Schritt-für-Schritt: Skill anlegen
+
+1. **Neuer Skill** klicken.
+2. **Name** vergeben (gut überlegen — unveränderlich!).
+3. **Beschreibung** und vor allem **„Wann nutzen?"** ausfüllen — das entscheidet,
+   ob der Agent den Skill im richtigen Moment findet.
+4. Unter **Anweisungen** die eigentliche Anleitung schreiben (Markdown: Listen,
+   Überschriften, Codeblöcke sind erlaubt).
+5. Optional **benötigte Tools** und **Quellen** ergänzen.
+6. Speichern.
+
+## Skills pro Agent an-/ausschalten
+
+Bei einem Agenten gibt es einen **Skills-Reiter**: dort siehst du, welche Skills
+für diesen Agenten verfügbar sind, und kannst sie einzeln **an/aus** schalten.
+So bekommt jeder Agent genau die Anleitungen, die zu seiner Rolle passen.
+
+## Typische Fehler
+
+- **Agent lädt den Skill nie** — Das Feld **„Wann nutzen?"** ist zu vage. Formulier
+  es konkret und situationsbezogen.
+- **„Name ungültig"** — Nur `a-z`, `0-9`, `_`, `-`, max. 50 Zeichen.
+- **Name falsch gewählt** — Er lässt sich nachträglich nicht ändern; im Zweifel
+  neu anlegen und den alten löschen.
+- **Quelle nicht erreichbar** — Braucht die URL einen Login, muss ein passendes
+  **Credential-Profil** hinterlegt und im Skill angegeben sein.
+
+## Tipps
+
+- **Ein Skill = ein Zweck.** Lieber mehrere kleine, klar benannte Skills als einen
+  überladenen.
+- **„Wann nutzen?" ist das Herzstück** — investier hier die meiste Sorgfalt.
+- **Markdown nutzen**: Nummerierte Schritte und Checklisten machen die Anleitung
+  für den Agenten am zuverlässigsten befolgbar.
+- **System-Skills als Vorlage** ansehen, um ein Gefühl für guten Aufbau zu
+  bekommen.

--- a/frontend/src/i18n/help/de/teamchat.md
+++ b/frontend/src/i18n/help/de/teamchat.md
@@ -1,0 +1,64 @@
+# Teamchat — gemeinsame Räume für Menschen und Agenten
+
+## Was ist das?
+
+Der **Teamchat** ist ein Gruppen-Chat, in dem **mehrere Menschen und mehrere
+Agenten** zusammen in einem **Raum** schreiben. Anders als der Buddy-Chat (nur du
++ dein Assistent) ist das ein gemeinsamer Ort — wie ein Slack- oder
+Discord-Kanal, aber direkt in HydraHive und mit KI-Agenten als vollwertigen
+Teilnehmern.
+
+## Kernbegriffe
+
+- **Raum** — ein Chatkanal. Kann **privat** (nur eingeladene Mitglieder) oder
+  **offen** (zum Entdecken/Beitreten) sein.
+- **Mitglieder** — die Menschen im Raum. Du siehst, wer **online/offline** ist.
+- **Zugeschaltete Agenten** — KI-Agenten, die im Raum mitlesen und antworten können.
+- **@name** — mit einem `@` sprichst du gezielt einen Agenten (oder eine Person)
+  an.
+
+## Schritt-für-Schritt: Raum aufsetzen
+
+1. **Neuer Raum** → Namen vergeben, optional gleich Mitglieder (kommagetrennt)
+   eintragen.
+2. Sichtbarkeit wählen: **Privat** oder **Offen**.
+3. **Anlegen**.
+4. Im Raum über **Agent zuschalten** einen oder mehrere Agenten hinzufügen.
+5. Losschreiben. Mit **@name** sprichst du einen bestimmten Agenten direkt an —
+   ohne @ läuft es als normale Gruppennachricht.
+
+## Mitglieder & Agenten verwalten
+
+- **Mitglied hinzufügen / entfernen** — über den Benutzernamen.
+- **Agent zuschalten / entfernen** — steuert, welche KI im Raum aktiv ist.
+- **Entdecken** — offene Räume finden und **beitreten**.
+
+## Wann Teamchat statt Buddy?
+
+- **Buddy**: dein privater 1:1-Assistent.
+- **Teamchat**: wenn **mehrere Leute** mit demselben Agenten (oder mehreren
+  Agenten) zusammenarbeiten sollen — z.B. ein Support-Raum, ein Projektraum, ein
+  Brainstorming mit mehreren Spezialisten-Agenten gleichzeitig.
+
+## Voraussetzung
+
+Der Teamchat läuft technisch über einen **Matrix-Server** (Tuwunel). Erscheint
+*„Team-Chat ist nicht aktiviert"*, ist dieser Server nicht erreichbar oder der
+Teamchat ist ausgeschaltet — dann muss er zuerst unter **Extensions** aktiviert
+bzw. eingerichtet werden.
+
+## Typische Fragen
+
+- **„Der Agent antwortet nicht"** — Ist er dem Raum **zugeschaltet**? Und hast du
+  ihn mit **@name** angesprochen?
+- **„Ich sehe den Raum nicht"** — Bei privaten Räumen musst du **Mitglied** sein;
+  offene findest du über **Entdecken**.
+- **„Team-Chat ist nicht aktiviert"** — Der Matrix-Homeserver ist nicht erreichbar
+  oder der Teamchat ist aus; siehe **Extensions**.
+
+## Tipps
+
+- **Mehrere Agenten in einem Raum**: praktisch, um verschiedene Spezialisten
+  gleichzeitig zu Wort kommen zu lassen — sprich sie gezielt per `@name` an.
+- **Offene Räume** eignen sich für Themen, zu denen andere spontan dazustoßen
+  sollen; **private** für vertrauliche Runden.

--- a/frontend/src/i18n/help/en/atelier.md
+++ b/frontend/src/i18n/help/en/atelier.md
@@ -1,0 +1,84 @@
+# Atelier — create images, videos, audio and whole films
+
+## What is this?
+
+The **Atelier** is your media workshop. Here you have AI generate **images**,
+**videos**, **music/speech**, and even **whole short films** — all bound to a
+**project** so your works stay cleanly separated. The special part: through
+**characters** and a **style anchor**, the look stays **consistent** across many
+images (the same figure always looks the same).
+
+At the top you pick the **project** you're working in. All generated media land in
+its storage.
+
+## The tabs
+
+### Generate
+The starting point: you describe via a **prompt** what should be created, pick a
+**model** and format, and generate an image. If you select a **character**, its
+profile is automatically merged into the prompt — so it stays recognizable.
+
+### Gallery
+All generated **images** of the project. From here you can view images, reuse them
+(as reference/start frame for videos), or delete them. A picture's exact prompt is
+also viewable and copyable.
+
+### Videos
+From a prompt — or from an existing image as a **start frame** — short **video
+clips** are created. Each model offers different **durations** and **formats** (the
+selection adapts automatically to the chosen model so no invalid combination
+occurs). Each clip shows model, duration, format, and source as small info badges.
+
+### Audio
+Generates **music** or **speech** (voiceover) — useful for scoring films.
+
+### Director (screenplay → film)
+The most ambitious part: you write a **screenplay** (title, logline, description),
+and a **director agent** breaks it into **scenes** and **shots** (individual camera
+setups). For each shot you can generate image and video, step by step to the
+finished film. Camera setups (close-up, wide, aerial …) help steer the look
+deliberately.
+
+## Characters & style — the key to consistency
+
+- **Character (figure)** — has a **profile** (appearance, traits) that is merged
+  **verbatim into every prompt**, plus optionally a **style anchor**, **palette**
+  (hex colors), and **seed**. This way the same figure looks the same in every
+  image.
+- **Style anchor** — a fixed style block (e.g. *"flat vector, thick outlines"*) that
+  stays constant across an image series.
+- **Reference images** — uploaded templates the generation orients itself to.
+
+## Step by step: from image to film
+
+1. Pick a **project** at the top (or create one first).
+2. Optionally create a figure under **Characters** with profile + style anchor.
+3. **Generate** tab: write a prompt, pick figure/model/format → generate image.
+4. **Videos** tab: create a clip from the image (start frame) or a prompt —
+   duration/format per model.
+5. **Audio** tab: generate matching music or a voiceover.
+6. **Edit film**: click several clips in order and **render** (mixed formats are
+   fitted in), optionally add music.
+7. For structured projects: **Director** tab — write a screenplay, have the
+   director agent break it into scenes/shots, and work through it.
+
+## Common mistakes
+
+- **"No projects available"** — The Atelier is project-bound. First create one
+  under *Projects*.
+- **Video fails / format rejected** — Use the **durations/formats** offered by the
+  model; the selection is already tailored to the model.
+- **Figure looks inconsistent** — Profile too vague. Describe appearance concretely
+  and use **style anchor** + **seed** for repeatability.
+- **Film tab empty** — Generate **videos** first; the film assembles existing clips.
+
+## Tips
+
+- **Character first, then the series**: a good character profile saves a lot of
+  later touch-up.
+- **Use an image as a start frame** for videos best from the **Gallery** — that
+  preserves the look.
+- **Reuse prompts**: via the prompt view you can copy successful prompts and reuse
+  them slightly modified.
+- **Director for longer stories**: instead of juggling clips individually, the
+  screenplay approach gives you structure (scenes → shots) and a through-line.

--- a/frontend/src/i18n/help/en/buddy.md
+++ b/frontend/src/i18n/help/en/buddy.md
@@ -1,0 +1,90 @@
+# Buddy — your personal assistant
+
+## What is this?
+
+Buddy is the **home page** of HydraHive and your personal AI assistant. Unlike the **Workshop** (where you work with specialized agents on purpose), Buddy is your everyday companion: ask questions, jot things down, kick off tasks, keep an overview.
+
+Buddy keeps **one continuous conversation** (a session) that persists — so you can always pick up where you left off. The animated **Hydra mascot** on the left shows its state: idle (waiting), working (thinking / using tools), or speaking (voice output).
+
+Buddy is a full agent: it can **use tools** (read files, search the web, send email, generate images …) — you decide which ones in the settings.
+
+## What can I do here?
+
+- **Just start typing** — ask a question or give a task, press Enter. The answer streams in live.
+- **Use commands** — messages starting with `/` are shortcuts (see below).
+- **Pick a model** — the model selector at the top: which AI model Buddy currently uses.
+- **Set project context** — bind Buddy to a project; its file tools then work inside that project's folder.
+- **Control thinking depth** — the "Reasoning Effort" pill sets how thoroughly the model reasons (more depth = slower but more considered; only for models that support it).
+- **Module widgets** — installed modules show small helpers on the right that send something to Buddy on click.
+- **Customize Buddy** — the gear icon opens Buddy's settings (name, character, tools …).
+
+## Key terms
+
+- **Buddy session** — the single, ongoing conversation with your assistant. It stays saved until you start fresh with `/clear`.
+- **Tools** — abilities beyond plain talk (web search, file access, mail, media generation …).
+- **Compaction** — older messages get summarized so the conversation doesn't grow too long (and costly).
+- **Reasoning Effort** — the model's thinking effort per reply (minimal/low/medium/high).
+- **Soul / character** — Buddy's personality: name, tone (casual/professional/brief) and a free-form character text.
+
+## Slash commands
+
+Type one of these as a message:
+
+| Command | Effect |
+|---------|--------|
+| `/help` | Shows this command list in the chat |
+| `/clear` (or `/reset`) | Starts a fresh chat — the old session stays in history |
+| `/remember [name]` | Saves the current conversation as a persistent note (memory) |
+| `/model [name]` | Shows or switches Buddy's model |
+| `/character` | Rolls a new character for Buddy |
+| `/compact` | Manually compacts the current session (saves tokens) |
+| `/tokens` | Shows token count and context window usage |
+| `/title <text>` | Renames the Buddy session |
+| `/system` | Shows the current system prompt |
+| `/tools` | Lists the tools available in the backend |
+| `/agent` | Shows info about the Buddy agent |
+| `/soul` | Shows the building blocks of Buddy's personality |
+| `/export` | Outputs the conversation as Markdown |
+
+## Step by step
+
+### Your first conversation
+
+1. Buddy is already there when you open HydraHive (home page `/`).
+2. Type your message below — e.g. *"Summarize what HydraHive can do"* — and press **Enter**.
+3. Watch the answer stream in. If Buddy uses a tool (e.g. web search), you'll see it in the transcript.
+
+### Bind Buddy to a project
+
+1. Open the **project selector** at the top.
+2. Pick a project — Buddy's file tools now work inside that project's folder.
+3. To unbind, set it back to "no project".
+
+### Configure Buddy's personality & tools
+
+1. Top right: the **gear** (Buddy settings).
+2. Tabs:
+   - **Identity** — name, character text, language (de/en/auto), tone (casual/professional/brief).
+   - **Context** — what Buddy should permanently know about you/your environment.
+   - **Tools** — which tools Buddy may use (only enable what you actually need).
+   - **Mail** — appears only when mail tools are active (mailbox access).
+   - **Compaction** — when auto-compaction kicks in.
+3. **Save**. Changing core identity may start a fresh session.
+
+### Tidy up a long conversation
+
+- If it gets very long, type `/compact` — older parts get summarized, the thread stays intact.
+- To start over completely: `/clear`. The old transcript isn't lost, it just moves to the background.
+
+## Common questions
+
+- **"Buddy or Workshop — which one?"** Buddy = your personal everyday assistant (one ongoing conversation). Workshop = focused work with multiple specialized agents in separate sessions.
+- **"Buddy doesn't answer / loads forever"** — Check that a model is set up under **LLM configuration** and a valid key is stored. Without a configured model Buddy can't think.
+- **"Buddy can't do X (e.g. send mail)"** — The tool is probably not enabled. Gear → **Tools** → turn on the relevant tool.
+- **"How does Buddy remember something permanently?"** — Use `/remember`, or put it in the **Context** tab.
+
+## Tips
+
+- **Enable tools sparingly**: fewer tools means Buddy picks the right one more reliably. Only enable what you use regularly.
+- **Dose reasoning effort**: keep it low for quick questions, turn it up for tricky tasks.
+- **Maintain context**: what Buddy should always know (your name, preferences, project environment) belongs in the **Context** tab — then you don't have to repeat it every message.

--- a/frontend/src/i18n/help/en/butler.md
+++ b/frontend/src/i18n/help/en/butler.md
@@ -1,0 +1,91 @@
+# Butler — automations without programming
+
+## What is this?
+
+The **Butler** is your automation construction kit. On a canvas you build a rule
+by **dragging and connecting** nodes: *"When X happens, and Y applies, then do
+Z."* No code — you plug the building blocks together like a flowchart.
+
+Example: *"When an email arrives from my boss (trigger), and it contains the word
+'urgent' (condition), then let agent 'Assistant' reply (action)."*
+
+Such a rule is called a **flow**. You can have several flows and switch each one
+**active** or **inactive** individually.
+
+## The three building blocks
+
+A flow always reads left to right: **trigger → condition(s) → action(s)**. Only
+the trigger is required — conditions are optional.
+
+### 1. Trigger (the "When …")
+
+What should start it?
+
+- **Message received** — an incoming message to an agent.
+- **Webhook received** — an external service calls a URL (you get a hook URL to
+  copy).
+- **Heartbeat fired** — time-based/recurring (for regular tasks).
+- **Git event** — e.g. a push or change in a repository.
+- **Discord event** — e.g. a reaction or message in a channel.
+- **Email received** — an incoming email.
+
+### 2. Conditions (the "… and if it applies …")
+
+Refine when the flow should actually fire. Each condition has a **Yes/No** output:
+
+- **Time window** / **Day of week** — only at certain times.
+- **Contact known** — only from known senders.
+- **Message contains** / **Field contains** — text filters on content.
+- **Git: branch / author / action is …** — filters on Git events.
+- **Email: sender / subject / body contains …** — filters on emails.
+- **Discord: event type / emoji is …** — filters on Discord.
+
+### 3. Actions (the "… then do …")
+
+What should happen?
+
+- **Agent reply** — an agent handles the message freely.
+- **Agent reply with instruction** — agent replies, guided by your prompt.
+- **Fixed reply** — always the same predefined text.
+- **Queue** / **Ignore** — set aside for later or discard.
+- **Forward** — hand over to another agent.
+- **HTTP POST** — call an external URL (with JSON body).
+- **Send email**.
+- **Git: create issue / add comment** — create something in the repository.
+- **Discord post** — write a message into a channel.
+
+## Step by step: build your first flow
+
+1. Drag a **trigger** from the palette (left) onto the canvas.
+2. Drag an **action** in and **connect** the two (drag from the trigger's output
+   to the action's input).
+3. Optional: insert a **condition** in between — connect its **Yes** output to the
+   action.
+4. Click a node → set the details in the **Properties panel** on the right (e.g.
+   which agent, which channel, which text filter).
+5. Give the flow a **name** at the top and click **Save**.
+6. Test safely with **Dry run**: the flow is played through with a test event —
+   **no real actions** are executed. You see whether the trigger matches and how
+   many actions would run.
+7. When it's right: switch the flow to **Active**.
+
+## Common mistakes
+
+- **"Not active yet — no backend event sender available"** — The chosen trigger
+  isn't (yet) wired to a real event source in your installation. The flow saves
+  but won't fire until the source exists.
+- **"Save the flow first, then dry run"** — Dry run only works with a saved flow.
+- **Action never runs** — Check the **connections**: is the trigger actually
+  connected to the action? With conditions: is the action on the **Yes** output?
+- **Discord channel missing** — You need the **numeric channel ID** (in Discord:
+  right-click the channel → Copy ID).
+
+## Tips
+
+- **Dry run first, then activate.** The dry run is harmless — always use it before
+  going live.
+- **Start small**: trigger + one action. Add conditions later.
+- **Several flows** instead of one giant flow — one per purpose, individually
+  toggleable, much clearer.
+- **Project context**: flows belong to the current project — make sure you're in
+  the right one.

--- a/frontend/src/i18n/help/en/communication.md
+++ b/frontend/src/i18n/help/en/communication.md
@@ -1,0 +1,45 @@
+# Communication — messengers that reach your agent
+
+## What is this?
+
+On this page you connect **external messengers** to HydraHive so you can reach
+your personal (master) agent **on the go** — without opening the web interface. If
+you write on WhatsApp, for example, the message lands directly with your agent,
+and its reply comes back the same way.
+
+In short: your agent gets a "phone" you can text.
+
+## Available channels
+
+- **WhatsApp** — incoming messages go directly to your master agent.
+- **Discord** — direct messages (DMs) and **@mentions** go to your master agent.
+
+(Which channels are ready depends on your installation and the stored credentials.)
+
+## What is it good for?
+
+- You can give your agent tasks **on the go** ("Summarize my mail", "How's the
+  server doing?").
+- The agent can notify you **proactively** (e.g. via a Butler automation that posts
+  a Discord message).
+- No constant browser login needed — your familiar messenger is enough.
+
+## Interplay with other areas
+
+- **Butler**: incoming messages can serve as a **trigger** for automations ("When a
+  Discord message with … → let agent reply").
+- **Credentials**: connecting some services needs tokens/access — those live under
+  *Credentials* or in the system settings.
+
+## Common questions
+
+- **"My WhatsApp message doesn't arrive"** — The connection isn't fully set up
+  (access/token missing or expired). Check the channel's connection settings.
+- **"Discord: agent doesn't react to normal messages"** — By default it reacts to
+  **DMs** and **@mentions**. Address it directly.
+
+## Tips
+
+- **Start with one channel** (e.g. Discord) until the path works reliably before
+  adding more.
+- **Combine with Butler** if you want automatic reactions to incoming messages.

--- a/frontend/src/i18n/help/en/credentials.md
+++ b/frontend/src/i18n/help/en/credentials.md
@@ -1,0 +1,72 @@
+# Credentials — access data for web requests
+
+## What is this?
+
+This is where you store **access data (tokens, passwords, keys)** that your agents need to reach protected websites or services. The trick: you store an access secret **once** and define via a **URL pattern** what it applies to. When an agent then calls a matching address, the secret is **injected automatically** — the agent doesn't need to (and can't) know the token itself.
+
+**Security (important):** Tokens **never** appear in the AI context or in tool results. They are only applied server-side during the actual network call and are stored encrypted. The model never "sees" your password.
+
+## Why do I need this?
+
+Examples:
+- An agent should query a **private forum** or a **token-protected API**.
+- An agent should connect to a server via **SSH** (e.g. to run commands there).
+- A site requires a **cookie** or a **custom header** to serve content.
+
+Without a matching credential the agent would just get "401 Unauthorized" or a login page.
+
+## Credential types
+
+| Type | For | How it's sent |
+|------|-----|---------------|
+| **Bearer Token** | API tokens, modern web APIs | `Authorization: Bearer <value>` |
+| **Basic Auth** | classic username/password login | `Authorization: Basic <base64 of user:pass>` |
+| **Cookie** | sites expecting session cookies | `Cookie: <value>` (e.g. `session=abc123`) |
+| **Custom Header** | your own header names (e.g. `X-API-Key`) | your header name + value |
+| **Query Parameter** | token appended to the URL | `…?<param>=<value>` |
+| **SSH Key** | SSH access to a server | private key + host + user |
+
+## Fields explained
+
+- **Name** — free choice (only `a-z`, `0-9`, `_`, `-`) so you recognize the access.
+- **Type** — one of the above. Matching extra fields appear per type.
+- **Value** — the actual secret (token, `user:password`, cookie string …).
+- **URL pattern** — determines which addresses the access applies to. A **glob pattern**:
+  - `*` = for **all** URLs (use with care!)
+  - `https://forum.example.com/*` = only this host and everything below it
+- **Header name** / **Query param name** — only for "Custom Header" / "Query Parameter": what the field should be called.
+- **Description** — optional note for yourself.
+
+### Additionally for SSH keys
+- **Private key (PEM)** — your private key in OpenSSH or PEM format. Stored encrypted, **never** passed to the model.
+- **Hostname / IP** — the server to access.
+- **SSH username** — the login name on the server.
+
+## Step by step
+
+### Store an API token (Bearer)
+
+1. Click **New credential**.
+2. Give it a **name** (e.g. `github-api`).
+3. **Type** = Bearer Token.
+4. **Value** = paste your token.
+5. **URL pattern** = e.g. `https://api.github.com/*`.
+6. Save. From now on the token is injected automatically when this API is called.
+
+### Create an SSH access
+
+1. **New credential** → **Type** = SSH Key.
+2. Paste the **private key** (PEM/OpenSSH), set **host** and **username**.
+3. Save. The agent can now connect to this host via SSH without knowing the key.
+
+## Common mistakes
+
+- **Agent still gets 401/login page** — The **URL pattern** doesn't match the actually called address. Check spelling and `*` placement.
+- **"Name invalid"** — Only `a-z`, `0-9`, `_`, `-`, max 50 characters.
+- **Pattern too broad** — `*` sends the access to **every** URL. Keep it as narrow as possible (just the one host) so a token isn't accidentally sent to foreign servers.
+
+## Tips
+
+- **As narrow as possible**: a URL pattern should only cover the hosts the access is really meant for.
+- **One access, many agents**: all agents benefit automatically — you maintain the token in a single place.
+- **Credentials vs. LLM keys**: this is about access to **external services**. The keys for the AI models themselves live under **LLM configuration**, not here.

--- a/frontend/src/i18n/help/en/datamining.md
+++ b/frontend/src/i18n/help/en/datamining.md
@@ -1,0 +1,65 @@
+# Datamining — search what your agents have done
+
+## What is this?
+
+Datamining is your **archive and magnifying glass** for everything that happened
+in HydraHive: every conversation, every tool call, every session. You can search
+it, trace histories, and analyze how much was "worked" (and consumed).
+
+In short: normal chat shows you the *now* — datamining shows you the *entire past*,
+searchable.
+
+## The tabs
+
+### Live feed
+A live stream of current events — you see in near real time what the agents are
+doing right now (messages, tool calls). Good for watching operations live.
+
+### Search
+Full-text search across **all** conversations. You can:
+- filter by a **search term**,
+- restrict by **event type** (e.g. only user inputs, only tool calls),
+- turn on **semantic search** — then it searches not just for exact words but for
+  **meaning similarity** (finds relevant things even when other words were used).
+
+### Sessions
+The list of all past **sessions** with date, agent, and user. A click opens the
+detail view with all the session's **events** — handy to read a complete history
+step by step.
+
+### Token statistics
+Analysis of **consumption**: created/last active, message count, and token
+metrics. Here you see which sessions were especially "expensive".
+
+### Graph
+A visual representation of relationships (e.g. sessions and the users involved).
+Use **Load graph** to build the view.
+
+## Import
+
+Via the **Import** function you can bring additional data sources into the archive
+(e.g. from extensions/issues). If an import is configured, you see the status
+**Mirror active**.
+
+## Step by step: find something from the past
+
+1. Open the **Search** tab.
+2. Enter a search term — if your memory is fuzzy, turn on **semantic search**.
+3. Optionally restrict the **event type**.
+4. Click a hit → view the related session in detail in the **Sessions** tab.
+
+## Common questions
+
+- **"When did we talk about X?"** → Search (semantic if needed), then open the
+  session.
+- **"Which session was so expensive?"** → **Token statistics** tab.
+- **"What's the agent doing right now?"** → **Live feed**.
+- **"Mirror inactive / not configured"** → The database mirror
+  (`HH_PG_MIRROR_DSN`) isn't set up; that's a system setting.
+
+## Tips
+
+- **Semantic search** is your friend when you only vaguely remember.
+- **Event-type filter** cuts out noise — e.g. only "user inputs" to quickly find
+  the thread of conversation.
+- **Check token statistics regularly** if you want to keep an eye on costs.

--- a/frontend/src/i18n/help/en/memory.md
+++ b/frontend/src/i18n/help/en/memory.md
@@ -1,0 +1,72 @@
+# Memory — what your agents remember
+
+## What is this?
+
+Here you see what an agent remembers **beyond individual conversations**. A normal
+chat is "forgotten" once closed — memory is where important things persist: notes,
+learned facts, and the condensed essence of past sessions.
+
+You pick an **agent** on the right and then see its memory state across three tabs.
+
+## The three tabs
+
+### 1. Memory (notes)
+
+Concrete notes the agent creates itself or that you give it. Each entry has:
+
+- **Key** — the name/keyword the note is filed under (e.g.
+  `project.deployment-path`).
+- **Content** — the actual note text.
+- **Confidence** — how reliable the agent considers this note (0–1). If an entry is
+  confirmed repeatedly, confidence rises; contradictory new info can mark old
+  entries as outdated.
+- **Project** — which project the note belongs to (or global).
+- **Updated** — when last changed.
+
+### 2. Crystals
+
+A **crystal** is the automatically condensed essence of a finished session — the
+"distillate", so that not every detail but the essentials are preserved. A crystal
+typically contains:
+
+- **Key outcomes** — what came out of it.
+- **Lessons learned** — what was learned.
+- **Affected files** — what was worked on.
+
+This keeps the thread across many sessions without the agent having to drag along
+the entire old chat.
+
+### 3. Sessions
+
+The list of this agent's past **sessions** — with the original prompt and the
+recorded observations. Useful to trace what happened when.
+
+## Search and filter
+
+- **Search** — searches **key and content** of the entries.
+- **Project** — restrict to a specific project (project ID).
+- **Show expired** — also show entries that have reached an expiry date (normally
+  hidden).
+
+## Step by step: view memories
+
+1. Pick the **agent** on the right.
+2. Open the **Memory** tab — the active notes appear.
+3. Filter by keyword via **Search**.
+4. Unwanted entries can be **deleted** individually.
+
+## Common questions
+
+- **"Why does the agent still know that?"** — Because it's stored as a memory entry
+  or crystal. Here you can view it and delete it if needed.
+- **"An entry is outdated/wrong"** — Delete it. The agent can create a new, correct
+  note when needed.
+- **"Where's my old chat?"** — In the **Sessions** tab; the condensed version under
+  **Crystals**.
+
+## Tips
+
+- **Read confidence as a hint**: low confidence = the agent is unsure.
+- **Use the project filter** if an agent works across several projects — otherwise
+  the notes visually mix.
+- **Cleanup allowed**: deleting outdated entries keeps the agent focused.

--- a/frontend/src/i18n/help/en/onboarding.md
+++ b/frontend/src/i18n/help/en/onboarding.md
@@ -1,0 +1,92 @@
+# Getting started with HydraHive
+
+Welcome! This page is your guiding thread. HydraHive is big — but you don't need
+to understand everything at once. Here's the shortest path from "just logged in"
+to "it works".
+
+## What is HydraHive anyway?
+
+HydraHive is a platform where **AI agents** work for you. An agent is an AI
+assistant with a role, its own tools, and access to whatever you allow it. You
+can talk to them, give them tasks, and let them do things automatically in the
+background.
+
+There are two main places to work:
+
+- **Buddy** (the home page 🫀) — your **personal assistant** for everyday things.
+  One ongoing conversation, always there for you.
+- **Workshop** (💬) — for **focused work** with specialized agents in separate
+  sessions (e.g. a coding agent for a project).
+
+## Step 1 — Set up an AI model (required!)
+
+Without a language model, no agent can think. This is the very first step.
+
+1. Go to **Settings → LLM configuration** (gear at the top).
+2. Enter your **API key** for a provider (e.g. Anthropic, OpenAI, OpenRouter —
+   whatever you have).
+3. Pick a **default model**.
+4. Done — now Buddy and the agents can respond.
+
+> If you later see "no model configured" everywhere or nothing happens, this step
+> is usually the missing piece.
+
+## Step 2 — Talk to Buddy
+
+1. Click **Buddy** at the top left (the heart icon, home page).
+2. Type a message below, e.g. *"What can you do for me?"* → **Enter**.
+3. The answer streams in live. Buddy can use tools (web search, files …) — you
+   choose which via Buddy's gear icon.
+
+Buddy is the easiest entry point. Everything else builds on it.
+
+## Step 3 — Create a project (when working on something concrete)
+
+A **project** is a bounded workspace with its own file folder. Agents working in
+a project only "see" its files — cleanly separated from everything else.
+
+1. **Settings → Projects → New**.
+2. Name it, optionally link a Git repo.
+3. In **Buddy** or the **Workshop** you can then pick this project as context —
+   the file tools will operate in its workspace from then on.
+
+## Step 4 — Your own agents (when Buddy isn't enough)
+
+If you need a specialist (e.g. "code reviewer", "research agent"), create one
+under **Settings → Agents**: role, model, allowed tools. Then start sessions with
+it in the **Workshop**.
+
+## Where do I find what?
+
+The left navigation is sorted into groups:
+
+- **Overview** — dashboard (system state, activity).
+- **Working** — Buddy, Workshop, Agents, Projects, Communication, Team chat.
+- **Automation** — Butler (automations), Skills, MCP, Plugins.
+- **Infrastructure** — VMs, containers, datamining, memory, and more.
+- **Settings** (gear) — LLM, credentials, modules, users, system.
+
+On many pages you'll find a **? icon** at the top — it opens help specific to
+that page. Use it generously.
+
+## Common pitfalls for newcomers
+
+- **"Nothing responds / loads forever"** → Check step 1: model + valid API key
+  under LLM configuration.
+- **"The agent can't do X"** → The tool isn't enabled. Turn it on under **Tools**
+  for the agent or Buddy.
+- **"The agent can't reach a protected site"** → Store an access under
+  **Credentials** (with a matching URL pattern).
+- **"Where are my files?"** → In the **workspace** of the respective project.
+
+## Recommended reading order
+
+1. **Buddy** — your assistant (home page)
+2. **LLM configuration** — so everything works
+3. **Projects** — when working on something concrete
+4. **Agents** — for specialists
+5. **Workshop** — focused work
+6. **Credentials** — as soon as external access is needed
+
+Good luck — and don't worry, you don't need to master everything at once. Start
+with Buddy.

--- a/frontend/src/i18n/help/en/skills.md
+++ b/frontend/src/i18n/help/en/skills.md
@@ -1,0 +1,79 @@
+# Skills — knowledge and instructions for your agents
+
+## What is this?
+
+A **skill** is a reusable **set of instructions** that an agent loads when needed.
+Instead of explaining to an agent every single time *how* to do something ("this
+is how you do a code review", "this is how you write a commit message"), you write
+it down once as a skill. The agent then pulls in these instructions on its own
+when the situation fits.
+
+Think of a skill like a **cheat sheet** or **checklist** sitting on a shelf, to be
+opened at the right moment.
+
+## Why is this useful?
+
+- **Consistency**: the agent does a task the same way every time (per your
+  guidance), not differently each time.
+- **Less repetition**: you don't have to re-explain your approach in every
+  conversation.
+- **Save context**: the skill is only loaded when actually needed — it doesn't
+  weigh the agent down all the time.
+
+## Two kinds of skills
+
+- **Your own skills** — that you create and maintain yourself.
+- **System skills** — bundled templates (e.g. for code review, debugging, git
+  workflow). These are ready to use.
+
+## A skill's fields
+
+- **Name** — short identifier (only `a-z`, `0-9`, `_`, `-`). **Note:** it **cannot
+  be changed** after creation.
+- **Description** — what the skill is about (one line).
+- **When to use?** — the most important part: one sentence telling the AI **in
+  which situation** to load this skill. Example: *"When the user asks for a code
+  review."* The clearer, the more reliably the agent reaches for the right skill.
+- **Required tools** — comma-separated list of tools the skill assumes (optional).
+- **Instructions (Markdown)** — the actual content: the step-by-step guide the
+  agent receives on loading.
+- **Sources / URLs** — optional addresses (forums, APIs, docs) the agent may fetch
+  as part of the skill. If a source needs credentials, provide the name of a
+  **credential profile** (see the *Credentials* help) — auth is then injected
+  automatically.
+
+## Step by step: create a skill
+
+1. Click **New skill**.
+2. Give it a **name** (think carefully — it's immutable!).
+3. Fill in **description** and especially **"When to use?"** — this decides whether
+   the agent finds the skill at the right moment.
+4. Under **Instructions** write the actual guide (Markdown: lists, headings, code
+   blocks are allowed).
+5. Optionally add **required tools** and **sources**.
+6. Save.
+
+## Toggle skills per agent
+
+On an agent there's a **Skills tab**: there you see which skills are available for
+that agent and can toggle them individually **on/off**. That way each agent gets
+exactly the instructions that fit its role.
+
+## Common mistakes
+
+- **Agent never loads the skill** — The **"When to use?"** field is too vague.
+  Phrase it concretely and situationally.
+- **"Name invalid"** — Only `a-z`, `0-9`, `_`, `-`, max 50 characters.
+- **Wrong name chosen** — It can't be changed afterwards; if in doubt, create a new
+  one and delete the old.
+- **Source unreachable** — If the URL needs a login, a matching **credential
+  profile** must be stored and referenced in the skill.
+
+## Tips
+
+- **One skill = one purpose.** Prefer several small, clearly named skills over one
+  overloaded one.
+- **"When to use?" is the heart** — invest the most care here.
+- **Use Markdown**: numbered steps and checklists make the guide most reliably
+  followable for the agent.
+- **Look at system skills** as templates to get a feel for good structure.

--- a/frontend/src/i18n/help/en/teamchat.md
+++ b/frontend/src/i18n/help/en/teamchat.md
@@ -1,0 +1,61 @@
+# Team chat — shared rooms for humans and agents
+
+## What is this?
+
+**Team chat** is a group chat where **several humans and several agents** write
+together in a **room**. Unlike the Buddy chat (just you + your assistant), this is
+a shared place — like a Slack or Discord channel, but right inside HydraHive and
+with AI agents as full participants.
+
+## Core terms
+
+- **Room** — a chat channel. Can be **private** (invited members only) or **open**
+  (discoverable/joinable).
+- **Members** — the humans in the room. You see who's **online/offline**.
+- **Attached agents** — AI agents that can read along and reply in the room.
+- **@name** — with an `@` you address a specific agent (or person) directly.
+
+## Step by step: set up a room
+
+1. **New room** → give it a name, optionally add members (comma-separated) right
+   away.
+2. Choose visibility: **Private** or **Open**.
+3. **Create**.
+4. In the room, add one or more agents via **Attach agent**.
+5. Start writing. Use **@name** to address a specific agent directly — without @ it
+   runs as a normal group message.
+
+## Manage members & agents
+
+- **Add / remove member** — by username.
+- **Attach / detach agent** — controls which AI is active in the room.
+- **Discover** — find open rooms and **join**.
+
+## When team chat instead of Buddy?
+
+- **Buddy**: your private 1:1 assistant.
+- **Team chat**: when **several people** should work with the same agent (or
+  several agents) — e.g. a support room, a project room, a brainstorm with multiple
+  specialist agents at once.
+
+## Prerequisite
+
+Team chat technically runs over a **Matrix server** (Tuwunel). If you see *"Team
+chat is not enabled"*, that server is unreachable or team chat is switched off —
+then it must first be enabled/set up under **Extensions**.
+
+## Common questions
+
+- **"The agent doesn't reply"** — Is it **attached** to the room? And did you
+  address it with **@name**?
+- **"I don't see the room"** — For private rooms you must be a **member**; open ones
+  you find via **Discover**.
+- **"Team chat is not enabled"** — The Matrix homeserver is unreachable or team chat
+  is off; see **Extensions**.
+
+## Tips
+
+- **Multiple agents in one room**: handy to let different specialists speak at once
+  — address them specifically via `@name`.
+- **Open rooms** suit topics others should join spontaneously; **private** ones for
+  confidential groups.

--- a/frontend/src/i18n/help/loader.ts
+++ b/frontend/src/i18n/help/loader.ts
@@ -1,9 +1,23 @@
 // Vite glob-Import: lädt Hilfe-Inhalte beim ersten Zugriff lazy nach.
 const modules = import.meta.glob("./*/*.md", { query: "?raw", import: "default" })
 
+// Alle Hilfe-Themen. Ein Topic braucht eine Datei help/<lang>/<topic>.md.
+// Fehlt sie, zeigt der Drawer den "fehlt noch"-Hinweis (kein Crash).
 export type HelpTopic =
-  | "dashboard" | "chat" | "agents" | "projects"
-  | "llm" | "mcp" | "system"
+  // Kern-Nav
+  | "dashboard" | "buddy" | "chat" | "werkstatt" | "agents" | "projects"
+  | "communication" | "teamchat"
+  // Automatisierung
+  | "butler" | "zahnfee" | "skills" | "mcp" | "plugins"
+  // Infrastruktur
+  | "vms" | "containers" | "federation" | "streaming" | "datamining" | "memory"
+  // Konfiguration
+  | "llm" | "credentials" | "system" | "extensions" | "modules" | "users" | "settings"
+  // Einstieg
+  | "onboarding"
+  // Module
+  | "atelier" | "patientenakte" | "cryptoboard" | "notizbuch" | "scratchpad"
+  | "deepresearch" | "homeassistant" | "archiver"
 
 export async function loadHelp(topic: HelpTopic, lang: string): Promise<string> {
   const code = lang.split("-")[0]

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -34,7 +34,10 @@
       "faq_setup": "Setup",
       "glossary_main": "Begriffe A-Z",
       "skills": "Skills",
-      "memory": "Gedächtnis"
+      "memory": "Gedächtnis",
+      "datamining": "Datamining",
+      "communication": "Kommunikation",
+      "teamchat": "Teamchat"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -37,7 +37,8 @@
       "memory": "Gedächtnis",
       "datamining": "Datamining",
       "communication": "Kommunikation",
-      "teamchat": "Teamchat"
+      "teamchat": "Teamchat",
+      "atelier": "Atelier (Medien)"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -15,6 +15,7 @@
     "topics": {
       "onboarding": "Erste Schritte",
       "buddy": "Buddy (Assistent)",
+      "butler": "Butler (Automationen)",
       "credentials": "Credentials",
       "architecture": "3-Ebenen-Architektur",
       "compaction": "Compaction",
@@ -31,7 +32,9 @@
       "faq_general": "Allgemein",
       "faq_errors": "Fehlermeldungen",
       "faq_setup": "Setup",
-      "glossary_main": "Begriffe A-Z"
+      "glossary_main": "Begriffe A-Z",
+      "skills": "Skills",
+      "memory": "Gedächtnis"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -13,6 +13,9 @@
       "glossary": "Glossar"
     },
     "topics": {
+      "onboarding": "Erste Schritte",
+      "buddy": "Buddy (Assistent)",
+      "credentials": "Credentials",
       "architecture": "3-Ebenen-Architektur",
       "compaction": "Compaction",
       "mcp": "MCP-Protokoll",

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -37,7 +37,8 @@
       "memory": "Memory",
       "datamining": "Datamining",
       "communication": "Communication",
-      "teamchat": "Team chat"
+      "teamchat": "Team chat",
+      "atelier": "Atelier (media)"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -34,7 +34,10 @@
       "faq_setup": "Setup",
       "glossary_main": "Terms A-Z",
       "skills": "Skills",
-      "memory": "Memory"
+      "memory": "Memory",
+      "datamining": "Datamining",
+      "communication": "Communication",
+      "teamchat": "Team chat"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -15,6 +15,7 @@
     "topics": {
       "onboarding": "Getting started",
       "buddy": "Buddy (assistant)",
+      "butler": "Butler (automations)",
       "credentials": "Credentials",
       "architecture": "3-Tier Architecture",
       "compaction": "Compaction",
@@ -31,7 +32,9 @@
       "faq_general": "General",
       "faq_errors": "Error messages",
       "faq_setup": "Setup",
-      "glossary_main": "Terms A-Z"
+      "glossary_main": "Terms A-Z",
+      "skills": "Skills",
+      "memory": "Memory"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -13,6 +13,9 @@
       "glossary": "Glossary"
     },
     "topics": {
+      "onboarding": "Getting started",
+      "buddy": "Buddy (assistant)",
+      "credentials": "Credentials",
       "architecture": "3-Tier Architecture",
       "compaction": "Compaction",
       "mcp": "MCP Protocol",


### PR DESCRIPTION
## Warum
User-Feedback: neue Nutzer sind in HydraHive verloren, die In-App-Hilfe war lückenhaft (nur 7 Artikel für ~49 Bereiche, 5 Seiten mit Hilfe-Button).

## Was
Ausführliche, einsteigerfreundliche Deep-Dive-Hilfe-Artikel (de+en), jeweils aus dem echten Code/i18n verifiziert (keine erfundenen Features):

**Neue Artikel (10 Paare de+en):**
- `onboarding` — roter Faden "Erste Schritte" für komplett neue User
- `buddy` — die Startseite/Assistent
- `credentials` — Zugangsdaten (alle Typen, URL-Pattern, Sicherheit)
- `butler` — Automations-Baukasten (Trigger/Bedingung/Aktion, Probelauf)
- `skills` — wiederverwendbare Anleitungen für Agenten
- `memory` — Gedächtnis (Memory/Kristalle/Sessions)
- `datamining` — Archiv & Analyse
- `communication` — WhatsApp/Discord an den Master-Agent
- `teamchat` — gemeinsame Räume mit Menschen + Agenten
- `atelier` — Medien-Modul (Bild/Video/Audio/Regie), Charakter-Konsistenz

**Technik:**
- `loader.ts`: HelpTopic-Union auf alle geplanten Topics erweitert (Glob lädt Artikel automatisch)
- `HelpButton.tsx`: optionale `className`-Prop
- HelpButtons ergänzt: Buddy, Credentials, Butler, Skills, Memory, Datamining, Communication, Teamchat, Agenten/Projekte (Empty-State). Atelier-Button liegt im modules-Repo (Modul-Frontend).
- `help.json` (de+en): Handbuch-Übersicht erweitert
- `docs/HELP-COVERAGE.md`: Fahrplan + Fortschritt

## Test
- `npx tsc --noEmit` grün (inkl. Atelier via Modul-Spiegel-Prozedur)
- help.json de+en valides JSON
- Modul-Snapshot in `frontend/src/modules/atelier` NICHT verändert (nur temporär für tsc gespiegelt, danach restauriert)

## Noch offen (spätere Chargen, in HELP-COVERAGE dokumentiert)
VMs, Container, Users, Patientenakte; Dashboard-Artikel überarbeiten; Phase 3 Feld-Tooltips.