### PR TITLE
feat(modules): vereinheitlichte Modul-Liste, Beschreibungen & auffälligere Hilfe

### DIFF
--- a/core/src/hydrahive/api/routes/modules.py
+++ b/core/src/hydrahive/api/routes/modules.py
@@ -21,36 +21,68 @@ _SSE_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
 
 @router.get("", dependencies=[Depends(require_admin)])
 def list_modules() -> dict:
-    # Hub vor dem Listen pullen, damit "available" den echten Hub spiegelt.
-    # read_hub_index() pullt nur bei FEHLENDEM Cache — ohne dies fröre die Liste
-    # auf dem Stand des ersten Clones ein (neue Module würden nie auftauchen).
-    # Netzwerk-/Hub-Fehler beim Refresh sind unkritisch → Fallback auf den Cache.
-    # WICHTIG: erst refreshen, DANN available_version() lesen — sonst basiert die
-    # Update-Erkennung auf einem veralteten Cache.
+    """Eine gemergte Liste aller Module (installiert + verfügbar).
+
+    Jeder Eintrag trägt `installed` + Status. Der Hub-Index liefert alle bekannten
+    Module; REGISTRY liefert den installierten Stand (überschreibt Name/Beschreibung
+    mit dem tatsächlich installierten Manifest).
+    """
+    # Erst refreshen, DANN available_version/description lesen — sonst basiert die
+    # Update-Erkennung auf einem veralteten Cache. Hub-Fehler sind unkritisch.
     try:
         hub_client.refresh()
     except Exception as exc:
         logger.warning("Modul-Hub-Refresh fehlgeschlagen, nutze Cache: %s", exc)
+    try:
+        hub_modules = hub_client.read_hub_index().get("modules", [])
+    except Exception as exc:
+        logger.warning("Modul-Hub-Index nicht abrufbar: %s", exc)
+        hub_modules = []
 
-    installed = []
+    # id → Eintrag. Basis aus dem Hub (auch nicht-installierte Module).
+    by_id: dict[str, dict] = {}
+    for hm in hub_modules:
+        mid = hm.get("id")
+        if not mid:
+            continue
+        avail_ver = installer.available_version(mid)
+        by_id[mid] = {
+            "id": mid,
+            "name": hm.get("name") or mid,
+            "description": installer.available_description(mid),
+            "installed": False,
+            "loaded": False,
+            "error": None,
+            "version": None,
+            "available_version": avail_ver,
+            "update_available": False,
+        }
+
+    # Installierte Module drüberlegen (Name/Beschreibung aus dem echten Manifest).
     for m in REGISTRY.values():
         inst_ver = m.manifest.version if m.manifest else None
         avail_ver = installer.available_version(m.name)
