### PR TITLE
fix(llm): Anthropic-OAuth zeigt Code an (nicht URL) + Add-Flow klargestellt

### DIFF
--- a/frontend/src/features/llm/OAuthFlow.tsx
+++ b/frontend/src/features/llm/OAuthFlow.tsx
@@ -4,10 +4,13 @@ import { ExternalLink, Loader2 } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
 import { llmApi } from "./api"
 
-// Provider-spezifische Texte für den OAuth-Login (Flow ist identisch).
-const OAUTH_META: Record<string, { service: string; callback: string }> = {
-  "openai-codex": { service: "OpenAI/ChatGPT", callback: "localhost:1455" },
-  anthropic: { service: "Claude (claude.ai)", callback: "localhost:53692" },
+// Provider-spezifische Texte. mode="url": Browser zeigt Connection-Refused-Page,
+// User kopiert die REDIRECT-URL aus der Adresszeile (ChatGPT/Codex).
+// mode="code": Anbieter-Seite zeigt einen Code direkt an, User kopiert den CODE
+// (Anthropic/claude.ai — Format code#state).
+const OAUTH_META: Record<string, { service: string; callback: string; mode: "url" | "code" }> = {
+  "openai-codex": { service: "OpenAI/ChatGPT", callback: "localhost:1455", mode: "url" },
+  anthropic: { service: "Claude (claude.ai)", callback: "localhost:53692", mode: "code" },
 }
 
 export function OAuthFlow({
@@ -57,12 +60,21 @@ export function OAuthFlow({
 
       {step === 1 && (
         <div className="space-y-2">
-          <p className="text-xs text-zinc-400">
-            Login bei {meta.service}. Du wirst danach auf <code className="text-zinc-300">{meta.callback}</code> umgeleitet —
-            das wird im Browser eine "Diese Seite kann nicht erreicht werden"-Fehlermeldung zeigen.
-            <strong className="text-zinc-200"> Das ist normal.</strong> Du kopierst die ganze URL aus
-            dem Browser-Adressfeld in Schritt 2.
-          </p>
+          {meta.mode === "code" ? (
+            <p className="text-xs text-zinc-400">
+              Login bei {meta.service}. Nach dem Bestätigen zeigt die Seite einen
+              <strong className="text-zinc-200"> Authorisierungs-Code</strong> an
+              (Format <code className="text-zinc-300">code#state</code>). Diesen
+              Code kopierst du in Schritt 2.
+            </p>
+          ) : (
+            <p className="text-xs text-zinc-400">
+              Login bei {meta.service}. Du wirst danach auf <code className="text-zinc-300">{meta.callback}</code> umgeleitet —
+              das wird im Browser eine "Diese Seite kann nicht erreicht werden"-Fehlermeldung zeigen.
+              <strong className="text-zinc-200"> Das ist normal.</strong> Du kopierst die ganze URL aus
+              dem Browser-Adressfeld in Schritt 2.
+            </p>
+          )}
           <div className="flex gap-2">
             <button onClick={startFlow} disabled={busy}
               className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-xs font-medium disabled:opacity-40">
@@ -81,11 +93,19 @@ export function OAuthFlow({
 
       {step === 2 && (
         <div className="space-y-2">
-          <p className="text-xs text-zinc-400">
-            Kopier die ganze URL aus dem Browser-Adressfeld
-            (<code className="text-zinc-300">http://{meta.callback}/...?code=...&state=...</code>)
-            und füge sie hier ein:
-          </p>
+          {meta.mode === "code" ? (
+            <p className="text-xs text-zinc-400">
+              Füge den <strong className="text-zinc-200">Code</strong> ein, den die
+              Login-Seite angezeigt hat (Format
+              <code className="text-zinc-300"> code#state</code>):
+            </p>
+          ) : (
+            <p className="text-xs text-zinc-400">
+              Kopier die ganze URL aus dem Browser-Adressfeld
+              (<code className="text-zinc-300">http://{meta.callback}/...?code=...&state=...</code>)
+              und füge sie hier ein:
+            </p>
+          )}
           {authUrl && (
             <a href={authUrl} target="_blank" rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-[11px] text-violet-300 hover:text-violet-200 underline">
@@ -93,7 +113,10 @@ export function OAuthFlow({
             </a>
           )}
           <textarea value={code} onChange={(e) => setCode(e.target.value)}
-            rows={3} placeholder={`http://${meta.callback}/...?code=...&state=...`}
+            rows={3}
+            placeholder={meta.mode === "code"
+              ? "code#state"
+              : `http://${meta.callback}/...?code=...&state=...`}
             className="w-full px-3 py-2 rounded-lg bg-zinc-900 border border-white/[8%] text-zinc-200 text-xs font-mono placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50 resize-none" />
           {error && <p className="text-xs text-rose-400">{error}</p>}
           <div className="flex gap-2">

--- a/frontend/src/i18n/help/de/llm.md
+++ b/frontend/src/i18n/help/de/llm.md
@@ -54,12 +54,15 @@ erkennt am Präfix `sk-ant-oat...` automatisch, dass es ein OAuth-Token ist.
 Der bequemste Weg mit Claude-Abo — kein Terminal nötig. HydraHive holt den Token
 selbst und **erneuert ihn automatisch** (Auto-Refresh), du musst dich also nicht
 alle paar Tage neu einloggen.
-1. **Provider hinzufügen** → **Anthropic**.
-2. Unter dem API-Key-Feld beim OAuth-Login **Login öffnen** klicken → im Browser
-   bei **claude.ai** anmelden und autorisieren.
-3. Der Browser leitet auf `localhost:53692` um und zeigt „Seite nicht erreichbar" —
-   **das ist normal**. Die ganze URL aus dem Adressfeld kopieren.
-4. URL im zweiten Schritt einfügen → **Verbinden**. Es erscheint „Per OAuth
+1. **Provider hinzufügen** klicken und im Dropdown **Anthropic** auswählen.
+   Sobald „Anthropic" gewählt ist, erscheint **unter dem API-Key-Feld** der
+   Bereich „oder per OAuth-Login".
+2. Dort **Login öffnen** klicken → im Browser bei **claude.ai** anmelden und
+   autorisieren.
+3. **Anthropic zeigt danach einen Code direkt auf der Seite an** (Format
+   `code#state`) — anders als bei ChatGPT gibt es hier **keine URL zum Kopieren**.
+   Diesen **Code kopieren**.
+4. Den Code im zweiten Schritt einfügen → **Verbinden**. Es erscheint „Per OAuth
    verbunden".
 5. Modelle ankreuzen, **Hinzufügen**, Standard-Modell setzen, **Verbindung testen**.
 

--- a/frontend/src/i18n/help/en/llm.md
+++ b/frontend/src/i18n/help/en/llm.md
@@ -54,12 +54,13 @@ field — HydraHive detects the `sk-ant-oat...` prefix and treats it as OAuth.
 The most convenient path with a Claude subscription — no terminal needed.
 HydraHive fetches the token itself and **refreshes it automatically**, so you
 don't have to log in again every few days.
-1. **Add provider** → **Anthropic**.
-2. Below the API-key field, at the OAuth login, click **Open login** → sign in at
-   **claude.ai** and authorize.
-3. The browser redirects to `localhost:53692` and shows "site can't be reached" —
-   **that's normal**. Copy the whole URL from the address bar.
-4. Paste the URL in step two → **Connect**. It shows "Connected via OAuth".
+1. Click **Add provider** and select **Anthropic** in the dropdown. As soon as
+   "Anthropic" is selected, the "or via OAuth login" area appears **below the
+   API-key field**.
+2. There, click **Open login** → sign in at **claude.ai** and authorize.
+3. **Anthropic then shows a code directly on the page** (format `code#state`) —
+   unlike ChatGPT there is **no URL to copy** here. Copy that **code**.
+4. Paste the code in step two → **Connect**. It shows "Connected via OAuth".
 5. Pick models, **Add**, set default model, **Test connection**.
 
 > The API-key field stays visible in all three ways — the OAuth login (way 3) is


### PR DESCRIPTION
## Warum
User-Feedback zu PR #270, zwei Punkte:

1. **„Der OAuth-Login kommt nur beim Ändern eines bestehenden Tokens, nicht beim Neu-Anlegen."**
2. **„Bist du sicher mit dem URL-Kopieren? Bei Anthropic lief das anders — du hast vermutlich nur den ChatGPT-Flow kopiert."** → **Stimmt.**

## Punkt 2 — Faktencheck (er hatte recht)
Anthropic läuft anders als ChatGPT/Codex:
- `oauth/anthropic.py:parse_callback_input` akzeptiert ausdrücklich das **`code#state`-Format** (Kommentar: „wie pi-ai/OpenClaw").
- Offizielle Anthropic-Doku: *„If your browser shows a login code … paste it."* → claude.ai zeigt einen **Code** an, **keine** Redirect-URL zum Kopieren.

Im vorigen PR hatte ich den Codex-Text 1:1 übernommen (URL kopieren / localhost:53692). Das war falsch.

### Fix `OAuthFlow.tsx`
Provider-`mode`:
- `openai-codex`: `mode:"url"` — Redirect-URL aus der Adresszeile kopieren (unverändert).
- `anthropic`: `mode:"code"` — den auf der Seite angezeigten **Code** (`code#state`) einfügen.

Schritt-1/Schritt-2-Texte + Placeholder passen sich dem Modus an.

## Punkt 1 — Klarstellung + Anleitung
Der OAuth-Bereich hängt im Code **nicht** von Add/Edit ab — er erscheint, sobald „Anthropic" im Dropdown gewählt ist (verifiziert). Der wahrscheinlichste Grund fürs „fehlt beim Anlegen": die getestete Instanz war noch nicht auf dem #270-Stand. Anleitung (de+en) präzisiert: **erst Anthropic im Dropdown wählen** → dann erscheint „oder per OAuth-Login" unter dem Key-Feld.

## Test
tsc grün, eslint clean. Backend unverändert (Flow akzeptiert code#state bereits).
