### PR TITLE
feat(modules): Modul-Update-Erkennung, übersichtlichere Liste & Footer-Indikator

### DIFF
--- a/core/src/hydrahive/api/routes/modules.py
+++ b/core/src/hydrahive/api/routes/modules.py
@@ -21,29 +21,52 @@ _SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
 
 @router.get("", dependencies=[Depends(require_admin)])
 def list_modules() -> dict:
-    installed = [
-        {
-            "id": m.name,
-            "loaded": m.loaded,
-            "error": m.error,
-            "version": m.manifest.version if m.manifest else None,
-        }
-        for m in REGISTRY.values()
-    ]
     # Hub vor dem Listen pullen, damit "available" den echten Hub spiegelt.
     # read_hub_index() pullt nur bei FEHLENDEM Cache — ohne dies fröre die Liste
     # auf dem Stand des ersten Clones ein (neue Module würden nie auftauchen).
     # Netzwerk-/Hub-Fehler beim Refresh sind unkritisch → Fallback auf den Cache.
+    # WICHTIG: erst refreshen, DANN available_version() lesen — sonst basiert die
+    # Update-Erkennung auf einem veralteten Cache.
     try:
         hub_client.refresh()
     except Exception as exc:
         logger.warning("Modul-Hub-Refresh fehlgeschlagen, nutze Cache: %s", exc)
+
+    installed = []
+    for m in REGISTRY.values():
+        inst_ver = m.manifest.version if m.manifest else None
+        avail_ver = installer.available_version(m.name)
+        installed.append({
+            "id": m.name,
+            "loaded": m.loaded,
+            "error": m.error,
+            "version": inst_ver,
+            "available_version": avail_ver,
+            "update_available": installer.is_update_available(inst_ver, avail_ver),
+        })
+
     try:
         available = hub_client.read_hub_index().get("modules", [])
     except Exception as exc:  # Hub unerreichbar → leere Liste, aber nicht still schlucken
         logger.warning("Modul-Hub-Index nicht abrufbar: %s", exc)
         available = []
     return {"installed": installed, "available": available}
+
+
+@router.get("/update-count", dependencies=[Depends(require_admin)])
+def module_update_count() -> dict:
+    """Anzahl installierter Module mit verfügbarem Update — billig (kein git-pull).
+
+    Für den Footer-Indikator gedacht. Liest available_version() aus dem
+    VORHANDENEN Hub-Cache, ohne zu refreshen. Fehler → count 0 (nie werfen).
+    """
+    count = 0
+    for m in REGISTRY.values():
+        inst_ver = m.manifest.version if m.manifest else None
+        avail_ver = installer.available_version(m.name)
+        if installer.is_update_available(inst_ver, avail_ver):
+            count += 1
+    return {"count": count}
 
 
 def _stream(gen) -> StreamingResponse:

--- a/core/src/hydrahive/modules/installer.py
+++ b/core/src/hydrahive/modules/installer.py
@@ -53,6 +53,38 @@ def _cache_path_for(module_id: str) -> Path:
     raise InstallError(f"module_not_in_hub:{module_id}")
 
 