-        installed.append({
+        entry = by_id.get(m.name, {"id": m.name})
+        entry.update({
             "id": m.name,
+            "name": (m.manifest.name if m.manifest else None) or entry.get("name") or m.name,
+            "description": (m.manifest.description if m.manifest else "")
+                           or entry.get("description", ""),
+            "installed": True,
             "loaded": m.loaded,
             "error": m.error,
             "version": inst_ver,
             "available_version": avail_ver,
             "update_available": installer.is_update_available(inst_ver, avail_ver),
         })
+        by_id[m.name] = entry
 
-    try:
-        available = hub_client.read_hub_index().get("modules", [])
-    except Exception as exc:  # Hub unerreichbar → leere Liste, aber nicht still schlucken
-        logger.warning("Modul-Hub-Index nicht abrufbar: %s", exc)
-        available = []
-    return {"installed": installed, "available": available}
+    # Sortierung: installierte zuerst, dann alphabetisch nach Name.
+    modules = sorted(
+        by_id.values(),
+        key=lambda e: (not e["installed"], e["name"].lower()),
+    )
+    return {"modules": modules}
 
 
 @router.get("/update-count", dependencies=[Depends(require_admin)])

--- a/core/src/hydrahive/modules/installer.py
+++ b/core/src/hydrahive/modules/installer.py
@@ -69,6 +69,21 @@ def available_version(module_id: str) -> str | None:
         return None
 
 
+def available_description(module_id: str) -> str:
+    """Beschreibung aus dem manifest.json des Moduls im Hub-Cache (ohne git-pull).
+
+    Für die (noch) nicht installierte Ansicht — die installierte Beschreibung
+    kommt aus dem REGISTRY-Manifest. Fehler/kein Manifest → "" (nie werfen).
+    """
+    from hydrahive.modules.manifest import ManifestError, ModuleManifest
+    try:
+        src = _cache_path_for(module_id)
+        return ModuleManifest.load(src / "manifest.json").description
+    except (InstallError, ManifestError, OSError) as exc:
+        logger.debug("available_description(%s) nicht ermittelbar: %s", module_id, exc)
+        return ""
+
+
 def is_update_available(installed: str | None, available: str | None) -> bool:
     """True, wenn `available` eine neuere Version als `installed` ist.
 

--- a/core/src/hydrahive/modules/manifest.py
+++ b/core/src/hydrahive/modules/manifest.py
@@ -14,6 +14,7 @@ class ModuleManifest:
     id: str
     name: str
     version: str
+    description: str = ""
     icon: str = "Boxes"
     nav_group: str = "working"
     permissions: tuple[str, ...] = ()
@@ -34,6 +35,7 @@ class ModuleManifest:
             raise ManifestError(f"manifest.json: ungültige id {d['id']!r} (nur a-z0-9-)")
         return cls(
             id=d["id"], name=d["name"], version=str(d["version"]),
+            description=str(d.get("description", "")),
             icon=d.get("icon", "Boxes"), nav_group=d.get("nav_group", "working"),
             permissions=tuple(d.get("permissions", [])),
             has_service=bool(d.get("has_service", False)),

--- a/core/tests/test_module_installer.py
+++ b/core/tests/test_module_installer.py
@@ -108,3 +108,25 @@ def test_available_version_not_in_hub_returns_none(mod_env):
     with patch("hydrahive.modules.installer.hub_client.read_hub_index",
                return_value={"modules": []}):
         assert available_version("unknown") is None
+
+
+def test_available_description_reads_hub_cache_manifest(mod_env):
+    from unittest.mock import patch
+    src = mod_env / "hub" / "demo"
+    src.mkdir(parents=True)
+    (src / "manifest.json").write_text(
+        '{"id":"demo","name":"Demo","version":"1.0.0","description":"Zwei Sätze. Test."}'
+    )
+    with patch("hydrahive.modules.installer._cache_path_for", return_value=src):
+        from hydrahive.modules.installer import available_description
+        assert available_description("demo") == "Zwei Sätze. Test."
+
+
+def test_available_description_missing_returns_empty(mod_env):
+    from unittest.mock import patch
+    src = mod_env / "hub" / "nodesc"
+    src.mkdir(parents=True)
+    (src / "manifest.json").write_text('{"id":"nodesc","name":"X","version":"1.0.0"}')
+    with patch("hydrahive.modules.installer._cache_path_for", return_value=src):
+        from hydrahive.modules.installer import available_description
+        assert available_description("nodesc") == ""

--- a/core/tests/test_modules_routes.py
+++ b/core/tests/test_modules_routes.py
@@ -10,11 +10,11 @@ def test_list_modules_admin(client, admin_headers):
         r = client.get("/api/admin/modules", headers=admin_headers)
     assert r.status_code == 200
     body = r.json()
-    assert "installed" in body and "available" in body
+    assert "modules" in body and isinstance(body["modules"], list)
 
 
 def test_list_modules_refreshes_hub(client, admin_headers):
-    # Die "available"-Liste muss den echten Hub spiegeln → vor dem Listen pullen.
+    # Die Liste muss den echten Hub spiegeln → vor dem Listen pullen.
     with patch("hydrahive.api.routes.modules.hub_client.refresh") as mock_refresh, \
          patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value={"modules": []}):
         r = client.get("/api/admin/modules", headers=admin_headers)
@@ -22,15 +22,34 @@ def test_list_modules_refreshes_hub(client, admin_headers):
     mock_refresh.assert_called_once()
 
 
+def test_list_modules_includes_uninstalled_hub_module(client, admin_headers):
+    # Ein Hub-Modul, das NICHT installiert ist, erscheint mit installed=False.
+    cached = {"modules": [{"id": "example", "name": "Beispiel", "path": "example"}]}
+    with patch("hydrahive.api.routes.modules.REGISTRY", {}), \
+         patch("hydrahive.api.routes.modules.hub_client.refresh"), \
+         patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value=cached), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.0.0"), \
+         patch("hydrahive.api.routes.modules.installer.available_description", return_value="Ein Demo-Modul."):
+        r = client.get("/api/admin/modules", headers=admin_headers)
+    assert r.status_code == 200
+    ex = next(m for m in r.json()["modules"] if m["id"] == "example")
+    assert ex["installed"] is False
+    assert ex["name"] == "Beispiel"
+    assert ex["description"] == "Ein Demo-Modul."
+
+
 def test_list_modules_refresh_failure_falls_back_to_cache(client, admin_headers):
     # Netzwerk-/Hub-Fehler beim Refresh darf die Liste nicht killen — Cache-Fallback.
     from hydrahive.modules.hub_client import HubError
     cached = {"modules": [{"id": "example", "name": "X", "path": "example"}]}
-    with patch("hydrahive.api.routes.modules.hub_client.refresh", side_effect=HubError("net down")), \
-         patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value=cached):
+    with patch("hydrahive.api.routes.modules.REGISTRY", {}), \
+         patch("hydrahive.api.routes.modules.hub_client.refresh", side_effect=HubError("net down")), \
+         patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value=cached), \
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value=None), \
+         patch("hydrahive.api.routes.modules.installer.available_description", return_value=""):
         r = client.get("/api/admin/modules", headers=admin_headers)
     assert r.status_code == 200
-    assert any(m["id"] == "example" for m in r.json()["available"])
+    assert any(m["id"] == "example" for m in r.json()["modules"])
 
 
 def test_list_modules_requires_admin(client, auth_headers):
@@ -64,10 +83,12 @@ def test_list_modules_marks_update_available(client, admin_headers):
     with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("1.0.0")), \
          patch("hydrahive.api.routes.modules.hub_client.refresh"), \
          patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value={"modules": []}), \
-         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.2.0"):
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="1.2.0"), \
+         patch("hydrahive.api.routes.modules.installer.available_description", return_value=""):
         r = client.get("/api/admin/modules", headers=admin_headers)
     assert r.status_code == 200
-    demo = next(m for m in r.json()["installed"] if m["id"] == "demo")
+    demo = next(m for m in r.json()["modules"] if m["id"] == "demo")
+    assert demo["installed"] is True
     assert demo["version"] == "1.0.0"
     assert demo["available_version"] == "1.2.0"
     assert demo["update_available"] is True
@@ -77,9 +98,10 @@ def test_list_modules_no_update_when_current(client, admin_headers):
     with patch("hydrahive.api.routes.modules.REGISTRY", _fake_registry("2.0.0")), \
          patch("hydrahive.api.routes.modules.hub_client.refresh"), \
          patch("hydrahive.api.routes.modules.hub_client.read_hub_index", return_value={"modules": []}), \
-         patch("hydrahive.api.routes.modules.installer.available_version", return_value="2.0.0"):
+         patch("hydrahive.api.routes.modules.installer.available_version", return_value="2.0.0"), \
+         patch("hydrahive.api.routes.modules.installer.available_description", return_value=""):
         r = client.get("/api/admin/modules", headers=admin_headers)
-    demo = next(m for m in r.json()["installed"] if m["id"] == "demo")
+    demo = next(m for m in r.json()["modules"] if m["id"] == "demo")
     assert demo["update_available"] is False
 
 

--- a/docs/specs/modul-liste-vereinheitlicht.md
+++ b/docs/specs/modul-liste-vereinheitlicht.md
@@ -1,0 +1,88 @@
+# Spec: Modul-Verwaltung — eine Liste, Beschreibungen, kontextabhängige Buttons
+
+## Was
+
+Die Modul-Verwaltung (`/settings/modules`) wird umgebaut:
+
+1. **Eine einzige Liste** aller Module (installiert + verfügbar gemischt), statt
+   zwei getrennter Sektionen. Die separate „Verfügbare Module"-Sektion entfällt.
+2. Jedes Modul zeigt eine **2-Satz-Beschreibung** (aus dem Manifest).
+3. **Kontextabhängige Buttons**:
+   - nicht installiert → **Installieren**
+   - installiert → **Aktualisieren** (nur hervorgehoben, wenn Update vorliegt) +
+     **Deinstallieren**. Der Installieren-Button verschwindet nach Installation.
+4. Der **Hilfe-Button** der Seite wird auffälliger.
+
+## Warum
+
+Die Trennung „installiert oben / verfügbar unten" ist unübersichtlich; ein Modul
+tauchte doppelt gedacht auf (verfügbar-Liste zeigt auch Installiertes). Eine
+Liste mit klarem Status pro Karte ist verständlicher. Beschreibungen helfen neuen
+Nutzern zu verstehen, was ein Modul tut, bevor sie installieren.
+
+## Wie (grob)
+
+### Backend
+
+- **`ModuleManifest`** (manifest.py): neues optionales Feld
+  `description: str = ""`. In `load()` aus `d.get("description", "")` lesen.
+- **`installer.available_description(module_id) -> str`** (neu, analog
+  `available_version`): liest `description` aus dem Hub-Cache-Manifest (ohne
+  git-pull). Fehler → "".
+- **`GET /api/admin/modules`**: Antwort umbauen auf **eine** gemergte Liste
+  `modules`, jeder Eintrag:
+  ```
+  {
+    id, name, description,
+    installed: bool,
+    loaded: bool, error: str|null,          # nur wenn installed
+    version: str|null,                       # installierte Version
+    available_version: str|null,
+    update_available: bool
+  }
+  ```
+  Quelle: Hub-Index (alle bekannten Module) ⋃ REGISTRY (installierte). `name`/
+  `description` bevorzugt aus REGISTRY-Manifest (installiert), sonst aus
+  Hub-Cache. Rückwärtskompatibel: `installed`/`available` weiterhin mitliefern
+  ist NICHT nötig (Frontend wird mitgezogen) — aber `update-count` bleibt.
+- **`update-count`** bleibt unverändert.
+
+### Frontend
+
+- **types.ts**: `ModuleEntry` (vereinheitlicht) ersetzt Installed/Available-Split.
+- **api.ts**: `listModules()` liefert `{ modules: ModuleEntry[] }`.
+- **ModuleCard**: EINE Karte, die per `mod.installed` die Buttons wählt:
+  - nicht installiert: „Installieren" (violett).
+  - installiert: „Aktualisieren" (amber wenn `update_available`, sonst dezent) +
+    „Deinstallieren". Version-Badge + ggf. Update-Badge „v1.0 → v1.2".
+  - Beschreibung (2 Sätze) immer sichtbar.
+  - Nach erfolgreicher Aktion → `onRefresh()` (Liste neu laden → Buttons wechseln).
+- **ModulesPage**: eine Grid-Liste, sortiert (installiert zuerst, dann
+  alphabetisch). Kopf behält „Alle updaten" (nur veraltete). Kein Collapse mehr
+  nötig, aber „N Updates"-Zähler bleibt sinnvoll.
+- **Hilfe-Button auffälliger**: `HelpButton` bekommt eine `prominent`-Variante
+  (Text „Hilfe" + kräftigere Farbe/Border statt nur graues Icon). Auf der
+  Modul-Seite (und generell nutzbar).
+
+### Modul-Manifeste (hydrahive2-modules)
+
+Alle 15 Module bekommen `description` (2 Sätze, deutsch) im `manifest.json`.
+**Version-Bump**: Da sich die Manifeste ändern, hebe ich die Patch-Version jedes
+Moduls an (z.B. 1.0.0 → 1.0.1), damit die Update-Erkennung greift und der User
+das Beschreibungs-Update auch als Update sieht. (Versionierung macht der Agent.)
+
+## Akzeptanzkriterien
+
+- [ ] Eine Liste; keine „Verfügbare Module"-Sektion mehr.
+- [ ] Jede Karte zeigt eine 2-Satz-Beschreibung.
+- [ ] Nicht installiert → nur „Installieren". Nach Klick + Neuladen → „Aktualisieren"
+      + „Deinstallieren", kein „Installieren" mehr.
+- [ ] Update-Badge/Hervorhebung nur bei echtem Versions-Update.
+- [ ] Hilfe-Button ist deutlich sichtbarer (Text + Farbe).
+- [ ] Backend liefert `description`; fehlt sie, leerer String (kein Crash).
+- [ ] `tsc` grün, `eslint` clean, Backend pytest + ruff grün.
+
+## Nicht in Scope
+
+- Keine Mehrsprachigkeit der Beschreibungen (einsprachig im Manifest).
+- Kein Auto-Update.

--- a/frontend/src/features/modules/ModuleCard.tsx
+++ b/frontend/src/features/modules/ModuleCard.tsx
@@ -3,21 +3,22 @@ import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ArrowUpCircle, Boxes, CheckCircle, RefreshCw, XCircle } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
-import type { AvailableModule, InstalledModule } from "./types"
+import type { ModuleEntry } from "./types"
 import { installModule, uninstallModule, updateModule } from "./api"
 
 type Phase = "idle" | "running" | "done"
-type Action = "update" | "uninstall"
+type Action = "install" | "update" | "uninstall"
 
-interface InstalledCardProps {
-  mod: InstalledModule
+interface Props {
+  mod: ModuleEntry
   onRefresh: () => void
 }
 
-export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
+/** Eine Karte pro Modul — Buttons je nach Installationsstatus. */
+export function ModuleCard({ mod, onRefresh }: Props) {
   const { t } = useTranslation("modules")
   const [phase, setPhase] = useState<Phase>("idle")
-  const [action, setAction] = useState<Action>("update")
+  const [action, setAction] = useState<Action>("install")
   const [lines, setLines] = useState<string[]>([])
   const [failed, setFailed] = useState(false)
   const logRef = useRef<HTMLDivElement>(null)
@@ -27,12 +28,14 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
     logRef.current?.scrollTo(0, logRef.current.scrollHeight)
   }, [lines])
 
+  useEffect(() => () => stopRef.current?.(), [])
+
   function run(a: Action) {
     setAction(a)
     setPhase("running")
     setLines([])
     setFailed(false)
-    const fn = a === "update" ? updateModule : uninstallModule
+    const fn = a === "install" ? installModule : a === "update" ? updateModule : uninstallModule
     stopRef.current = fn(
       mod.id,
       (line) => setLines((l) => [...l.slice(-500), line]),
@@ -41,19 +44,21 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
     )
   }
 
-  useEffect(() => {
-    return () => stopRef.current?.()
-  }, [])
+  const busy = phase === "running"
 
   return (
     <div className="box overflow-hidden flex flex-col gap-3 p-4" style={{ "--c": rgbFor("/plugins") } as CSSProperties}>
       <div className="flex items-start gap-3">
-        <div className="p-2 rounded-lg bg-emerald-500/10 text-emerald-400 shrink-0">
+        <div className={
+          "p-2 rounded-lg shrink-0 " +
+          (mod.installed ? "bg-emerald-500/10 text-emerald-400" : "bg-zinc-700/50 text-zinc-400")
+        }>
           <Boxes size={18} />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="font-medium text-zinc-100 text-sm">{mod.id}</span>
+            <span className="font-medium text-zinc-100 text-sm">{mod.name}</span>
+            <span className="text-[10px] text-zinc-500 font-mono">{mod.id}</span>
             {mod.version && (
               <span className="px-1.5 py-0.5 rounded-full text-[10px] bg-zinc-800 text-zinc-400 border border-white/[6%]">
                 v{mod.version}
@@ -67,16 +72,21 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
                 {t("update.badge", { from: mod.version, to: mod.available_version })}
               </span>
             )}
-            {mod.loaded ? (
-              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
-                <CheckCircle size={9} /> {t("status.loaded")}
-              </span>
-            ) : (
-              <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-rose-500/15 text-rose-400 border border-rose-500/30">
-                <XCircle size={9} /> {t("status.error")}
-              </span>
+            {mod.installed && (
+              mod.loaded ? (
+                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
+                  <CheckCircle size={9} /> {t("status.loaded")}
+                </span>
+              ) : (
+                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-rose-500/15 text-rose-400 border border-rose-500/30">
+                  <XCircle size={9} /> {t("status.error")}
+                </span>
+              )
             )}
           </div>
+          {mod.description && (
+            <p className="text-[12px] text-zinc-400 mt-1 leading-snug">{mod.description}</p>
+          )}
           {mod.error && (
             <p className="text-[11px] text-rose-400 mt-0.5 font-mono">{mod.error}</p>
           )}
@@ -103,113 +113,37 @@ export function InstalledModuleCard({ mod, onRefresh }: InstalledCardProps) {
         </div>
       )}
 
-      <div className="flex gap-2">
+      {mod.installed ? (
+        <div className="flex gap-2">
+          <button
+            onClick={() => run("update")}
+            disabled={busy}
+            className={
+              "flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border text-xs font-medium transition-colors disabled:opacity-40 " +
+              (mod.update_available
+                ? "bg-amber-500/15 hover:bg-amber-500/25 border-amber-500/30 text-amber-300"
+                : "bg-violet-500/10 hover:bg-violet-500/20 border-violet-500/20 text-violet-300")
+            }>
+            <RefreshCw size={11} className={busy && action === "update" ? "animate-spin" : ""} />
+            {busy && action === "update"
+              ? t("actions.updating")
+              : mod.update_available ? t("update.available") : t("actions.update")}
+          </button>
+          <button
+            onClick={() => run("uninstall")}
+            disabled={busy}
+            className="flex-1 py-1.5 rounded-lg bg-rose-500/10 hover:bg-rose-500/20 border border-rose-500/20 text-rose-400 text-xs font-medium transition-colors disabled:opacity-40">
+            {busy && action === "uninstall" ? t("actions.uninstalling") : t("actions.uninstall")}
+          </button>
+        </div>
+      ) : (
         <button
-          onClick={() => run("update")}
-          disabled={phase === "running"}
-          className={
-            "flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border text-xs font-medium transition-colors disabled:opacity-40 " +
-            (mod.update_available
-              ? "bg-amber-500/15 hover:bg-amber-500/25 border-amber-500/30 text-amber-300"
-              : "bg-violet-500/10 hover:bg-violet-500/20 border-violet-500/20 text-violet-300")
-          }>
-          <RefreshCw size={11} className={phase === "running" && action === "update" ? "animate-spin" : ""} />
-          {phase === "running" && action === "update"
-            ? t("actions.updating")
-            : mod.update_available ? t("update.available") : t("actions.update")}
+          onClick={() => run("install")}
+          disabled={busy}
+          className="py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-medium transition-colors disabled:opacity-40">
+          {busy && action === "install" ? t("actions.installing") : t("actions.install")}
         </button>
-        <button
-          onClick={() => run("uninstall")}
-          disabled={phase === "running"}
-          className="flex-1 py-1.5 rounded-lg bg-rose-500/10 hover:bg-rose-500/20 border border-rose-500/20 text-rose-400 text-xs font-medium transition-colors disabled:opacity-40">
-          {phase === "running" && action === "uninstall" ? t("actions.uninstalling") : t("actions.uninstall")}
-        </button>
-      </div>
-    </div>
-  )
-}
-
-interface AvailableCardProps {
-  mod: AvailableModule
-  onRefresh: () => void
-}
-
-export function AvailableModuleCard({ mod, onRefresh }: AvailableCardProps) {
-  const { t } = useTranslation("modules")
-  const [phase, setPhase] = useState<Phase>("idle")
-  const [lines, setLines] = useState<string[]>([])
-  const [failed, setFailed] = useState(false)
-  const logRef = useRef<HTMLDivElement>(null)
-  const stopRef = useRef<(() => void) | null>(null)
-
-  useEffect(() => {
-    logRef.current?.scrollTo(0, logRef.current.scrollHeight)
-  }, [lines])
-
-  function handleInstall() {
-    setPhase("running")
-    setLines([])
-    setFailed(false)
-    stopRef.current = installModule(
-      mod.id,
-      (line) => setLines((l) => [...l.slice(-500), line]),
-      () => { setPhase("done"); onRefresh() },
-      (msg) => { setLines((l) => [...l, `[FEHLER] ${msg}`]); setFailed(true); setPhase("done") },
-    )
-  }
-
-  useEffect(() => {
-    return () => stopRef.current?.()
-  }, [])
-
-  return (
-    <div className="box overflow-hidden flex flex-col gap-3 p-4" style={{ "--c": rgbFor("/plugins") } as CSSProperties}>
-      <div className="flex items-start gap-3">
-        <div className="p-2 rounded-lg bg-zinc-700/50 text-zinc-400 shrink-0">
-          <Boxes size={18} />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="font-medium text-zinc-100 text-sm">{mod.name ?? mod.id}</span>
-            {mod.name && mod.name !== mod.id && (
-              <span className="text-[10px] text-zinc-500 font-mono">{mod.id}</span>
-            )}
-            <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-zinc-800 text-zinc-400 border border-white/[6%]">
-              {t("status.available")}
-            </span>
-          </div>
-          {mod.path && (
-            <p className="text-[11px] text-zinc-600 mt-0.5 font-mono truncate">{mod.path}</p>
-          )}
-        </div>
-      </div>
-
-      {phase !== "idle" && (
-        <div ref={logRef}
-          className="overflow-y-auto p-3 font-mono text-[11px] leading-relaxed bg-zinc-950/50 rounded-lg max-h-40">
-          {lines.length === 0 && <span className="text-zinc-600">{t("log.waiting")}</span>}
-          {lines.map((l, i) => (
-            <div key={i} className={
-              l.startsWith("[OK]") ? "text-emerald-400" :
-              l.startsWith("[FEHLER]") || l.startsWith("[ERROR]") ? "text-rose-400" :
-              l.startsWith("[WARN]") ? "text-amber-400" :
-              "text-zinc-300"
-            }>{l}</div>
-          ))}
-          {phase === "done" && (
-            <div className={`mt-1 font-medium ${failed ? "text-rose-400" : "text-emerald-400"}`}>
-              {failed ? t("log.failed") : t("log.success")}
-            </div>
-          )}
-        </div>
       )}
-
-      <button
-        onClick={handleInstall}
-        disabled={phase === "running"}
-        className="py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-medium transition-colors disabled:opacity-40">
-        {phase === "running" ? t("actions.installing") : t("actions.install")}
-      </button>
     </div>
   )
 }

--- a/frontend/src/features/modules/ModulesPage.tsx
+++ b/frontend/src/features/modules/ModulesPage.tsx
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { ArrowUpCircle, Boxes, ChevronDown, ChevronRight, RefreshCw } from "lucide-react"
+import { ArrowUpCircle, Boxes, RefreshCw } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
 import type { ModulesIndex } from "./types"
 import { listModules, updateModule } from "./api"
-import { InstalledModuleCard, AvailableModuleCard } from "./ModuleCard"
+import { ModuleCard } from "./ModuleCard"
 
 export function ModulesPage() {
   const { t } = useTranslation("modules")
-  const [data, setData] = useState<ModulesIndex>({ installed: [], available: [] })
+  const [data, setData] = useState<ModulesIndex>({ modules: [] })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [collapsed, setCollapsed] = useState(false)
   const [batch, setBatch] = useState<{ done: number; total: number } | null>(null)
   const stopRef = useRef<(() => void) | null>(null)
 
@@ -18,10 +18,7 @@ export function ModulesPage() {
     setLoading(true)
     setError(null)
     try {
-      const idx = await listModules()
-      setData(idx)
-      // Bei vielen installierten Modulen die Sektion einklappen → Übersicht.
-      setCollapsed(idx.installed.length > 4)
+      setData(await listModules())
     } catch (e) {
       setError(String(e))
     }
@@ -32,10 +29,10 @@ export function ModulesPage() {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { load() }, [load])
 
-  // Laufenden Batch beim Unmount abbrechen.
   useEffect(() => () => stopRef.current?.(), [])
 
-  const outdated = data.installed.filter((m) => m.update_available)
+  const outdated = data.modules.filter((m) => m.update_available)
+  const installedCount = data.modules.filter((m) => m.installed).length
 
   /** Alle veralteten Module sequentiell aktualisieren (ein Stream nach dem anderen). */
   const updateAll = useCallback(async () => {
@@ -45,7 +42,7 @@ export function ModulesPage() {
       await new Promise<void>((resolve) => {
         stopRef.current = updateModule(
           outdated[i].id,
-          () => { /* Logs pro Modul zeigt die Karte selbst nicht — Batch ist kompakt */ },
+          () => { /* Batch kompakt — pro-Modul-Logs zeigt die Karte selbst */ },
           () => resolve(),
           () => resolve(), // Fehler eines Moduls stoppt den Batch nicht
         )
@@ -58,45 +55,24 @@ export function ModulesPage() {
   }, [outdated, batch, load])
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <Boxes className="text-violet-400" size={20} />
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
           <span className="text-xs text-zinc-500">
-            {t("installed_count", { count: data.installed.length })}
+            {t("installed_count", { count: installedCount })}
           </span>
+          {outdated.length > 0 && (
+            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/15 text-amber-300 border border-amber-500/30">
+              <ArrowUpCircle size={9} />
+              {t("update.count", { count: outdated.length })}
+            </span>
+          )}
+          <HelpButton topic="modules" prominent />
         </div>
-        <button
-          onClick={load}
-          disabled={loading || batch !== null}
-          className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors disabled:opacity-40">
-          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-        </button>
-      </div>
-
-      {error && (
-        <div className="p-4 rounded-xl bg-rose-500/10 border border-rose-500/20 text-rose-400 text-sm">
-          {error}
-        </div>
-      )}
-
-      {/* Installed */}
-      <section className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <button
-            onClick={() => setCollapsed((v) => !v)}
-            className="flex items-center gap-1.5 text-sm font-semibold text-zinc-400 uppercase tracking-wide hover:text-zinc-200 transition-colors">
-            {collapsed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}
-            {t("section.installed")}
-            {outdated.length > 0 && (
-              <span className="normal-case tracking-normal flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/15 text-amber-300 border border-amber-500/30">
-                <ArrowUpCircle size={9} />
-                {t("update.count", { count: outdated.length })}
-              </span>
-            )}
-          </button>
+        <div className="flex items-center gap-2">
           {outdated.length > 0 && (
             <button
               onClick={updateAll}
@@ -108,38 +84,32 @@ export function ModulesPage() {
                 : t("update.all")}
             </button>
           )}
+          <button
+            onClick={load}
+            disabled={loading || batch !== null}
+            className="p-1.5 rounded-md text-zinc-500 hover:text-zinc-200 hover:bg-white/[5%] transition-colors disabled:opacity-40">
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          </button>
         </div>
+      </div>
 
-        {loading && data.installed.length === 0 ? (
-          <p className="text-zinc-500 text-sm">{t("loading")}</p>
-        ) : data.installed.length === 0 ? (
-          <p className="text-zinc-500 text-sm">{t("empty_installed")}</p>
-        ) : collapsed ? null : (
-          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
-            {data.installed.map((mod) => (
-              <InstalledModuleCard key={mod.id} mod={mod} onRefresh={load} />
-            ))}
-          </div>
-        )}
-      </section>
+      {error && (
+        <div className="p-4 rounded-xl bg-rose-500/10 border border-rose-500/20 text-rose-400 text-sm">
+          {error}
+        </div>
+      )}
 
-      {/* Available */}
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-wide">
-          {t("section.available")}
-        </h2>
-        {loading && data.available.length === 0 ? (
-          <p className="text-zinc-500 text-sm">{t("loading")}</p>
-        ) : data.available.length === 0 ? (
-          <p className="text-zinc-500 text-sm">{t("empty_available")}</p>
-        ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
-            {data.available.map((mod) => (
-              <AvailableModuleCard key={mod.id} mod={mod} onRefresh={load} />
-            ))}
-          </div>
-        )}
-      </section>
+      {loading && data.modules.length === 0 ? (
+        <p className="text-zinc-500 text-sm">{t("loading")}</p>
+      ) : data.modules.length === 0 ? (
+        <p className="text-zinc-500 text-sm">{t("empty")}</p>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+          {data.modules.map((mod) => (
+            <ModuleCard key={mod.id} mod={mod} onRefresh={load} />
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/features/modules/types.ts
+++ b/frontend/src/features/modules/types.ts
@@ -1,19 +1,18 @@
-export interface InstalledModule {
+/** Ein Modul in der vereinheitlichten Liste (installiert oder verfügbar). */
+export interface ModuleEntry {
   id: string
+  name: string
+  description: string
+  installed: boolean
   loaded: boolean
   error: string | null
+  /** Installierte Version (null wenn nicht installiert). */
   version: string | null
-  available_version?: string | null
-  update_available?: boolean
-}
-
-export interface AvailableModule {
-  id: string
-  name?: string
-  path?: string
+  /** Version im Hub (null wenn nicht ermittelbar). */
+  available_version: string | null
+  update_available: boolean
 }
 
 export interface ModulesIndex {
-  installed: InstalledModule[]
-  available: AvailableModule[]
+  modules: ModuleEntry[]
 }

--- a/frontend/src/i18n/HelpButton.tsx
+++ b/frontend/src/i18n/HelpButton.tsx
@@ -4,7 +4,14 @@ import { useTranslation } from "react-i18next"
 import { HelpDrawer } from "./HelpDrawer"
 import type { HelpTopic } from "./help/loader"
 
-export function HelpButton({ topic, className = "" }: { topic: HelpTopic; className?: string }) {
+interface Props {
+  topic: HelpTopic
+  className?: string
+  /** Auffällige Variante: Icon + Label "Hilfe", kräftiges Violett mit Border. */
+  prominent?: boolean
+}
+
+export function HelpButton({ topic, className = "", prominent = false }: Props) {
   const [open, setOpen] = useState(false)
   const { t } = useTranslation("nav")
   return (
@@ -12,9 +19,14 @@ export function HelpButton({ topic, className = "" }: { topic: HelpTopic; classN
       <button
         onClick={() => setOpen(true)}
         title={t("help_button")}
-        className={`${className} p-2 rounded-lg text-zinc-500 hover:text-violet-300 hover:bg-violet-500/10 transition-colors`.trim()}
+        className={
+          prominent
+            ? `${className} inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium text-violet-200 bg-violet-500/15 hover:bg-violet-500/25 border border-violet-500/40 transition-colors`.trim()
+            : `${className} p-2 rounded-lg text-zinc-500 hover:text-violet-300 hover:bg-violet-500/10 transition-colors`.trim()
+        }
       >
-        <HelpCircle size={15} />
+        <HelpCircle size={prominent ? 14 : 15} />
+        {prominent && <span>{t("help_label")}</span>}
       </button>
       <HelpDrawer topic={topic} open={open} onClose={() => setOpen(false)} />
     </>

--- a/frontend/src/i18n/locales/de/modules.json
+++ b/frontend/src/i18n/locales/de/modules.json
@@ -2,12 +2,7 @@
   "title": "Module",
   "installed_count": "{{count}} installiert",
   "loading": "Lade Module…",
-  "empty_installed": "Keine Module installiert.",
-  "empty_available": "Keine weiteren Module verfügbar.",
-  "section": {
-    "installed": "Installierte Module",
-    "available": "Verfügbare Module"
-  },
+  "empty": "Keine Module gefunden.",
   "status": {
     "loaded": "Geladen",
     "error": "Fehler",
@@ -21,10 +16,6 @@
     "count_other": "{{count}} Updates",
     "all": "Alle updaten",
     "all_running": "Aktualisiere ({{done}}/{{total}})…"
-  },
-  "section_toggle": {
-    "expand": "Ausklappen",
-    "collapse": "Einklappen"
   },
   "actions": {
     "install": "Installieren",

--- a/frontend/src/i18n/locales/de/nav.json
+++ b/frontend/src/i18n/locales/de/nav.json
@@ -45,6 +45,7 @@
   },
   "online": "Online",
   "help_button": "Seiten-Hilfe öffnen",
+  "help_label": "Hilfe",
   "update": {
     "available": "Update verfügbar — klicken zum Aktualisieren",
     "force": "Update erzwingen / Rebuild",

--- a/frontend/src/i18n/locales/en/modules.json
+++ b/frontend/src/i18n/locales/en/modules.json
@@ -2,12 +2,7 @@
   "title": "Modules",
   "installed_count": "{{count}} installed",
   "loading": "Loading modules…",
-  "empty_installed": "No modules installed.",
-  "empty_available": "No further modules available.",
-  "section": {
-    "installed": "Installed Modules",
-    "available": "Available Modules"
-  },
+  "empty": "No modules found.",
   "status": {
     "loaded": "Loaded",
     "error": "Error",
@@ -21,10 +16,6 @@
     "count_other": "{{count}} updates",
     "all": "Update all",
     "all_running": "Updating ({{done}}/{{total}})…"
-  },
-  "section_toggle": {
-    "expand": "Expand",
-    "collapse": "Collapse"
   },
   "actions": {
     "install": "Install",

--- a/frontend/src/i18n/locales/en/nav.json
+++ b/frontend/src/i18n/locales/en/nav.json
@@ -45,6 +45,7 @@
   },
   "online": "Online",
   "help_button": "Open page help",
+  "help_label": "Help",
   "update": {
     "available": "Update available — click to update",
     "force": "Force update / rebuild",


### PR DESCRIPTION
## Warum
User-Feedback zur Modul-Verwaltung:
1. Getrennte Sektionen "installiert oben / verfügbar unten" sind unübersichtlich (Installiertes tauchte auch in "verfügbar" auf).
2. Es fehlten Beschreibungen — man wusste vor dem Installieren nicht, was ein Modul tut.
3. Der Hilfe-Button (graues Icon) ging unter.

## Was
**Eine vereinheitlichte Liste** aller Module. Jede Karte trägt eine 2-Satz-Beschreibung und kontextabhängige Buttons:
- nicht installiert → **Installieren**
- installiert → **Aktualisieren** (amber nur bei echtem Update) + **Deinstallieren**

Nach dem Installieren verschwindet der Installieren-Button und es erscheinen Update + Deinstallieren (Liste lädt neu).

## Backend
- `ModuleManifest`: neues optionales Feld `description`.
- `installer.available_description(id)`: Beschreibung aus dem Hub-Cache-Manifest (ohne git-pull, Fehler → "").
- `GET /api/admin/modules`: liefert jetzt **eine** gemergte Liste `modules` (Hub ⋃ REGISTRY), pro Eintrag `installed/loaded/error/version/available_version/update_available/description`. Sortierung: installiert zuerst, dann alphabetisch.
- `update-count` unverändert. Tests angepasst + erweitert, ruff clean.

## Frontend
- `ModuleEntry` (vereinheitlicht) ersetzt den Installed/Available-Split.
- `ModuleCard`: eine Karte, Buttons je nach `installed`, Beschreibung immer sichtbar.
- `ModulesPage`: eine Grid-Liste, "Alle updaten" + Update-Zähler bleiben.
- `HelpButton`: neue **prominent**-Variante (Icon + Label "Hilfe", kräftiges Violett mit Border) — auf der Modul-Seite aktiv.

## Zweites Repo
Die 2-Satz-Beschreibungen + Patch-Version-Bumps liegen in `hydrahive2-modules` (alle 15 Manifeste, bereits auf main gepusht). Versionierung macht der Agent.

## Test
Backend: 101 modul-bezogene Tests passed, ruff clean. Frontend: `tsc` grün, `eslint` clean.

## Nicht in Scope
Keine Mehrsprachigkeit der Beschreibungen (einsprachig im Manifest). Kein Auto-Update.

Spec: `docs/specs/modul-liste-vereinheitlicht.md`
