### PR TITLE
feat(llm): Anthropic-OAuth-Login in der GUI (dritter Weg)

### DIFF
--- a/core/src/hydrahive/api/routes/llm_oauth.py
+++ b/core/src/hydrahive/api/routes/llm_oauth.py
@@ -1,4 +1,4 @@
-"""OAuth-Login per GUI für ChatGPT Plus/Pro (Codex).
+"""OAuth-Login per GUI für ChatGPT Plus/Pro (Codex) und Anthropic (Claude-Abo).
 
 Zwei-Schritt-Flow ohne lokalen Callback-Server (für Remote-Server ohne SSH):
 
@@ -6,19 +6,24 @@ Zwei-Schritt-Flow ohne lokalen Callback-Server (für Remote-Server ohne SSH):
                     liefert authorize_url. User öffnet im Browser.
 2. /oauth/exchange → User pasted die Redirect-URL (oder den Code) zurück.
                     Server tauscht gegen Token, schreibt OAuth-Block in
-                    llm.json unter Provider-id "openai-codex".
+                    llm.json unter der Provider-id.
+
+Unterstützte Provider: "openai-codex" (ChatGPT) und "anthropic" (Claude-Abo).
+Für Anthropic bleibt ein evtl. vorhandener api_key erhalten — OAuth und
+API-Key/setup-token koexistieren (resolve_anthropic_token bevorzugt OAuth).
 """
 from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
+from types import ModuleType
 
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
 from hydrahive.api.middleware.auth import require_admin
 from hydrahive.api.middleware.errors import coded
+from hydrahive.oauth import anthropic as anthropic_oauth
 from hydrahive.oauth import openai_codex
 from hydrahive.settings import settings
 
@@ -39,9 +44,41 @@ CODEX_DEFAULT_MODELS = [
     "openai-codex/gpt-5.1-codex-mini",
 ]
 
+ANTHROPIC_DEFAULT_MODELS = [
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+]
+
+# Provider-Registry: Modul + Provider-Anzeigename + Default-Modelle.
+_PROVIDERS: dict[str, dict] = {
+    "openai-codex": {
+        "module": openai_codex,
+        "name": "ChatGPT Plus/Pro (Codex)",
+        "default_models": CODEX_DEFAULT_MODELS,
+    },
+    "anthropic": {
+        "module": anthropic_oauth,
+        "name": "Anthropic",
+        "default_models": ANTHROPIC_DEFAULT_MODELS,
+    },
+}
+
+
+def _provider_cfg(provider: str) -> dict:
+    cfg = _PROVIDERS.get(provider)
+    if cfg is None:
+        raise coded(status.HTTP_400_BAD_REQUEST, "oauth_unsupported_provider",
+                    message=f"OAuth nicht unterstützt für Provider {provider}")
+    return cfg
+
+
+def _module(provider: str) -> ModuleType:
+    return _provider_cfg(provider)["module"]
+
 
 class StartRequest(BaseModel):
-    provider: str  # nur "openai-codex" derzeit
+    provider: str  # "openai-codex" oder "anthropic"
 
 
 class StartResponse(BaseModel):
@@ -79,20 +116,30 @@ def _delete_pending() -> None:
         PENDING_PATH.unlink()
 
 
-def _write_provider_oauth(oauth_block: dict) -> None:
+def _write_provider_oauth(provider: str, oauth_block: dict) -> None:
+    """Schreibt den OAuth-Block unter die Provider-id in llm.json.
+
+    Ein vorhandener Provider-Eintrag (inkl. api_key aus Weg 1/2) bleibt
+    unangetastet — nur der oauth-Block wird gesetzt/aktualisiert. So koexistiert
+    OAuth mit API-Key/setup-token; resolve_anthropic_token bevorzugt OAuth.
+    """
+    cfg = _provider_cfg(provider)
     path = settings.llm_config
     if path.exists():
         data = json.loads(path.read_text())
     else:
         data = {"providers": [], "default_model": "", "embed_model": ""}
     providers = data.setdefault("providers", [])
-    found = next((p for p in providers if p.get("id") == "openai-codex"), None)
+    found = next((p for p in providers if p.get("id") == provider), None)
     if found is None:
-        found = {"id": "openai-codex", "name": "ChatGPT Plus/Pro (Codex)",
-                 "api_key": "", "models": list(CODEX_DEFAULT_MODELS)}
+        found = {"id": provider, "name": cfg["name"],
+                 "api_key": "", "models": list(cfg["default_models"])}
         providers.append(found)
+    elif not found.get("models"):
+        # Existierender Provider ohne Modelle (z.B. nur api_key gesetzt) → Defaults ergänzen.
+        found["models"] = list(cfg["default_models"])
     found["oauth"] = oauth_block
-    if not data.get("default_model") and found["models"]:
+    if not data.get("default_model") and found.get("models"):
         data["default_model"] = found["models"][0]
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2))
@@ -100,26 +147,22 @@ def _write_provider_oauth(oauth_block: dict) -> None:
 
 @router.post("/start", dependencies=[Depends(require_admin)], response_model=StartResponse)
 def oauth_start(req: StartRequest) -> StartResponse:
-    if req.provider != "openai-codex":
-        raise coded(status.HTTP_400_BAD_REQUEST, "oauth_unsupported_provider",
-                    message=f"OAuth nicht unterstützt für Provider {req.provider}")
-    verifier, challenge = openai_codex.make_pkce()
-    state = openai_codex.make_state()
+    mod = _module(req.provider)
+    verifier, challenge = mod.make_pkce()
+    state = mod.make_state()
     _save_pending({
         "provider": req.provider,
         "verifier": verifier,
         "state": state,
         "ts": int(time.time()),
     })
-    url = openai_codex.authorize_url(challenge=challenge, state=state)
+    url = mod.authorize_url(challenge=challenge, state=state)
     return StartResponse(authorize_url=url, state=state)
 
 
 @router.post("/exchange", dependencies=[Depends(require_admin)], response_model=ExchangeResponse)
 async def oauth_exchange(req: ExchangeRequest) -> ExchangeResponse:
-    if req.provider != "openai-codex":
-        raise coded(status.HTTP_400_BAD_REQUEST, "oauth_unsupported_provider",
-                    message=f"OAuth nicht unterstützt für Provider {req.provider}")
+    mod = _module(req.provider)
     pending = _load_pending()
     if not pending or pending.get("provider") != req.provider:
         raise coded(status.HTTP_400_BAD_REQUEST, "oauth_no_pending",
@@ -129,7 +172,7 @@ async def oauth_exchange(req: ExchangeRequest) -> ExchangeResponse:
         raise coded(status.HTTP_400_BAD_REQUEST, "oauth_expired",
                     message="OAuth-Flow abgelaufen — bitte neu starten")
 
-    parsed = openai_codex.parse_callback_input(req.code_or_url)
+    parsed = mod.parse_callback_input(req.code_or_url)
     code = parsed.get("code", "")
     if not code:
         raise coded(status.HTTP_400_BAD_REQUEST, "oauth_no_code",
@@ -140,7 +183,7 @@ async def oauth_exchange(req: ExchangeRequest) -> ExchangeResponse:
                     message="OAuth-State stimmt nicht überein — Flow neu starten")
 
     try:
-        token = await openai_codex.exchange_code(code=code, verifier=pending["verifier"])
+        token = await mod.exchange_code(code=code, verifier=pending["verifier"])
     except Exception as e:
         raise coded(status.HTTP_400_BAD_REQUEST, "oauth_exchange_failed",
                     message=f"Token-Tausch fehlgeschlagen: {e}")
@@ -149,16 +192,14 @@ async def oauth_exchange(req: ExchangeRequest) -> ExchangeResponse:
         raise coded(status.HTTP_400_BAD_REQUEST, "oauth_no_access",
                     message="Token-Antwort ohne access_token")
 
-    _write_provider_oauth(token)
+    _write_provider_oauth(req.provider, token)
     _delete_pending()
     return ExchangeResponse(ok=True, account_id=token.get("account_id", ""))
 
 
 @router.delete("/{provider}", dependencies=[Depends(require_admin)])
 def oauth_revoke(provider: str) -> dict:
-    if provider != "openai-codex":
-        raise coded(status.HTTP_400_BAD_REQUEST, "oauth_unsupported_provider",
-                    message=f"OAuth nicht unterstützt für Provider {provider}")
+    _provider_cfg(provider)  # 400 für unbekannte Provider
     path = settings.llm_config
     if not path.exists():
         return {"ok": True}

--- a/core/tests/test_llm_oauth_routes.py
+++ b/core/tests/test_llm_oauth_routes.py
@@ -1,0 +1,107 @@
+"""Tests für /api/llm/oauth — Codex (Regression) + Anthropic (neuer dritter Weg).
+
+Kernpunkte:
+- Beide Provider können start/exchange/revoke (Provider-Dispatch).
+- Unbekannte Provider → 400.
+- Anthropic-OAuth-Exchange löscht einen vorhandenen api_key NICHT (Koexistenz
+  von Weg 1/2 [api_key/setup-token] mit Weg 3 [OAuth]).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+
+def _fake_pkce():
+    return ("verifier123", "challenge123")
+
+
+def test_start_codex(client, admin_headers):
+    with patch("hydrahive.api.routes.llm_oauth.openai_codex.make_pkce", _fake_pkce), \
+         patch("hydrahive.api.routes.llm_oauth.openai_codex.make_state", lambda: "state-x"), \
+         patch("hydrahive.api.routes.llm_oauth.openai_codex.authorize_url",
+               lambda **k: "https://auth.openai.com/authorize?x=1"):
+        r = client.post("/api/llm/oauth/start", json={"provider": "openai-codex"},
+                        headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["authorize_url"].startswith("https://auth.openai.com/")
+
+
+def test_start_anthropic(client, admin_headers):
+    with patch("hydrahive.api.routes.llm_oauth.anthropic_oauth.make_pkce", _fake_pkce), \
+         patch("hydrahive.api.routes.llm_oauth.anthropic_oauth.make_state", lambda: "state-y"), \
+         patch("hydrahive.api.routes.llm_oauth.anthropic_oauth.authorize_url",
+               lambda **k: "https://claude.ai/oauth/authorize?x=1"):
+        r = client.post("/api/llm/oauth/start", json={"provider": "anthropic"},
+                        headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["authorize_url"].startswith("https://claude.ai/oauth/authorize")
+
+
+def test_start_unknown_provider_400(client, admin_headers):
+    r = client.post("/api/llm/oauth/start", json={"provider": "groq"}, headers=admin_headers)
+    assert r.status_code == 400
+
+
+def test_start_requires_admin(client, auth_headers):
+    r = client.post("/api/llm/oauth/start", json={"provider": "anthropic"}, headers=auth_headers)
+    assert r.status_code in (401, 403)
+
+
+def test_anthropic_exchange_preserves_api_key(client, admin_headers):
+    """Weg 3 (OAuth) darf einen bestehenden api_key (Weg 1/2) NICHT löschen."""
+    from hydrahive.settings import settings
+    # Vorbedingung: Anthropic-Provider mit api_key existiert bereits.
+    settings.llm_config.parent.mkdir(parents=True, exist_ok=True)
+    settings.llm_config.write_text(json.dumps({
+        "providers": [{"id": "anthropic", "name": "Anthropic",
+                       "api_key": "sk-ant-api03-KEEPME", "models": ["claude-sonnet-4-6"]}],
+        "default_model": "claude-sonnet-4-6", "embed_model": "",
+    }))
+    pending = {"provider": "anthropic", "verifier": "v", "state": "s", "ts": 9_999_999_999}
+
+    token = {"access": "sk-ant-oat01-NEW", "refresh": "ref", "expires_at": 9_999_999_999, "scope": "x"}
+    with patch("hydrahive.api.routes.llm_oauth._load_pending", return_value=pending), \
+         patch("hydrahive.api.routes.llm_oauth._delete_pending"), \
+         patch("hydrahive.api.routes.llm_oauth.anthropic_oauth.parse_callback_input",
+               return_value={"code": "c", "state": "s"}), \
+         patch("hydrahive.api.routes.llm_oauth.anthropic_oauth.exchange_code",
+               new=AsyncMock(return_value=token)):
+        r = client.post("/api/llm/oauth/exchange",
+                        json={"provider": "anthropic", "code_or_url": "http://x/callback?code=c&state=s"},
+                        headers=admin_headers)
+    assert r.status_code == 200
+    saved = json.loads(settings.llm_config.read_text())
+    prov = next(p for p in saved["providers"] if p["id"] == "anthropic")
+    assert prov["api_key"] == "sk-ant-api03-KEEPME"   # Weg 1/2 unangetastet
+    assert prov["oauth"]["access"] == "sk-ant-oat01-NEW"  # Weg 3 dazu
+
+
+def test_exchange_no_pending_400(client, admin_headers):
+    with patch("hydrahive.api.routes.llm_oauth._load_pending", return_value={}):
+        r = client.post("/api/llm/oauth/exchange",
+                        json={"provider": "anthropic", "code_or_url": "code"},
+                        headers=admin_headers)
+    assert r.status_code == 400
+
+
+def test_revoke_anthropic_keeps_api_key(client, admin_headers):
+    from hydrahive.settings import settings
+    settings.llm_config.parent.mkdir(parents=True, exist_ok=True)
+    settings.llm_config.write_text(json.dumps({
+        "providers": [{"id": "anthropic", "name": "Anthropic",
+                       "api_key": "sk-ant-api03-KEEPME", "models": ["claude-sonnet-4-6"],
+                       "oauth": {"access": "sk-ant-oat01-X"}}],
+        "default_model": "claude-sonnet-4-6", "embed_model": "",
+    }))
+    r = client.delete("/api/llm/oauth/anthropic", headers=admin_headers)
+    assert r.status_code == 200
+    saved = json.loads(settings.llm_config.read_text())
+    prov = next(p for p in saved["providers"] if p["id"] == "anthropic")
+    assert "oauth" not in prov               # OAuth entfernt
+    assert prov["api_key"] == "sk-ant-api03-KEEPME"  # api_key bleibt
+
+
+def test_revoke_unknown_provider_400(client, admin_headers):
+    r = client.delete("/api/llm/oauth/groq", headers=admin_headers)
+    assert r.status_code == 400

--- a/docs/specs/anthropic-oauth-gui.md
+++ b/docs/specs/anthropic-oauth-gui.md
@@ -1,0 +1,87 @@
+# Spec: Anthropic-OAuth-Login in der GUI freischalten (dritter Weg)
+
+## Was
+
+Anthropic bekommt einen dritten Einrichtungsweg: **OAuth-Login per Button**
+(anklicken → auf claude.ai bestätigen → Redirect-URL zurückkopieren → verbunden).
+Der Token wird automatisch refresht. Die zwei bestehenden Wege bleiben **komplett
+unangetastet**:
+- Weg 1: klassischer API-Key `sk-ant-api03-...` ins Key-Feld
+- Weg 2: `claude setup-token`-Token `sk-ant-oat01-...` ins Key-Feld
+- Weg 3 (NEU): OAuth-Login-Button
+
+## Warum
+
+Der komplette Anthropic-OAuth-Code existiert bereits (`oauth/anthropic.py`:
+authorize_url / exchange_code / refresh_access_token; `resolve_anthropic_token`
+bevorzugt OAuth vor API-Key), ist aber nicht an GUI/Route angeschlossen — die
+OAuth-Route lässt nur `openai-codex` durch. Nutzer mit Claude-Abo wollen den
+bequemen Klick-Flow ohne CLI.
+
+## Kernentscheidung: hybrider Provider (additiv)
+
+Codex ist rein-OAuth (`auth: "oauth"` → Key-Feld verschwindet). Für Anthropic
+darf das NICHT übernommen werden, sonst brechen Weg 1+2. Stattdessen ein NEUES,
+additives Flag `oauthOptional: true`:
+- Key-Feld bleibt sichtbar + funktionsfähig (Weg 1+2 unverändert)
+- zusätzlich darunter ein optionaler OAuth-Login (Weg 3)
+- Das bestehende `auth: "oauth"` (erzwingt Key-Feld weg) bleibt exklusiv bei Codex
+
+Konflikt-Priorität: **OAuth vor API-Key** (bestehende `resolve_anthropic_token`-
+Logik, unverändert). Hat ein User beides, gewinnt OAuth.
+
+## Wie
+
+### Backend `api/routes/llm_oauth.py`
+- Provider-Dispatch statt hartem `== "openai-codex"`:
+  - `_provider_module(provider)` → `openai_codex` | `anthropic` (sonst 400).
+  - `_default_models(provider)` → Codex-Liste | Anthropic-Liste.
+- `oauth_start`: unterstützt `openai-codex` UND `anthropic`. Für Anthropic:
+  `anthropic.make_pkce()/make_state()/authorize_url()`.
+- `oauth_exchange`: Provider-abhängiger `exchange_code`. Für Anthropic KEIN
+  `extract_account_id` (nicht vorhanden) → account_id "".
+  **Wichtig:** `_write_provider_oauth` darf ein vorhandenes `api_key` NICHT
+  löschen (Koexistenz Weg 1/2 + Weg 3). Nur den `oauth`-Block setzen + ggf.
+  Default-Modelle ergänzen, wenn der Provider noch keine hat.
+- `oauth_revoke`: auch für `anthropic` (entfernt nur den oauth-Block, api_key
+  bleibt).
+- Codex-Pfad bleibt funktional identisch.
+
+### Backend `oauth/anthropic.py`
+- `make_pkce`/`make_state` sind schon aus `_base` importiert — re-exportieren
+  falls nötig (Codex tut das über `# noqa: F401`). Kein Verhaltensänderung.
+
+### Frontend
+- `_llm_providers.ts`: Anthropic-Eintrag um `oauthOptional: true` erweitern
+  (Key-Placeholder `sk-ant-...` bleibt).
+- `ProviderForm.tsx`: neue Bedingung `isOAuthOptional`. Wenn gesetzt:
+  Key-Feld normal rendern (wie bisher) UND darunter `OAuthFlow` anzeigen
+  (unabhängig vom Key). `isOAuth` (Codex) unberührt. Submit bleibt möglich mit
+  Key ODER Token.
+- `OAuthFlow.tsx`: provider-spezifische Texte (aktuell hart „OpenAI/ChatGPT",
+  „localhost:1455"). Kleine Map je providerId:
+  - openai-codex: ChatGPT, localhost:1455/auth/callback
+  - anthropic: claude.ai, localhost:53692/callback
+  Logik/Flow identisch (start → open → paste URL → exchange).
+
+### Anleitung `i18n/help/{de,en}/llm.md`
+- Dritter Abschnitt „Weg 3: OAuth-Login (Claude-Abo, ein Klick)".
+- Klar abgegrenzt von Weg 1 (API-Key) + Weg 2 (setup-token).
+- Hinweis: Token wird automatisch refresht (löst das „nach 1-2 Tagen tot"-Problem
+  früherer Setups).
+
+## Akzeptanzkriterien
+- [ ] Anthropic zeigt weiterhin ein API-Key-Feld (Weg 1+2 funktionieren unverändert).
+- [ ] Anthropic zeigt zusätzlich einen OAuth-Login (Weg 3): Login öffnen →
+      claude.ai bestätigen → URL zurück → verbunden.
+- [ ] Nach OAuth-Connect steht ein `oauth`-Block unter Provider `anthropic`,
+      ein evtl. vorhandener `api_key` bleibt erhalten.
+- [ ] Revoke entfernt nur den oauth-Block.
+- [ ] Codex-Flow unverändert.
+- [ ] Backend-Tests für den Anthropic-Zweig (start/exchange-Guard, Koexistenz
+      key+oauth). pytest + ruff grün. tsc grün.
+
+## Nicht in Scope
+- Kein Auto-Login ohne User-Klick.
+- Keine Änderung an `resolve_anthropic_token` (OAuth-vor-Key bleibt).
+- Kein lokaler Callback-Server (manueller URL-Paste wie bei Codex).

--- a/frontend/src/features/llm/OAuthFlow.tsx
+++ b/frontend/src/features/llm/OAuthFlow.tsx
@@ -4,6 +4,12 @@ import { ExternalLink, Loader2 } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
 import { llmApi } from "./api"
 
+// Provider-spezifische Texte für den OAuth-Login (Flow ist identisch).
+const OAUTH_META: Record<string, { service: string; callback: string }> = {
+  "openai-codex": { service: "OpenAI/ChatGPT", callback: "localhost:1455" },
+  anthropic: { service: "Claude (claude.ai)", callback: "localhost:53692" },
+}
+
 export function OAuthFlow({
   providerId,
   onConnected,
@@ -13,6 +19,7 @@ export function OAuthFlow({
   onConnected: () => void
   onCancel?: () => void
 }) {
+  const meta = OAUTH_META[providerId] ?? { service: providerId, callback: "localhost" }
   const [step, setStep] = useState<1 | 2>(1)
   const [authUrl, setAuthUrl] = useState("")
   const [code, setCode] = useState("")
@@ -51,7 +58,7 @@ export function OAuthFlow({
       {step === 1 && (
         <div className="space-y-2">
           <p className="text-xs text-zinc-400">
-            Login bei OpenAI/ChatGPT. Du wirst danach auf <code className="text-zinc-300">localhost:1455</code> umgeleitet —
+            Login bei {meta.service}. Du wirst danach auf <code className="text-zinc-300">{meta.callback}</code> umgeleitet —
             das wird im Browser eine "Diese Seite kann nicht erreicht werden"-Fehlermeldung zeigen.
             <strong className="text-zinc-200"> Das ist normal.</strong> Du kopierst die ganze URL aus
             dem Browser-Adressfeld in Schritt 2.
@@ -76,7 +83,7 @@ export function OAuthFlow({
         <div className="space-y-2">
           <p className="text-xs text-zinc-400">
             Kopier die ganze URL aus dem Browser-Adressfeld
-            (<code className="text-zinc-300">http://localhost:1455/auth/callback?code=...&state=...</code>)
+            (<code className="text-zinc-300">http://{meta.callback}/...?code=...&state=...</code>)
             und füge sie hier ein:
           </p>
           {authUrl && (
@@ -86,7 +93,7 @@ export function OAuthFlow({
             </a>
           )}
           <textarea value={code} onChange={(e) => setCode(e.target.value)}
-            rows={3} placeholder="http://localhost:1455/auth/callback?code=...&state=..."
+            rows={3} placeholder={`http://${meta.callback}/...?code=...&state=...`}
             className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-white/[8%] text-zinc-200 text-xs font-mono placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50 resize-none" />
           {error && <p className="text-xs text-rose-400">{error}</p>}
           <div className="flex gap-2">

--- a/frontend/src/features/llm/ProviderForm.tsx
+++ b/frontend/src/features/llm/ProviderForm.tsx
@@ -23,6 +23,8 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
   const [customModels, setCustomModels] = useState(existing ? existing.models.join(", ") : "")
   const known = KNOWN_PROVIDERS.find((p) => p.id === form.id)
   const isOAuth = (known as { auth?: string } | undefined)?.auth === "oauth"
+  // Hybrid-Provider (Anthropic): Key-Feld bleibt sichtbar UND zusätzlich OAuth-Login.
+  const isOAuthOptional = (known as { oauthOptional?: boolean } | undefined)?.oauthOptional === true
   const hasToken = !!form.oauth?.access
 
   function handleSubmit(e: React.FormEvent) {
@@ -77,6 +79,25 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
           onConnected={() => onOAuthConnected?.()}
         />
       )}
+      {isOAuthOptional && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-[11px] text-zinc-500">
+            <span className="h-px flex-1 bg-white/[8%]" />
+            {t("form.or_oauth")}
+            <span className="h-px flex-1 bg-white/[8%]" />
+          </div>
+          {hasToken ? (
+            <p className="flex items-center gap-1.5 text-xs text-emerald-400">
+              <CheckCircle size={12} /> {t("form.oauth_connected")}
+            </p>
+          ) : (
+            <OAuthFlow
+              providerId={form.id}
+              onConnected={() => onOAuthConnected?.()}
+            />
+          )}
+        </div>
+      )}
       {known && (
         <div>
           <label className="block text-xs text-zinc-500 mb-1">Eigene Modelle (optional, kommagetrennt)</label>
@@ -88,7 +109,13 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
       )}
       <div className="flex items-center gap-2">
         <button type="submit"
-          disabled={!form.id || (!isOAuth && !form.api_key) || (isOAuth && !hasToken)}
+          disabled={
+            !form.id
+            || (isOAuth && !hasToken)
+            // Hybrid (Anthropic): Key ODER OAuth-Token reicht.
+            || (isOAuthOptional && !form.api_key && !hasToken)
+            || (!isOAuth && !isOAuthOptional && !form.api_key)
+          }
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all">
           <Plus size={14} /> {isEdit ? tCommon("actions.save") : tCommon("actions.add")}
         </button>

--- a/frontend/src/features/llm/_llm_providers.ts
+++ b/frontend/src/features/llm/_llm_providers.ts
@@ -2,7 +2,11 @@ import type { LlmProvider } from "./api"
 
 export const KNOWN_PROVIDERS = [
   {
+    // Hybrid: API-Key-Feld bleibt (Weg 1 sk-ant-api03, Weg 2 sk-ant-oat01 via
+    // `claude setup-token`) UND zusätzlich optionaler OAuth-Login (Weg 3).
+    // oauthOptional versteckt das Key-Feld NICHT (anders als auth:"oauth").
     id: "anthropic", name: "Anthropic", placeholder: "sk-ant-...",
+    oauthOptional: true as const,
     models: [],
   },
   {

--- a/frontend/src/i18n/help/de/llm.md
+++ b/frontend/src/i18n/help/de/llm.md
@@ -28,36 +28,47 @@ Das **Standard-Modell** wird verwendet wenn ein Agent kein eigenes Modell expliz
 
 ## Schritt-für-Schritt
 
-### Anthropic mit Claude-Abo (Pro/Max) einrichten — OAuth-Token
+### Anthropic einrichten — drei Wege
 
-Mit einem Claude-Abo (Pro/Max) kannst du deinen Account statt eines
-kostenpflichtigen API-Keys nutzen. Der OAuth-Token wird **in der Shell mit der
-Claude-Code-CLI erzeugt** und hier ins normale API-Key-Feld eingefügt — HydraHive
+Für Anthropic gibt es **drei** Wege. Alle enden im selben Provider „Anthropic".
+Wenn du sowohl einen Key als auch OAuth hinterlegst, hat **OAuth Vorrang**.
+
+**Weg 1 — klassischer API-Key (Pay-per-Use)**
+1. In der Anthropic-Console einen API-Key erstellen (`sk-ant-api03-...`).
+2. **Provider hinzufügen** → **Anthropic** → Key ins **API-Key-Feld** einfügen.
+3. Modelle ankreuzen, **Hinzufügen**, **Verbindung testen**.
+   Abrechnung nach API-Preisen (nicht übers Abo).
+
+**Weg 2 — Abo-Token per CLI (`claude setup-token`)**
+Nutzt dein Claude-Abo (Pro/Max) statt API-Credits. Der Token wird **in der Shell
+mit der Claude-Code-CLI** erzeugt und ins API-Key-Feld eingefügt — HydraHive
 erkennt am Präfix `sk-ant-oat...` automatisch, dass es ein OAuth-Token ist.
+1. In einer Shell mit Claude-Code-CLI: `claude setup-token` ausführen.
+2. Browser öffnet sich → mit Claude-Account **anmelden und autorisieren**.
+3. Der langlebige Token (`sk-ant-oat01-...`, ~1 Jahr) erscheint **in der Shell** →
+   kopieren.
+4. **Provider hinzufügen** → **Anthropic** → Token ins **API-Key-Feld** einfügen.
+5. Modelle ankreuzen, **Hinzufügen**, **Verbindung testen**.
 
-1. In einer Shell mit installierter Claude-Code-CLI den Befehl ausführen:
-   ```
-   claude setup-token
-   ```
-2. Es öffnet sich der Browser → mit deinem Claude-Account (Pro/Max) **anmelden
-   und autorisieren**.
-3. Danach erscheint **in der Shell** ein langlebiger Token (`sk-ant-oat01-...`,
-   ~1 Jahr gültig). Diesen kopieren.
-4. Hier **Provider hinzufügen** → **Anthropic**.
-5. API-Key-Feld: den kopierten `sk-ant-oat01-...`-Token einfügen (kein
-   OAuth-Login-Button nötig — der wird nur für ChatGPT/Codex gebraucht).
-6. Modelle ankreuzen (z.B. `claude-sonnet-4-6`, `claude-opus-4-8`).
-7. **Hinzufügen**.
-8. Standard-Modell setzen, **Verbindung testen** klicken — sollte "OK" zurückgeben.
+**Weg 3 — OAuth-Login per Klick (Abo, ohne CLI)**
+Der bequemste Weg mit Claude-Abo — kein Terminal nötig. HydraHive holt den Token
+selbst und **erneuert ihn automatisch** (Auto-Refresh), du musst dich also nicht
+alle paar Tage neu einloggen.
+1. **Provider hinzufügen** → **Anthropic**.
+2. Unter dem API-Key-Feld beim OAuth-Login **Login öffnen** klicken → im Browser
+   bei **claude.ai** anmelden und autorisieren.
+3. Der Browser leitet auf `localhost:53692` um und zeigt „Seite nicht erreichbar" —
+   **das ist normal**. Die ganze URL aus dem Adressfeld kopieren.
+4. URL im zweiten Schritt einfügen → **Verbinden**. Es erscheint „Per OAuth
+   verbunden".
+5. Modelle ankreuzen, **Hinzufügen**, Standard-Modell setzen, **Verbindung testen**.
 
-> Alternativ geht auch ein klassischer API-Key aus der Anthropic-Console
-> (`sk-ant-api03-...`) — dann wird pro Nutzung nach API-Preisen abgerechnet statt
-> übers Abo.
+> Das API-Key-Feld bleibt bei allen drei Wegen sichtbar — der OAuth-Login (Weg 3)
+> ist eine zusätzliche Option, kein Ersatz.
 
 ### ChatGPT Plus/Pro (Codex) per OAuth-Login
 
-Das ist der **einzige** Provider mit echtem OAuth-Login-Button in der GUI (kein
-Key nötig):
+Auch ChatGPT hat einen OAuth-Login-Button (kein Key nötig):
 
 1. **Provider hinzufügen** → **ChatGPT Plus/Pro (Codex)**.
 2. **Login öffnen** klicken → im Browser bei ChatGPT anmelden.

--- a/frontend/src/i18n/help/en/llm.md
+++ b/frontend/src/i18n/help/en/llm.md
@@ -28,36 +28,46 @@ The **default model** is used when an agent doesn't explicitly set one.
 
 ## Step by step
 
-### Set up Anthropic with a Claude subscription (Pro/Max) — OAuth token
+### Set up Anthropic — three ways
 
-With a Claude subscription (Pro/Max) you can use your account instead of a paid
-API key. The OAuth token is **generated in a shell with the Claude Code CLI** and
-pasted here into the normal API-key field — HydraHive detects the `sk-ant-oat...`
-prefix and automatically treats it as an OAuth token.
+Anthropic has **three** setup paths. All end up in the same "Anthropic" provider.
+If you configure both a key and OAuth, **OAuth takes precedence**.
 
-1. In a shell with the Claude Code CLI installed, run:
-   ```
-   claude setup-token
-   ```
-2. Your browser opens → **sign in and authorize** with your Claude account
-   (Pro/Max).
-3. A long-lived token (`sk-ant-oat01-...`, valid ~1 year) then appears **in the
-   shell**. Copy it.
-4. Click **Add provider** → **Anthropic**.
-5. Paste the `sk-ant-oat01-...` token into the API-key field (no OAuth login
-   button needed — that's only for ChatGPT/Codex).
-6. Pick models (e.g. `claude-sonnet-4-6`, `claude-opus-4-8`).
-7. **Add**.
-8. Set default model, click **Test connection** — should return "OK".
+**Way 1 — classic API key (pay-per-use)**
+1. Create an API key in the Anthropic Console (`sk-ant-api03-...`).
+2. **Add provider** → **Anthropic** → paste the key into the **API-key field**.
+3. Pick models, **Add**, **Test connection**. Billed at API prices (not via the
+   subscription).
 
-> Alternatively a classic API key from the Anthropic Console works too
-> (`sk-ant-api03-...`) — that bills per usage at API prices instead of via the
-> subscription.
+**Way 2 — subscription token via CLI (`claude setup-token`)**
+Uses your Claude subscription (Pro/Max) instead of API credits. The token is
+**generated in a shell with the Claude Code CLI** and pasted into the API-key
+field — HydraHive detects the `sk-ant-oat...` prefix and treats it as OAuth.
+1. In a shell with the Claude Code CLI: run `claude setup-token`.
+2. Browser opens → **sign in and authorize** with your Claude account.
+3. The long-lived token (`sk-ant-oat01-...`, ~1 year) appears **in the shell** →
+   copy it.
+4. **Add provider** → **Anthropic** → paste the token into the **API-key field**.
+5. Pick models, **Add**, **Test connection**.
+
+**Way 3 — OAuth login by click (subscription, no CLI)**
+The most convenient path with a Claude subscription — no terminal needed.
+HydraHive fetches the token itself and **refreshes it automatically**, so you
+don't have to log in again every few days.
+1. **Add provider** → **Anthropic**.
+2. Below the API-key field, at the OAuth login, click **Open login** → sign in at
+   **claude.ai** and authorize.
+3. The browser redirects to `localhost:53692` and shows "site can't be reached" —
+   **that's normal**. Copy the whole URL from the address bar.
+4. Paste the URL in step two → **Connect**. It shows "Connected via OAuth".
+5. Pick models, **Add**, set default model, **Test connection**.
+
+> The API-key field stays visible in all three ways — the OAuth login (way 3) is
+> an additional option, not a replacement.
 
 ### ChatGPT Plus/Pro (Codex) via OAuth login
 
-This is the **only** provider with a real OAuth login button in the GUI (no key
-needed):
+ChatGPT also has an OAuth login button (no key needed):
 
 1. **Add provider** → **ChatGPT Plus/Pro (Codex)**.
 2. Click **Open login** → sign in at ChatGPT in the browser.

--- a/frontend/src/i18n/locales/de/llm.json
+++ b/frontend/src/i18n/locales/de/llm.json
@@ -26,7 +26,9 @@
     "provider_label": "Provider",
     "api_key": "API Key",
     "models_label": "Modelle ({{selected}} ausgewählt)",
-    "custom_model": "oder Custom-Modell eingeben…"
+    "custom_model": "oder Custom-Modell eingeben…",
+    "or_oauth": "oder per OAuth-Login",
+    "oauth_connected": "Per OAuth verbunden"
   },
   "default_model": "Standard-Modell",
   "embed_model": "Embedding-Modell",

--- a/frontend/src/i18n/locales/en/llm.json
+++ b/frontend/src/i18n/locales/en/llm.json
@@ -26,7 +26,9 @@
     "provider_label": "Provider",
     "api_key": "API Key",
     "models_label": "Models ({{selected}} selected)",
-    "custom_model": "or enter custom model…"
+    "custom_model": "or enter custom model…",
+    "or_oauth": "or via OAuth login",
+    "oauth_connected": "Connected via OAuth"
   },
   "default_model": "Default model",
   "embed_model": "Embedding model",


### PR DESCRIPTION
## Warum
Anthropic soll den bequemen OAuth-Klick-Flow bekommen (Login öffnen → auf claude.ai bestätigen → Redirect-URL zurückkopieren → verbunden), **ohne** die zwei bestehenden Einrichtungswege zu beschädigen.

Der Anthropic-OAuth-Code existierte bereits (`oauth/anthropic.py`: authorize/exchange/refresh), war aber nicht an GUI/Route angeschlossen — die OAuth-Route ließ nur `openai-codex` durch.

## Die drei Wege (alle funktionieren nach diesem PR)
1. **API-Key** `sk-ant-api03-…` ins Key-Feld (pay-per-use)
2. **setup-token** `sk-ant-oat01-…` ins Key-Feld (`claude setup-token`, Abo)
3. **OAuth-Login per Klick** (NEU, Abo, ohne CLI, mit Auto-Refresh)

Konflikt-Priorität: **OAuth vor API-Key** (bestehende `resolve_anthropic_token`-Logik, unverändert).

## Backend (`llm_oauth.py`)
- Provider-Dispatch (`_PROVIDERS`-Registry) statt hartem `openai-codex`: start/exchange/revoke unterstützen jetzt **codex UND anthropic**; unbekannte Provider weiter 400.
- `_write_provider_oauth` löscht **kein** vorhandenes `api_key` mehr → Weg 3 koexistiert mit Weg 1/2.
- Codex-Pfad funktional identisch.
- 8 neue Routen-Tests: Koexistenz key+oauth, revoke behält key, Dispatch, 400-Fälle.

## Frontend
- `_llm_providers`: Anthropic bekommt **additives** Flag `oauthOptional` (nicht `auth:"oauth"`) → **Key-Feld bleibt sichtbar**, Weg 1+2 intakt.
- `ProviderForm`: bei `oauthOptional` Key-Feld **und** OAuth-Login rendern; Submit akzeptiert Key **oder** Token.
- `OAuthFlow`: provider-spezifische Texte (claude.ai / `localhost:53692` für Anthropic; ChatGPT / `1455` für Codex) — Flow identisch.

## Anleitung
`llm.md` (de+en): Anthropic-Abschnitt als drei klar getrennte Wege, Hinweis auf Auto-Refresh (löst das „nach 1-2 Tagen tot"-Problem früherer Setups). Codex-Abschnitt entschärft.

## Test
Backend: 17 OAuth-Tests passed (inkl. api_key-Koexistenz), ruff clean. Frontend: `tsc` grün, `eslint` clean.

## Nicht in Scope
Kein Auto-Login ohne Klick. Keine Änderung an `resolve_anthropic_token`. Kein lokaler Callback-Server (manueller URL-Paste wie bei Codex).

Spec: `docs/specs/anthropic-oauth-gui.md`