+def available_version(module_id: str) -> str | None:
+    """Version aus dem manifest.json des Moduls im Hub-Cache (ohne git-pull).
+
+    Nutzt den bereits vorhandenen Hub-Cache — es wird NICHT frisch gepullt, damit
+    der Aufruf billig bleibt (z.B. für den Footer-Zähler). Fehler/kein Manifest
+    → None (nie werfen; Update-Erkennung darf die Modul-Liste nie sprengen).
+    """
+    from hydrahive.modules.manifest import ManifestError, ModuleManifest
+    try:
+        src = _cache_path_for(module_id)
+        return ModuleManifest.load(src / "manifest.json").version
+    except (InstallError, ManifestError, OSError) as exc:
+        logger.debug("available_version(%s) nicht ermittelbar: %s", module_id, exc)
+        return None
+
+
+def is_update_available(installed: str | None, available: str | None) -> bool:
+    """True, wenn `available` eine neuere Version als `installed` ist.
+
+    Semver-Vergleich via packaging.version; bei Parse-Fehler Fallback auf
+    String-Ungleichheit (konservativ: unterschiedlich → Update anbieten).
+    Fehlt eine der Versionen → kein Update.
+    """
+    if not installed or not available:
+        return False
+    from packaging.version import InvalidVersion, Version
+    try:
+        return Version(available) > Version(installed)
+    except InvalidVersion:
+        return available != installed
+
+
 def copy_module_in(module_id: str) -> None:
     """Kopiert ein Modul aus dem Hub-Cache in die lokalen Verzeichnisse.
 

--- a/core/tests/test_module_installer.py
+++ b/core/tests/test_module_installer.py
@@ -55,3 +55,56 @@ def test_remove_module_files_rejects_traversal_id(mod_env):
     from hydrahive.modules.installer import remove_module_files, InstallError
     with pytest.raises(InstallError):
         remove_module_files("../../etc")
+
+
+# --- Update-Erkennung (Option A: Versionsvergleich) ------------------------
+
+def test_is_update_available_semver():
+    from hydrahive.modules.installer import is_update_available
+    assert is_update_available("1.0.0", "1.1.0") is True
+    assert is_update_available("1.0.0", "2.0.0") is True
+    assert is_update_available("1.2.0", "1.10.0") is True   # echtes Semver, nicht String
+    assert is_update_available("1.1.0", "1.1.0") is False
+    assert is_update_available("2.0.0", "1.0.0") is False   # installiert neuer
+
+
+def test_is_update_available_missing_versions():
+    from hydrahive.modules.installer import is_update_available
+    assert is_update_available(None, "1.0.0") is False
+    assert is_update_available("1.0.0", None) is False
+    assert is_update_available(None, None) is False
+
+
+def test_is_update_available_non_semver_fallback():
+    from hydrahive.modules.installer import is_update_available
+    # Nicht-parsebare Versionen → String-Ungleichheit (konservativ Update anbieten)
+    assert is_update_available("2024-01", "2024-02") is True
+    assert is_update_available("foo", "foo") is False
+
+
+def test_available_version_reads_hub_cache_manifest(mod_env):
+    from unittest.mock import patch
+    src = mod_env / "hub" / "example"
+    src.mkdir(parents=True)
+    (src / "manifest.json").write_text('{"id":"example","name":"X","version":"1.3.0"}')
+    with patch("hydrahive.modules.installer._cache_path_for", return_value=src):
+        from hydrahive.modules.installer import available_version
+        assert available_version("example") == "1.3.0"
+
+
+def test_available_version_missing_manifest_returns_none(mod_env):
+    from unittest.mock import patch
+    src = mod_env / "hub" / "gone"
+    src.mkdir(parents=True)  # kein manifest.json
+    with patch("hydrahive.modules.installer._cache_path_for", return_value=src):
+        from hydrahive.modules.installer import available_version
+        assert available_version("gone") is None
+
+
+def test_available_version_not_in_hub_returns_none(mod_env):
+    # _cache_path_for wirft InstallError, wenn das Modul nicht im Hub steht
+    from hydrahive.modules.installer import available_version
+    from unittest.mock import patch
+    with patch("hydrahive.modules.installer.hub_client.read_hub_index",
+               return_value={"modules": []}):
+        assert available_version("unknown") is None

--- a/core/tests/test_modules_routes.py
+++ b/core/tests/test_modules_routes.py
@@ -47,3 +47,57 @@ def test_install_streams(client, admin_headers):
         r = client.post("/api/admin/modules/example/install", headers=admin_headers)
     assert r.status_code == 200
     assert "line1" in r.text
+
+
+# --- Update-Erkennung: erweiterte Felder + /update-count -------------------
+
+def _fake_registry(version: str = "1.0.0"):
+    """Ein LoadedModule 'demo' mit gegebener installierter Version."""
+    from hydrahive.modules.manifest import ModuleManifest
+    from hydrahive.modules.registry import LoadedModule
+    from pathlib import Path
+    manifest = ModuleManifest(id="demo", name="Demo", version=version)
+    return {"demo": LoadedModule(name="demo", manifest=manifest, path=Path("/x"), loaded=True)}
+
+
+def test_list_modules_marks_update_available(client, admin_headers):
+    with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("1.0.0")), \
+         patch("hydrahive.api.routes.modules.hub_client.refresh"), \
+         patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value={"modules": []}), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.2.0"):
+        r = client.get("/api/admin/modules", headers=admin_headers)
+    assert r.status_code == 200
+    demo = next(m for m in r.json()["installed"] if m["id"] == "demo")
+    assert demo["version"] == "1.0.0"
+    assert demo["available_version"] == "1.2.0"
+    assert demo["update_available"] is True
+
+
+def test_list_modules_no_update_when_current(client, admin_headers):
+    with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("2.0.0")), \
+         patch("hydrahive.api.routes.modules.hub_client.refresh"), \
+         patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value={"modules": []}), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="2.0.0"):
+        r = client.get("/api/admin/modules", headers=admin_headers)
+    demo = next(m for m in r.json()["installed"] if m["id"] == "demo")
+    assert demo["update_available"] is False
+
+
+def test_update_count_admin(client, admin_headers):
+    with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("1.0.0")), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.5.0"):
+        r = client.get("/api/admin/modules/update-count", headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["count"] == 1
+
+
+def test_update_count_zero_when_current(client, admin_headers):
+    with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("1.5.0")), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.5.0"):
+        r = client.get("/api/admin/modules/update-count", headers=admin_headers)
+    assert r.json()["count"] == 0
+
+
+def test_update_count_requires_admin(client, auth_headers):
+    r = client.get("/api/admin/modules/update-count", headers=auth_headers)
+    assert r.status_code in (401, 403)

--- a/docs/specs/modul-updates.md
+++ b/docs/specs/modul-updates.md
@@ -1,0 +1,75 @@
+# Spec: Modul-Update-Erkennung, Übersichtlichkeit & Footer-Indikatoren
+
+## Was
+
+Drei zusammenhängende Verbesserungen der Modul-Verwaltung (`/settings/modules`):
+
+1. **Update-Erkennung pro Modul** — anzeigen, wenn für ein installiertes Modul
+   eine neuere Version im Hub bereitsteht (Versionsvergleich, Option A).
+2. **Übersichtlichkeit** — installierte Module in eine **einklappbare** Sektion;
+   zusätzlich ein **„Alle updaten"**-Button, der nur Module mit verfügbarem
+   Update nacheinander aktualisiert.
+3. **Footer-Indikator** — ein kleiner Blob im Seitenfooter, der auf verfügbare
+   **Modul-Updates** hinweist (analog zum bereits existierenden Core-„↑").
+
+## Warum
+
+Nutzer sehen aktuell nicht, ob ein Modul veraltet ist. Die installierten Module
+blähen die Liste auf. Und der Footer zeigt nur die Core-Version bzw. das
+Core-Update, aber nichts zu Modul-Updates.
+
+## Wie (grob)
+
+### Backend
+
+- **`installer.available_version(module_id) -> str | None`** (neu, öffentlich):
+  liest die `version` aus `manifest.json` im Hub-Cache (via bereits vorhandenem
+  `_cache_path_for`). Fehler/kein Manifest → `None`.
+- **`installer.is_update_available(installed, available) -> bool`** (neu):
+  Semver-Vergleich mit `packaging.version.Version`; bei Parse-Fehler Fallback auf
+  String-Ungleichheit. `available > installed` → `True`.
+- **`GET /api/admin/modules`** erweitern: pro installiertem Modul zusätzlich
+  `available_version: str | null` und `update_available: bool`. (Der Endpoint
+  pullt bereits den Hub — die Cache-Manifeste sind danach aktuell.)
+- **`GET /api/admin/modules/update-count`** (neu, admin): liefert
+  `{ count: N }` = Anzahl installierter Module mit `update_available`. Liest den
+  **vorhandenen Cache ohne git-pull** (billig, für Footer-Poll geeignet).
+
+### Frontend
+
+- **types.ts**: `InstalledModule` um `available_version?: string | null` und
+  `update_available?: boolean` erweitern.
+- **api.ts**: `getModuleUpdateCount(): Promise<{count:number}>`.
+- **ModuleCard (InstalledModuleCard)**: bei `update_available` ein Badge
+  „Update: v{version} → v{available_version}" + Update-Button hervorheben
+  (amber). Ohne Update: Button dezent, Text „Aktuell".
+- **ModulesPage**:
+  - Installierte Sektion **einklappbar** (Toggle im Sektionskopf; Default:
+    eingeklappt, wenn > 0 installiert). Kopf zeigt „Installiert (N)" +
+    „· M Updates" wenn vorhanden.
+  - **„Alle updaten"**-Button (nur sichtbar, wenn ≥1 Update): fährt die Module
+    mit `update_available` **sequentiell** durch (ein Stream nach dem anderen),
+    danach ein `onRefresh`.
+- **AppFooter**: zweiter Blob (nur `isAdmin`) für Modul-Updates: bei `count>0`
+  ein amber „⬢ N", Klick → `/settings/modules`. Nutzt eine neue
+  `moduleUpdateCount`-Prop; Datenquelle in `useLayoutUpdate` (admin-gated
+  Einmal-Load; kein Poll-Zwang).
+
+## Akzeptanzkriterien
+
+- [ ] Ein installiertes Modul mit niedrigerer Version als im Hub zeigt Badge +
+      hervorgehobenen Update-Button.
+- [ ] Ist die installierte Version gleich/höher, kein Update-Hinweis.
+- [ ] Kaputtes/fehlendes Hub-Manifest → kein Absturz, `update_available=false`.
+- [ ] Installierte Sektion ist einklappbar; Update-Zähler im Kopf korrekt.
+- [ ] „Alle updaten" aktualisiert genau die veralteten Module, sequentiell.
+- [ ] Footer zeigt für Admins bei Modul-Updates einen Blob → Klick öffnet
+      Modul-Seite. Für Nicht-Admins unsichtbar.
+- [ ] `npx tsc --noEmit` grün; Backend pytest + ruff grün.
+
+## Nicht in Scope
+
+- Kein automatisches Update ohne Nutzer-Klick.
+- Kein Commit-Fallback (Option A pur — Module ohne Versions-Bump gelten als
+  aktuell; das ist gewollt).
+- Keine Änderung am Update-Mechanismus selbst (`installer.update`).

--- a/frontend/src/features/modules/ModuleCard.tsx
+++ b/frontend/src/features/modules/ModuleCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Boxes, CheckCircle, RefreshCw, XCircle } from "lucide-react"
+import { ArrowUpCircle, Boxes, CheckCircle, RefreshCw, XCircle } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
 import type { AvailableModule, InstalledModule } from "./types"
 import { installModule, uninstallModule, updateModule } from "./api"
@@ -59,6 +59,14 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
                 v{mod.version}
               </span>
             )}
+            {mod.update_available && mod.available_version && (
+              <span
+                title={t("update.available")}
+                className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/15 text-amber-300 border border-amber-500/30">
+                <ArrowUpCircle size={9} />
+                {t("update.badge", { from: mod.version, to: mod.available_version })}
+              </span>
+            )}
             {mod.loaded ? (
               <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
                 <CheckCircle size={9} /> {t("status.loaded")}
@@ -99,9 +107,16 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
         <button
           onClick={() => run("update")}
           disabled={phase === "running"}
-          className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-violet-500/10 hover:bg-violet-500/20 border border-violet-500/20 text-violet-300 text-xs font-medium transition-colors disabled:opacity-40">
+          className={
+            "flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border text-xs font-medium transition-colors disabled:opacity-40 " +
+            (mod.update_available
+              ? "bg-amber-500/15 hover:bg-amber-500/25 border-amber-500/30 text-amber-300"
+              : "bg-violet-500/10 hover:bg-violet-500/20 border-violet-500/20 text-violet-300")
+          }>
           <RefreshCw size={11} className={phase === "running" && action === "update" ? "animate-spin" : ""} />
-          {phase === "running" && action === "update" ? t("actions.updating") : t("actions.update")}
+          {phase === "running" && action === "update"
+            ? t("actions.updating")
+            : mod.update_available ? t("update.available") : t("actions.update")}
         </button>
         <button
           onClick={() => run("uninstall")}

--- a/frontend/src/features/modules/ModulesPage.tsx
+++ b/frontend/src/features/modules/ModulesPage.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Boxes, RefreshCw } from "lucide-react"
+import { ArrowUpCircle, Boxes, ChevronDown, ChevronRight, RefreshCw } from "lucide-react"
 import type { ModulesIndex } from "./types"
-import { listModules } from "./api"
+import { listModules, updateModule } from "./api"
 import { InstalledModuleCard, AvailableModuleCard } from "./ModuleCard"
 
 export function ModulesPage() {
@@ -10,12 +10,18 @@ export function ModulesPage() {
   const [data, setData] = useState<ModulesIndex>({ installed: [], available: [] })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [collapsed, setCollapsed] = useState(false)
+  const [batch, setBatch] = useState<{ done: number; total: number } | null>(null)
+  const stopRef = useRef<(() => void) | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      setData(await listModules())
+      const idx = await listModules()
+      setData(idx)
+      // Bei vielen installierten Modulen die Sektion einklappen → Übersicht.
+      setCollapsed(idx.installed.length > 4)
     } catch (e) {
       setError(String(e))
     }
@@ -25,6 +31,31 @@ export function ModulesPage() {
   // load() ist async — setState passiert nach dem await; die Regel über-feuert hier.
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load() }, [load])
+
+  // Laufenden Batch beim Unmount abbrechen.
+  useEffect(() => () => stopRef.current?.(), [])
+
+  const outdated = data.installed.filter((m) => m.update_available)
+
+  /** Alle veralteten Module sequentiell aktualisieren (ein Stream nach dem anderen). */
+  const updateAll = useCallback(async () => {
+    if (outdated.length === 0 || batch) return
+    setBatch({ done: 0, total: outdated.length })
+    for (let i = 0; i < outdated.length; i++) {
+      await new Promise<void>((resolve) => {
+        stopRef.current = updateModule(
+          outdated[i].id,
+          () => { /* Logs pro Modul zeigt die Karte selbst nicht — Batch ist kompakt */ },
+          () => resolve(),
+          () => resolve(), // Fehler eines Moduls stoppt den Batch nicht
+        )
+      })
+      setBatch({ done: i + 1, total: outdated.length })
+    }
+    stopRef.current = null
+    setBatch(null)
+    await load()
+  }, [outdated, batch, load])
 
   return (
     <div className="space-y-6">
@@ -39,7 +70,8 @@ export function ModulesPage() {
         </div>
         <button
           onClick={load}
-          className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors">
+          disabled={loading || batch !== null}
+          className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors disabled:opacity-40">
           <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
         </button>
       </div>
@@ -52,14 +84,37 @@ export function ModulesPage() {
 
       {/* Installed */}
       <section className="space-y-3">
-        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide">
-          {t("section.installed")}
-        </h2>
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={() => setCollapsed((v) => !v)}
+            className="flex items-center gap-1.5 text-sm font-semibold text-zinc-400 uppercase tracking-wide hover:text-zinc-200 transition-colors">
+            {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
+            {t("section.installed")}
+            {outdated.length > 0 && (
+              <span className="normal-case tracking-normal flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/15 text-amber-300 border border-amber-500/30">
+                <ArrowUpCircle size={9} />
+                {t("update.count", { count: outdated.length })}
+              </span>
+            )}
+          </button>
+          {outdated.length > 0 && (
+            <button
+              onClick={updateAll}
+              disabled={batch !== null}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-500/15 hover:bg-amber-500/25 border border-amber-500/30 text-amber-300 text-xs font-medium transition-colors disabled:opacity-60">
+              <RefreshCw size={12} className={batch ? "animate-spin" : ""} />
+              {batch
+                ? t("update.all_running", { done: batch.done, total: batch.total })
+                : t("update.all")}
+            </button>
+          )}
+        </div>
+
         {loading && data.installed.length === 0 ? (
           <p className="text-zinc-500 text-sm">{t("loading")}</p>
         ) : data.installed.length === 0 ? (
           <p className="text-zinc-500 text-sm">{t("empty_installed")}</p>
-        ) : (
+        ) : collapsed ? null : (
           <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
             {data.installed.map((mod) => (
               <InstalledModuleCard key={mod.id} mod={mod} onRefresh={load} />

--- a/frontend/src/features/modules/api.ts
+++ b/frontend/src/features/modules/api.ts
@@ -13,6 +13,11 @@ export function listModules(): Promise<ModulesIndex> {
   return api.get<ModulesIndex>(BASE)
 }
 
+/** Anzahl installierter Module mit verfügbarem Update (billig, für den Footer). */
+export function getModuleUpdateCount(): Promise<{ count: number }> {
+  return api.get<{ count: number }>(`${BASE}/update-count`)
+}
+
 function stream(
   path: string,
   method: "POST" | "DELETE",

--- a/frontend/src/features/modules/types.ts
+++ b/frontend/src/features/modules/types.ts
@@ -3,6 +3,8 @@ export interface InstalledModule {
   loaded: boolean
   error: string | null
   version: string | null
+  available_version?: string | null
+  update_available?: boolean
 }
 
 export interface AvailableModule {

--- a/frontend/src/i18n/locales/de/modules.json
+++ b/frontend/src/i18n/locales/de/modules.json
@@ -13,6 +13,19 @@
     "error": "Fehler",
     "available": "Verfügbar"
   },
+  "update": {
+    "available": "Update verfügbar",
+    "badge": "v{{from}} → v{{to}}",
+    "current": "Aktuell",
+    "count_one": "{{count}} Update",
+    "count_other": "{{count}} Updates",
+    "all": "Alle updaten",
+    "all_running": "Aktualisiere ({{done}}/{{total}})…"
+  },
+  "section_toggle": {
+    "expand": "Ausklappen",
+    "collapse": "Einklappen"
+  },
   "actions": {
     "install": "Installieren",
     "installing": "Installiert…",

--- a/frontend/src/i18n/locales/de/nav.json
+++ b/frontend/src/i18n/locales/de/nav.json
@@ -48,6 +48,7 @@
   "update": {
     "available": "Update verfügbar — klicken zum Aktualisieren",
     "force": "Update erzwingen / Rebuild",
+    "modules": "{{count}} Modul-Update(s) verfügbar — zur Modul-Verwaltung",
     "modal_title": "System-Update",
     "confirm_question": "Jetzt aktualisieren?",
     "confirm_question_force": "Update erzwingen?",

--- a/frontend/src/i18n/locales/en/modules.json
+++ b/frontend/src/i18n/locales/en/modules.json
@@ -13,6 +13,19 @@
     "error": "Error",
     "available": "Available"
   },
+  "update": {
+    "available": "Update available",
+    "badge": "v{{from}} → v{{to}}",
+    "current": "Up to date",
+    "count_one": "{{count}} update",
+    "count_other": "{{count}} updates",
+    "all": "Update all",
+    "all_running": "Updating ({{done}}/{{total}})…"
+  },
+  "section_toggle": {
+    "expand": "Expand",
+    "collapse": "Collapse"
+  },
   "actions": {
     "install": "Install",
     "installing": "Installing…",

--- a/frontend/src/i18n/locales/en/nav.json
+++ b/frontend/src/i18n/locales/en/nav.json
@@ -48,6 +48,7 @@
   "update": {
     "available": "Update available — click to update",
     "force": "Force update / rebuild",
+    "modules": "{{count}} module update(s) available — go to module management",
     "modal_title": "System update",
     "confirm_question": "Update now?",
     "confirm_question_force": "Force update?",

--- a/frontend/src/shared/AppFooter.tsx
+++ b/frontend/src/shared/AppFooter.tsx
@@ -1,17 +1,19 @@
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
-import { RefreshCw, Settings } from "lucide-react"
+import { Boxes, RefreshCw, Settings } from "lucide-react"
 
 interface Props {
   version: string | null
   commit: string | null
   updateBehind: number | null
+  moduleUpdateCount: number
   isAdmin: boolean
   onUpdateClick: () => void
 }
 
-export function AppFooter({ version, commit, updateBehind, isAdmin, onUpdateClick }: Props) {
+export function AppFooter({ version, commit, updateBehind, moduleUpdateCount, isAdmin, onUpdateClick }: Props) {
   const { t } = useTranslation("nav")
+  const navigate = useNavigate()
   return (
     <footer className="flex items-center justify-between gap-3 px-4 py-1.5 border-t border-white/[6%] bg-zinc-950/80 text-[11px] text-zinc-500">
       <div className="flex items-center gap-3">
@@ -27,6 +29,16 @@ export function AppFooter({ version, commit, updateBehind, isAdmin, onUpdateClic
       <div className="flex items-center gap-2 font-mono tabular-nums">
         {version && (
           <span>v{version}{commit && <> · <span className="text-zinc-600">{commit}</span></>}</span>
+        )}
+        {isAdmin && moduleUpdateCount > 0 && (
+          <button
+            type="button"
+            onClick={() => navigate("/settings/modules")}
+            title={t("update.modules", { count: moduleUpdateCount })}
+            className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-500/15 border border-amber-500/30 text-amber-300 hover:bg-amber-500/25"
+          >
+            <Boxes size={11} /> {moduleUpdateCount}
+          </button>
         )}
         {updateBehind !== null && (
           updateBehind > 0 ? (

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -18,10 +18,10 @@ export function Layout() {
   const { pathname } = useLocation()
 
   const {
-    version, commit, updateBehind,
+    version, commit, updateBehind, moduleUpdateCount,
     updateState, updateError, newCommit,
     confirmUpdate, openUpdateModal, closeUpdateModal,
-  } = useLayoutUpdate()
+  } = useLayoutUpdate(role === "admin")
   const [bentoOpen, setBentoOpen] = useState(false)
 
   // Aktives Theme (aus localStorage). Re-render bei Wechsel via Custom-Event.
@@ -68,7 +68,7 @@ export function Layout() {
     role, t, pathname, visible, quickLinks, currentPage,
     onBentoToggle: () => setBentoOpen((o) => !o),
     footer: {
-      version, commit, updateBehind,
+      version, commit, updateBehind, moduleUpdateCount,
       isAdmin: role === "admin",
       onUpdateClick: openUpdateModal,
     },

--- a/frontend/src/shared/layouts/SidebarLayout.tsx
+++ b/frontend/src/shared/layouts/SidebarLayout.tsx
@@ -95,6 +95,7 @@ export function SidebarLayout({ chrome }: { chrome: LayoutChrome }) {
           version={footer.version}
           commit={footer.commit}
           updateBehind={footer.updateBehind}
+          moduleUpdateCount={footer.moduleUpdateCount}
           isAdmin={footer.isAdmin}
           onUpdateClick={footer.onUpdateClick}
         />

--- a/frontend/src/shared/layouts/TopnavLayout.tsx
+++ b/frontend/src/shared/layouts/TopnavLayout.tsx
@@ -93,6 +93,7 @@ export function TopnavLayout({ chrome }: { chrome: LayoutChrome }) {
         version={footer.version}
         commit={footer.commit}
         updateBehind={footer.updateBehind}
+        moduleUpdateCount={footer.moduleUpdateCount}
         isAdmin={footer.isAdmin}
         onUpdateClick={footer.onUpdateClick}
       />

--- a/frontend/src/shared/layouts/types.ts
+++ b/frontend/src/shared/layouts/types.ts
@@ -23,6 +23,8 @@ export interface LayoutChrome {
     version: string | null
     commit: string | null
     updateBehind: number | null
+    /** Anzahl installierter Module mit verfügbarem Update (0 = keine). */
+    moduleUpdateCount: number
     isAdmin: boolean
     onUpdateClick: () => void
   }

--- a/frontend/src/shared/useLayoutUpdate.ts
+++ b/frontend/src/shared/useLayoutUpdate.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react"
 import { api } from "@/shared/api-client"
+import { getModuleUpdateCount } from "@/features/modules/api"
 import type { UpdateState } from "@/shared/UpdateModal"
 
-export function useLayoutUpdate() {
+export function useLayoutUpdate(isAdmin: boolean) {
   const [version, setVersion] = useState<string | null>(null)
   const [commit, setCommit] = useState<string | null>(null)
   const [updateBehind, setUpdateBehind] = useState<number | null>(null)
+  const [moduleUpdateCount, setModuleUpdateCount] = useState(0)
   const [updateState, setUpdateState] = useState<"idle" | UpdateState>("idle")
   const [updateError, setUpdateError] = useState<string | null>(null)
   const [newCommit, setNewCommit] = useState<string | null>(null)
@@ -20,6 +22,22 @@ export function useLayoutUpdate() {
     const t = setInterval(loadHealth, 5 * 60 * 1000)
     return () => clearInterval(t)
   }, [])
+
+  // Modul-Update-Zähler nur für Admins (Endpoint ist admin-gated). Billiger
+  // Cache-Read im Backend (kein git-pull) — trotzdem selten pollen.
+  useEffect(() => {
+    // Nur Admins fragen den (admin-gated) Zähler ab. Nicht-Admins: bleibt 0
+    // (Initialwert) — kein synchroner setState im Effect nötig.
+    if (!isAdmin) return
+    function loadModuleUpdates() {
+      getModuleUpdateCount()
+        .then((r) => setModuleUpdateCount(r.count))
+        .catch(() => {})
+    }
+    loadModuleUpdates()
+    const t = setInterval(loadModuleUpdates, 15 * 60 * 1000)
+    return () => clearInterval(t)
+  }, [isAdmin])
 
   async function confirmUpdate() {
     setUpdateState("starting"); setUpdateError(null)
@@ -62,7 +80,7 @@ export function useLayoutUpdate() {
   }
 
   return {
-    version, commit, updateBehind,
+    version, commit, updateBehind, moduleUpdateCount,
     updateState, updateError, newCommit,
     confirmUpdate,
     openUpdateModal: () => { setUpdateState("confirm"); setUpdateError(null); setNewCommit(null) },


### PR DESCRIPTION
## Warum
Drei User-Wünsche zur Modul-Verwaltung:
1. Man sieht nicht, wenn für ein Modul ein **Update** vorliegt.
2. Die installierten Module machen die Liste unübersichtlich → **einklappbar** + **"Alle updaten"**.
3. Im **Footer** soll ein kleiner Blob auf verfügbare Modul-Updates hinweisen, statt nur der Versionsnummer.

## Ansatz
**Option A — Versionsvergleich** (Spec: `docs/specs/modul-updates.md`). Die `hub.json` hat keine Versionen; die stehen im `manifest.json` jedes Moduls. Also: installierte Version vs. Version im frisch gepullten Hub-Cache vergleichen (Semver via `packaging.version`).

## Backend
- `installer.available_version(id)` — Version aus Hub-Cache-Manifest (ohne git-pull; Fehler → None).
- `installer.is_update_available(installed, available)` — Semver-Vergleich, Fallback String-Ungleichheit.
- `GET /api/admin/modules` — pro Modul `available_version` + `update_available` (refresh vor Versions-Lesen).
- `GET /api/admin/modules/update-count` — billiger Zähler für den Footer (nutzt vorhandenen Cache, kein pull).
- 11 neue Tests (Unit + Route), ruff clean.

## Frontend
- **InstalledModuleCard**: amber Badge `v1.0 → v1.2` + hervorgehobener Update-Button bei Update.
- **ModulesPage**: installierte Sektion einklappbar (auto bei >4 Modulen), Update-Zähler im Kopf, "Alle updaten" (sequentiell nur die veralteten).
- **AppFooter**: admin-only Modul-Update-Blob (amber, Boxes-Icon) → Klick öffnet `/settings/modules`.
- `useLayoutUpdate(isAdmin)`: lädt den Zähler nur für Admins (15-min-Poll).
- i18n de+en für alle neuen Strings.

## Test
- Backend: 20 passed (Modul-Installer + Routes), ruff clean.
- Frontend: `tsc --noEmit` grün, `eslint` clean.

## Nicht in Scope
Kein Auto-Update ohne Klick. Kein Commit-Fallback (Option A pur: Module ohne Versions-Bump gelten als aktuell — gewollt).
