### PR TITLE
docs(help): LLM-Hilfe — Anthropic-OAuth-Weg korrigiert (claude setup-token)

### DIFF
--- a/frontend/src/i18n/help/de/llm.md
+++ b/frontend/src/i18n/help/de/llm.md
@@ -28,15 +28,42 @@ Das **Standard-Modell** wird verwendet wenn ein Agent kein eigenes Modell expliz
 
 ## Schritt-für-Schritt
 
-### Anthropic-OAuth-Token (Claude Max) einrichten
+### Anthropic mit Claude-Abo (Pro/Max) einrichten — OAuth-Token
 
-1. Auf https://claude.ai/settings/billing dein Token-Plan-Abo bestätigen
-2. OAuth-Token besorgen (siehe Anthropic-Docs)
-3. Hier **Provider hinzufügen** → **Anthropic**
-4. API-Key-Feld: `sk-ant-oat01-...` einfügen
-5. Modelle ankreuzen (`claude-sonnet-4-6` etc.)
-6. **Hinzufügen**
-7. Standard-Modell setzen, **Verbindung testen** klicken — sollte "OK" zurückgeben
+Mit einem Claude-Abo (Pro/Max) kannst du deinen Account statt eines
+kostenpflichtigen API-Keys nutzen. Der OAuth-Token wird **in der Shell mit der
+Claude-Code-CLI erzeugt** und hier ins normale API-Key-Feld eingefügt — HydraHive
+erkennt am Präfix `sk-ant-oat...` automatisch, dass es ein OAuth-Token ist.
+
+1. In einer Shell mit installierter Claude-Code-CLI den Befehl ausführen:
+   ```
+   claude setup-token
+   ```
+2. Es öffnet sich der Browser → mit deinem Claude-Account (Pro/Max) **anmelden
+   und autorisieren**.
+3. Danach erscheint **in der Shell** ein langlebiger Token (`sk-ant-oat01-...`,
+   ~1 Jahr gültig). Diesen kopieren.
+4. Hier **Provider hinzufügen** → **Anthropic**.
+5. API-Key-Feld: den kopierten `sk-ant-oat01-...`-Token einfügen (kein
+   OAuth-Login-Button nötig — der wird nur für ChatGPT/Codex gebraucht).
+6. Modelle ankreuzen (z.B. `claude-sonnet-4-6`, `claude-opus-4-8`).
+7. **Hinzufügen**.
+8. Standard-Modell setzen, **Verbindung testen** klicken — sollte "OK" zurückgeben.
+
+> Alternativ geht auch ein klassischer API-Key aus der Anthropic-Console
+> (`sk-ant-api03-...`) — dann wird pro Nutzung nach API-Preisen abgerechnet statt
+> übers Abo.
+
+### ChatGPT Plus/Pro (Codex) per OAuth-Login
+
+Das ist der **einzige** Provider mit echtem OAuth-Login-Button in der GUI (kein
+Key nötig):
+
+1. **Provider hinzufügen** → **ChatGPT Plus/Pro (Codex)**.
+2. **Login öffnen** klicken → im Browser bei ChatGPT anmelden.
+3. Der Browser leitet auf `localhost:1455` um und zeigt „Seite nicht erreichbar" —
+   **das ist normal**. Die ganze URL aus dem Adressfeld kopieren.
+4. URL im zweiten Schritt einfügen → **Verbinden**.
 
 ### MiniMax-Provider mit Token-Plan
 

--- a/frontend/src/i18n/help/en/llm.md
+++ b/frontend/src/i18n/help/en/llm.md
@@ -28,15 +28,42 @@ The **default model** is used when an agent doesn't explicitly set one.
 
 ## Step by step
 
-### Set up Anthropic OAuth (Claude Max)
+### Set up Anthropic with a Claude subscription (Pro/Max) — OAuth token
 
-1. Confirm your Token Plan subscription on https://claude.ai/settings/billing
-2. Get your OAuth token (see Anthropic docs)
-3. Click **Add provider** → **Anthropic**
-4. Paste `sk-ant-oat01-...` into API key
-5. Pick models (`claude-sonnet-4-6` etc.)
-6. **Add**
-7. Set default model, click **Test connection** — should return "OK"
+With a Claude subscription (Pro/Max) you can use your account instead of a paid
+API key. The OAuth token is **generated in a shell with the Claude Code CLI** and
+pasted here into the normal API-key field — HydraHive detects the `sk-ant-oat...`
+prefix and automatically treats it as an OAuth token.
+
+1. In a shell with the Claude Code CLI installed, run:
+   ```
+   claude setup-token
+   ```
+2. Your browser opens → **sign in and authorize** with your Claude account
+   (Pro/Max).
+3. A long-lived token (`sk-ant-oat01-...`, valid ~1 year) then appears **in the
+   shell**. Copy it.
+4. Click **Add provider** → **Anthropic**.
+5. Paste the `sk-ant-oat01-...` token into the API-key field (no OAuth login
+   button needed — that's only for ChatGPT/Codex).
+6. Pick models (e.g. `claude-sonnet-4-6`, `claude-opus-4-8`).
+7. **Add**.
+8. Set default model, click **Test connection** — should return "OK".
+
+> Alternatively a classic API key from the Anthropic Console works too
+> (`sk-ant-api03-...`) — that bills per usage at API prices instead of via the
+> subscription.
+
+### ChatGPT Plus/Pro (Codex) via OAuth login
+
+This is the **only** provider with a real OAuth login button in the GUI (no key
+needed):
+
+1. **Add provider** → **ChatGPT Plus/Pro (Codex)**.
+2. Click **Open login** → sign in at ChatGPT in the browser.
+3. The browser redirects to `localhost:1455` and shows "site can't be reached" —
+   **that's normal**. Copy the whole URL from the address bar.
+4. Paste the URL in step two → **Connect**.
 
 ### MiniMax with token plan
 


### PR DESCRIPTION
## Warum
User meldete: die Anleitung zur Anthropic-OAuth-Einrichtung in der LLM-Hilfe stimmt nicht.

## Faktencheck (im Code verifiziert)
- **Kein GUI-OAuth für Anthropic**: `llm_oauth.py` (start/exchange/revoke) wirft für jeden Provider ausser `openai-codex` einen 400. Der "Login öffnen"-Button existiert nur für ChatGPT/Codex.
- **Anthropic-OAuth-Token gehen ins normale API-Key-Feld**: `_anthropic.py:_client()` erkennt am Präfix `sk-ant-oat...` automatisch OAuth (auth_token + Identity-Header).
- **Token-Beschaffung**: via Claude-Code-CLI `claude setup-token` → Browser-Login → langlebiger `sk-ant-oat01-...`-Token erscheint in der Shell. Bestätigt durch die offizielle Anthropic-Doku (code.claude.com/docs/en/authentication).

## Korrektur (de + en)
- Anthropic-Abschnitt neu: echter `claude setup-token`-Weg, klarer Hinweis "kein OAuth-Button nötig", plus Alternative klassischer API-Key (`sk-ant-api03-`).
- Neuer ChatGPT/Codex-Abschnitt: der einzige Provider mit echtem GUI-OAuth-Login (localhost:1455-URL zurückkopieren).

Reine Doku (Markdown), kein Code-Change.