### PR TITLE
docs(help): Deep-Dive-Hilfe — VMs, Container, Benutzer

### DIFF
--- a/docs/HELP-COVERAGE.md
+++ b/docs/HELP-COVERAGE.md
@@ -35,6 +35,8 @@
 | Streaming | /streaming | ❌ | ❌ | ✅ | niedrig |
 | Datamining | /datamining | ✅ | ✅ | ✅ | mittel |
 | Memory | /memory | ✅ | ✅ | ✅ | mittel |
+| VMs | /vms | ✅ | ✅ | ✅ | mittel |
+| Container | /containers | ✅ | ✅ | ✅ | mittel |
 | System | /settings → System | ✅ (2.3k) | ✅ | ✅ | hoch |
 | LLM | /settings → LLM | ✅ (3.3k) | ✅ | ✅ | hoch |
 | Hilfe/Handbuch | /help | (Meta) | — | — | — |
@@ -45,14 +47,14 @@
 | Credentials | ✅ (Artikel + Button) | hoch (Keys/Secrets — kritisch für Einstieg) |
 | Extensions | ❌ | niedrig |
 | Module (Verwaltung) | ❌ | mittel |
-| Benutzer/Users | ❌ | mittel |
+| Benutzer/Users | ✅ (Artikel + Button) | mittel |
 | Einstellungen (Mail, SearXNG, …) | ❌ | mittel |
 
 ## Module (frontend/src/modules/*)
 | Modul | Pfad | Artikel | Prio |
 |-------|------|---------|------|
 | Atelier | /atelier | ✅ (Artikel + Button, Button im modules-Repo) | mittel (groß, viel Erklärbedarf) |
-| Patientenakte | /akte | ❌ | mittel |
+| Patientenakte | /akte | ✅ (Artikel + Button, Button im modules-Repo) | mittel |
 | Cryptoboard | /cryptoboard | ❌ | niedrig |
 | Notizbuch | /notizbuch | ❌ | niedrig |
 | Scratchpad | /scratchpad | ❌ | niedrig |

--- a/frontend/src/features/containers/ContainersPage.tsx
+++ b/frontend/src/features/containers/ContainersPage.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 import { Box, Plus, RefreshCw } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import type { Container } from "./types"
 import { containersApi } from "./api"
 import { ContainerCard } from "./ContainerCard"
@@ -44,9 +45,12 @@ export function ContainersPage() {
   return (
     <div className="space-y-6 max-w-7xl">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-white">{t("title")}</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{t("detail.subtitle")}</p>
+        <div className="flex items-center gap-1">
+          <div>
+            <h1 className="text-xl font-bold text-white">{t("title")}</h1>
+            <p className="text-zinc-500 text-sm mt-0.5">{t("detail.subtitle")}</p>
+          </div>
+          <HelpButton topic="containers" />
         </div>
         <div className="flex items-center gap-2">
           <button onClick={refresh}

--- a/frontend/src/features/users/UsersPage.tsx
+++ b/frontend/src/features/users/UsersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useAuthStore } from "@/features/auth/useAuthStore"
+import { HelpButton } from "@/i18n/HelpButton"
 import { ApiKeysSection } from "./ApiKeysSection"
 import { ChangePasswordDialog } from "./ChangePasswordDialog"
 import { EditUserDialog } from "./EditUserDialog"
@@ -41,9 +42,12 @@ export function UsersPage() {
   return (
     <div className="space-y-5 max-w-3xl">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-white">{t("title")}</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+        <div className="flex items-center gap-1">
+          <div>
+            <h1 className="text-xl font-bold text-white">{t("title")}</h1>
+            <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+          </div>
+          <HelpButton topic="users" />
         </div>
         <button
           onClick={() => setShowNew(true)}

--- a/frontend/src/features/vms/VMsPage.tsx
+++ b/frontend/src/features/vms/VMsPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import type { CSSProperties } from "react"
 import { Disc, Download, Plus, RefreshCw } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import type { VM } from "./types"
 import { vmsApi } from "./api"
 import { VMCard } from "./VMCard"
@@ -57,9 +58,12 @@ export function VMsPage() {
   return (
     <div className="space-y-6 max-w-7xl">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-white">{t("title")}</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+        <div className="flex items-center gap-1">
+          <div>
+            <h1 className="text-xl font-bold text-white">{t("title")}</h1>
+            <p className="text-zinc-500 text-sm mt-0.5">{t("subtitle")}</p>
+          </div>
+          <HelpButton topic="vms" />
         </div>
         <div className="flex items-center gap-2">
           <button onClick={() => setShowImports(true)}

--- a/frontend/src/i18n/help/de/containers.md
+++ b/frontend/src/i18n/help/de/containers.md
@@ -1,0 +1,75 @@
+# Container
+
+## Was ist das?
+
+Container sind **leichtgewichtige, abgeschottete Dienste** — ähnlich wie VMs,
+aber viel schlanker und schneller. Technisch sind es **Linux-Container (LXC via
+incus)**: Sie teilen sich den Kernel des Hosts und starten in Sekunden, ohne den
+Overhead einer kompletten virtuellen Maschine.
+
+**Faustregel:** Willst du ein **komplettes fremdes Betriebssystem** (z.B. Windows)
+→ nimm eine **VM**. Willst du einen **einzelnen Linux-Dienst** schlank laufen
+lassen (z.B. eine Such-Engine, ein Passwort-Manager, ein Bookmark-Tool) → nimm
+einen **Container**.
+
+## Wozu ist das gut?
+
+Ideal für kleine, dauerhaft laufende Dienste — Beispiele wie in der Eingabemaske
+vorgeschlagen: **searxng** (Suche), **vaultwarden** (Passwörter), **linkding**
+(Bookmarks). Jeder Dienst läuft isoliert, kann aber über das Netzwerk erreichbar
+sein.
+
+## Kernbegriffe
+
+- **Image** — die Vorlage, aus der ein Container gebaut wird (z.B. ein Ubuntu- oder
+  Debian-Basis-Image). Du kannst aus den **Quick-Images** wählen oder einen
+  eigenen **Image-Alias** eingeben.
+- **Bridged / Isoliert** — Netzwerk-Betriebsart (wie bei VMs): bridged = eigene
+  IP im LAN, isoliert = kein Netzzugang.
+- **CPU-/RAM-Limit** — optionale Obergrenzen. Leer = unbegrenzt (der Container
+  darf sich nehmen, was da ist).
+
+## Schritt-für-Schritt: Container erstellen
+
+1. **Container erstellen** klicken.
+2. **Name** vergeben (1–63 Zeichen, beginnt mit Buchstabe, nur `a-z A-Z 0-9 -`) —
+   z.B. `searxng`.
+3. **Image** wählen (aus den Quick-Images oder eigener Alias).
+4. Optional **CPU-Limit** und **RAM-Limit (MB)** setzen — leer lassen = unbegrenzt.
+5. **Netzwerk** wählen: **Bridged (br0)** für eine eigene LAN-IP, **Isoliert** für
+   keinen Netzzugang.
+6. **Container erstellen** → er startet und erscheint in der Liste.
+
+## Die Detail-Ansicht (Tabs)
+
+Ein Klick auf einen Container öffnet die Detail-Ansicht mit vier Reitern:
+
+- **Config** — Einstellungen (Name, Beschreibung, CPU/RAM, Image). Das Image ist
+  read-only — für ein anderes Image den Container neu erstellen.
+- **Konsole** — eine Shell im Container, direkt im Browser.
+- **Logs** — das Lifecycle-Log (`incus info --show-log`), hilft bei Startproblemen.
+- **Stats** — Live-Auslastung (CPU/RAM) — nur wenn der Container läuft.
+
+## Typische Fehler
+
+- **„Image fehlt"** — Beim Anlegen wurde kein Image gewählt. Eins aus der Liste
+  nehmen oder einen gültigen Alias eintippen.
+- **„Name ungültig"** — 1–63 Zeichen, beginnt mit Buchstabe, nur `a-z A-Z 0-9 -`.
+- **Keine Live-Stats** — Der Container läuft nicht; erst starten.
+- **Kein Netzwerk im Container** — Netzwerk steht auf **Isoliert**; auf
+  **Bridged** umstellen.
+
+## Container oder VM?
+
+| | Container (LXC/incus) | VM (QEMU/KVM) |
+|---|---|---|
+| Gewicht | leicht, Sekunden-Start | schwer, eigener Kernel |
+| Betriebssystem | Linux (teilt Host-Kernel) | beliebig (auch Windows) |
+| Wofür | einzelne Dienste | komplette Fremdsysteme |
+
+## Tipps
+
+- **Ein Dienst pro Container** — sauberer zu warten und neu zu starten.
+- **Limits nur wenn nötig**: Für die meisten kleinen Dienste reicht „unbegrenzt";
+  Limits setzt du, wenn ein Container den Host nicht überlasten soll.
+- **Bridged**, wenn du den Dienst von anderen Geräten im Netz erreichen willst.

--- a/frontend/src/i18n/help/de/patientenakte.md
+++ b/frontend/src/i18n/help/de/patientenakte.md
@@ -1,0 +1,71 @@
+# Meine Akte — deine strukturierte Patientenakte
+
+## Was ist das?
+
+Die **Akte** ist deine persönliche, digitale **Gesundheitsakte**: Diagnosen,
+Medikamente, Laborwerte, Allergien, Arztbesuche und Dokumente an einem Ort,
+sauber strukturiert und durchsuchbar. Du kannst Daten selbst pflegen, aus offiziellen
+Quellen **importieren** und Verläufe über die Zeit ansehen.
+
+> **Wichtig:** Das ist ein persönliches Ablage- und Übersichts-Werkzeug, **kein
+> medizinisches Diagnose-System**. Es ersetzt keine ärztliche Beratung.
+
+## Die Bereiche (Navigation links)
+
+**Meine Akte**
+- **Übersicht** — Dashboard mit dem Wichtigsten auf einen Blick.
+- **Zeitstrahl** — alle Ereignisse chronologisch.
+- **Diagnosen**, **Medikamente**, **Laborwerte**, **Allergien**, **Ereignisse**,
+  **Bildgebung**, **Ärzte**, **Dokumente**, **Notizen** — je eine Liste zum
+  Pflegen und Nachschlagen. Laborwerte lassen sich als **Verlaufskurve** anzeigen.
+
+**Import**
+- **eGA / FHIR** — offizielle Gesundheitsdaten importieren (siehe unten).
+
+**Tracking**
+- **Apple Health** und **Schlaf** — Verlaufsdaten aus deinem Health-Tracking.
+
+## Daten importieren (eGA / FHIR)
+
+Du kannst deine Kassen-Gesundheitsakte importieren, statt alles abzutippen:
+
+1. In der **TK-Safe App** deine elektronische Gesundheitsakte (eGA) **exportieren**
+   → du erhältst eine **ZIP-Datei**.
+2. Im Import-Bereich **TK-eGA-ZIP** hochladen (alternativ ein **FHIR-Bundle**).
+3. HydraHive liest die Daten ein — du siehst, wie viele Einträge **neu** und wie
+   viele **aktualisiert** wurden.
+
+**Wichtig:** Importierte Daten sind **read-only** und bleiben **getrennt** von
+deiner selbst gepflegten Akte. So vermischt sich Offizielles nicht mit eigenen
+Einträgen. Der Import zeigt zusätzlich einen **Kosten-Überblick** (abgerechnete
+Arztbesuche, Apothekenpreise, deine Zuzahlung) und einen eigenen Zeitstrahl.
+
+## Verifizieren
+
+Einträge können als **manuell verifiziert** markiert werden (Häkchen). Nicht
+verifizierte Einträge (z.B. automatisch erkannte) sind entsprechend gekennzeichnet
+und lassen sich per Klick bestätigen — so behältst du den Überblick, was du selbst
+geprüft hast.
+
+## Schritt-für-Schritt: Eintrag anlegen
+
+1. Links den passenden Bereich wählen (z.B. **Medikamente**).
+2. Einen neuen Eintrag hinzufügen und die Felder ausfüllen.
+3. Speichern. Über die Aktionen kannst du Einträge später **bearbeiten**,
+   **löschen** oder **verifizieren**.
+
+## Typische Fragen
+
+- **„Daten konnten nicht geladen werden"** — Verbindungsproblem; Seite neu laden.
+- **„Wo kommt mein Import her?"** — TK-Safe App → Akte exportieren → ZIP hier
+  hochladen. Ohne Export gibt es nichts zu importieren.
+- **„Warum kann ich importierte Einträge nicht ändern?"** — Sie sind bewusst
+  read-only (Originaltreue). Eigene Ergänzungen macht du in der eigenen Akte.
+
+## Tipps
+
+- **Erst importieren, dann ergänzen**: Der eGA-Import spart viel Tipparbeit; eigene
+  Details fügst du danach hinzu.
+- **Laborwerte als Verlauf** ansehen — Trends erkennt man in der Kurve leichter als
+  in einer Tabelle.
+- **Verifizieren nutzen**, um geprüfte von ungeprüften Einträgen zu unterscheiden.

--- a/frontend/src/i18n/help/de/users.md
+++ b/frontend/src/i18n/help/de/users.md
@@ -1,0 +1,67 @@
+# Benutzer
+
+## Was ist das?
+
+Hier verwaltest du, **wer sich bei HydraHive anmelden darf** — die Benutzerkonten
+und ihre Rollen. Diesen Bereich sehen nur **Admins**. Zusätzlich verwaltest du
+hier **API-Keys**: langlebige Tokens, mit denen externe Programme (z.B. ein
+Skript oder ein MCP-Client) auf HydraHive zugreifen können, ohne sich per
+Benutzername/Passwort einzuloggen.
+
+## Die zwei Rollen
+
+- **Admin** — darf alles: Benutzer anlegen/bearbeiten/löschen, System-
+  Einstellungen, Module, VMs/Container usw.
+- **Benutzer** — normaler Zugang zum Arbeiten (Chat, Projekte, …), aber ohne
+  Verwaltungs- und System-Rechte.
+
+## Schritt-für-Schritt
+
+### Benutzer anlegen
+1. **Neuer Benutzer** klicken.
+2. **Benutzername** vergeben (nur Buchstaben, Ziffern, `_` und `-`), z.B. `alice`.
+3. **Passwort** setzen.
+4. **Rolle** wählen (Admin oder Benutzer).
+5. Anlegen — der Benutzer kann sich jetzt anmelden.
+
+### Passwort ändern
+Beim Benutzer **Passwort ändern** wählen und ein neues vergeben. (Als Admin kannst
+du das auch für andere tun.)
+
+### Benutzer bearbeiten / löschen
+Über die Aktionen am jeweiligen Eintrag. **Dich selbst kannst du nicht löschen** —
+das verhindert, dass sich der letzte Admin aussperrt.
+
+## API-Keys
+
+Ein **API-Key** ist ein langlebiges Token für **maschinellen Zugriff** — z.B.
+damit ein lokales Tool oder Skript die HydraHive-API nutzt, ohne interaktives
+Login.
+
+1. Einen Namen vergeben (z.B. `claude-code-local`) → **Key erzeugen**.
+2. **Wichtig:** Der Key wird **nur einmal** angezeigt — sofort kopieren und sicher
+   speichern. Danach ist er nicht mehr einsehbar.
+3. Nicht mehr benötigte Keys **widerrufen** (löschen) — dann funktioniert das
+   Token sofort nicht mehr.
+
+## Typische Fehler
+
+- **„Benutzername existiert bereits"** — Name schon vergeben, einen anderen wählen.
+- **„Du kannst dich nicht selbst löschen"** — Absicht; lösche dich über einen
+  zweiten Admin-Account, falls wirklich nötig.
+- **API-Key verloren** — Nicht wiederherstellbar; einen neuen erzeugen und den
+  alten widerrufen.
+
+## Unterschied: Benutzer-Login vs. API-Key vs. Credentials
+
+- **Benutzer** — Menschen, die sich im Browser anmelden.
+- **API-Key** — Programme, die HydraHive **von außen** ansprechen (kein Login).
+- **Credentials** (eigener Bereich) — Zugänge, die HydraHive-Agenten **nach außen**
+  brauchen (z.B. ein Token für eine fremde Webseite). Nicht verwechseln.
+
+## Tipps
+
+- **Sparsam mit Admin-Rechten**: Nur wer wirklich verwalten muss, braucht Admin.
+- **Ein API-Key pro Zweck/Tool** — so kannst du einzelne widerrufen, ohne andere
+  zu treffen.
+- **Starke Passwörter** vergeben, besonders für Admin-Konten.

--- a/frontend/src/i18n/help/de/vms.md
+++ b/frontend/src/i18n/help/de/vms.md
@@ -1,0 +1,84 @@
+# Virtuelle Maschinen (VMs)
+
+## Was ist das?
+
+Hier betreibst du **vollwertige virtuelle Computer** direkt auf dem HydraHive-
+Server — echte Betriebssysteme (Linux, Windows …) in einer abgeschotteten
+Umgebung. Technisch läuft das über **QEMU/KVM** (die native Virtualisierung von
+Linux). Du siehst alle VMs als Kacheln, kannst sie starten/stoppen und dich per
+**VNC-Konsole direkt im Browser** einloggen — wie ein Bildschirm, der an die VM
+angeschlossen ist.
+
+Denk an eine VM wie an einen **zweiten Rechner im Rechner**: eigene Festplatte,
+eigenes Betriebssystem, eigenes Netzwerk — komplett getrennt vom Host.
+
+## Wozu ist das gut?
+
+- Ein **Testsystem** aufsetzen, ohne echte Hardware.
+- Ein **anderes Betriebssystem** ausprobieren (z.B. Windows auf einem Linux-Server).
+- Einen **Dienst isoliert** laufen lassen, der nicht das Hauptsystem berühren soll.
+- Ein bestehendes Disk-Image (`qcow2`) importieren und weiterbetreiben.
+
+## Kernbegriffe
+
+- **ISO** — ein Installations-Abbild (z.B. der Windows- oder Ubuntu-Installer). Du
+  lädst es einmal in die **ISO-Library** hoch und bootest neue VMs davon.
+- **Disk / qcow2** — die virtuelle Festplatte der VM.
+- **Snapshot** — ein eingefrorener Zustand der VM, zu dem du später zurückkehren
+  kannst (praktisch vor riskanten Änderungen).
+- **Bridged / Isoliert** — die Netzwerk-Betriebsart (siehe unten).
+- **VNC-Konsole** — der Bildschirm der VM, im Browser bedienbar.
+
+## Schritt-für-Schritt: erste VM erstellen
+
+1. **Zuerst eine ISO hochladen**: Öffne die **ISO-Library** und lade das
+   Installations-Abbild deines Betriebssystems hoch (der Tipp oben auf der Seite
+   weist darauf hin).
+2. **Neue VM** klicken.
+3. **Name** vergeben (1–32 Zeichen, beginnt mit Buchstabe, nur `a-z A-Z 0-9 -`).
+4. **Boot-Quelle** wählen:
+   - **Aus ISO booten** — neue leere Disk + die ISO als Installations-Medium
+     (der Normalfall für eine Neuinstallation).
+   - **Importierte Disk** — eine vorhandene `qcow2` aus einem Disk-Import übernehmen.
+   - **Leere Disk** — bootet ins Leere, bis du später ein System nachreichst.
+5. **Netzwerk** wählen:
+   - **Bridged (br0)** — die VM bekommt eine eigene IP aus deinem LAN (wie ein
+     echtes Gerät im Netz).
+   - **Isoliert** — kein Netzwerkzugang (maximal abgeschottet).
+6. Optional **Disk-Interface / Machine-Type / Network-Device** anpassen
+   (Standardwerte passen meist; `virtio` = schnellste Performance unter KVM,
+   `sata` = kompatibler für ältere Gast-Systeme).
+7. **VM erstellen**.
+8. **Start** klicken → dann **Konsole**, um das Betriebssystem im Browser zu
+   installieren/bedienen.
+
+## Die Aktionen an jeder VM
+
+- **Start** — VM hochfahren.
+- **Konsole** — VNC-Bildschirm im Browser öffnen.
+- **Stop** — sauberes Herunterfahren (ACPI-Shutdown, wie „Herunterfahren"-Knopf).
+- **Aus** — hartes Ausschalten (SIGKILL, wie Stromstecker ziehen — nur wenn nötig).
+- **Snapshots** — Zustände sichern/wiederherstellen.
+- **QEMU-Log** — technisches Protokoll (hilft bei Startproblemen).
+- **Bearbeiten / Löschen**.
+
+## Typische Fehler
+
+- **„Keine ISOs vorhanden"** — Erst ein Installations-Abbild in die ISO-Library
+  hochladen, dann die VM erstellen.
+- **VM startet nicht / bootet ins Leere** — Bei „Leere Disk" fehlt ein System;
+  mit einer ISo booten oder eine importierte Disk verwenden. Das QEMU-Log gibt
+  Hinweise.
+- **Keine Netzwerkverbindung in der VM** — Netzwerk steht auf **Isoliert**; auf
+  **Bridged** umstellen, wenn die VM ins Netz soll.
+- **Konsole bleibt schwarz** — VM läuft evtl. noch nicht oder ist schon
+  heruntergefahren; Status der Kachel prüfen.
+
+## Tipps
+
+- **Snapshot vor Risiko**: Vor Updates oder Experimenten einen Snapshot anlegen —
+  Rückkehr ist ein Klick.
+- **virtio bevorzugen**, wenn das Gast-OS es unterstützt (Linux immer, Windows mit
+  Treiber) — deutlich schneller.
+- **Sauber herunterfahren** (Stop/ACPI) statt „Aus", damit das Gast-Dateisystem
+  keinen Schaden nimmt.

--- a/frontend/src/i18n/help/en/containers.md
+++ b/frontend/src/i18n/help/en/containers.md
@@ -1,0 +1,72 @@
+# Containers
+
+## What is this?
+
+Containers are **lightweight, isolated services** — similar to VMs but much
+leaner and faster. Technically they're **Linux containers (LXC via incus)**: they
+share the host's kernel and start in seconds, without the overhead of a full
+virtual machine.
+
+**Rule of thumb:** Want a **complete foreign operating system** (e.g. Windows) →
+use a **VM**. Want to run a **single Linux service** leanly (e.g. a search engine,
+a password manager, a bookmark tool) → use a **container**.
+
+## What is it good for?
+
+Ideal for small, always-on services — examples suggested in the form: **searxng**
+(search), **vaultwarden** (passwords), **linkding** (bookmarks). Each service runs
+in isolation but can be reachable over the network.
+
+## Core terms
+
+- **Image** — the template a container is built from (e.g. an Ubuntu or Debian
+  base image). Pick from the **quick images** or enter your own **image alias**.
+- **Bridged / Isolated** — network mode (like VMs): bridged = own IP on the LAN,
+  isolated = no network access.
+- **CPU/RAM limit** — optional caps. Empty = unlimited (the container may take
+  what's available).
+
+## Step by step: create a container
+
+1. Click **Create container**.
+2. Give it a **name** (1–63 chars, starts with a letter, only `a-z A-Z 0-9 -`) —
+   e.g. `searxng`.
+3. Choose an **image** (from quick images or your own alias).
+4. Optionally set a **CPU limit** and **RAM limit (MB)** — leave empty = unlimited.
+5. Choose the **network**: **Bridged (br0)** for its own LAN IP, **Isolated** for
+   no network access.
+6. **Create container** → it starts and appears in the list.
+
+## The detail view (tabs)
+
+Clicking a container opens the detail view with four tabs:
+
+- **Config** — settings (name, description, CPU/RAM, image). The image is
+  read-only — to use a different image, re-create the container.
+- **Console** — a shell inside the container, right in the browser.
+- **Logs** — the lifecycle log (`incus info --show-log`), helps with boot problems.
+- **Stats** — live usage (CPU/RAM) — only while the container runs.
+
+## Common mistakes
+
+- **"Image missing"** — No image chosen when creating. Pick one from the list or
+  type a valid alias.
+- **"Name invalid"** — 1–63 chars, starts with a letter, only `a-z A-Z 0-9 -`.
+- **No live stats** — The container isn't running; start it first.
+- **No network in the container** — Network is set to **Isolated**; switch to
+  **Bridged**.
+
+## Container or VM?
+
+| | Container (LXC/incus) | VM (QEMU/KVM) |
+|---|---|---|
+| Weight | light, seconds to start | heavy, own kernel |
+| OS | Linux (shares host kernel) | anything (incl. Windows) |
+| Use for | single services | complete foreign systems |
+
+## Tips
+
+- **One service per container** — cleaner to maintain and restart.
+- **Limits only when needed**: for most small services "unlimited" is fine; set
+  limits when a container shouldn't overload the host.
+- **Bridged** when you want to reach the service from other devices on the network.

--- a/frontend/src/i18n/help/en/patientenakte.md
+++ b/frontend/src/i18n/help/en/patientenakte.md
@@ -1,0 +1,68 @@
+# My Record — your structured patient record
+
+## What is this?
+
+The **Record** is your personal, digital **health record**: diagnoses,
+medications, lab values, allergies, doctor visits, and documents in one place,
+cleanly structured and searchable. You can maintain data yourself, **import** it
+from official sources, and view trends over time.
+
+> **Important:** This is a personal filing and overview tool, **not a medical
+> diagnosis system**. It does not replace professional medical advice.
+
+## The areas (left navigation)
+
+**My Record**
+- **Overview** — dashboard with the essentials at a glance.
+- **Timeline** — all events chronologically.
+- **Diagnoses**, **Medications**, **Lab values**, **Allergies**, **Events**,
+  **Imaging**, **Practitioners**, **Documents**, **Notes** — one list each to
+  maintain and look up. Lab values can be shown as a **trend curve**.
+
+**Import**
+- **eGA / FHIR** — import official health data (see below).
+
+**Tracking**
+- **Apple Health** and **Sleep** — trend data from your health tracking.
+
+## Importing data (eGA / FHIR)
+
+You can import your insurer's health record instead of typing everything:
+
+1. In the **TK-Safe app**, **export** your electronic health record (eGA) → you
+   get a **ZIP file**.
+2. In the import area, upload the **TK-eGA ZIP** (or a **FHIR bundle**).
+3. HydraHive reads the data — you see how many entries are **new** and how many
+   were **updated**.
+
+**Important:** imported data is **read-only** and stays **separate** from your
+self-maintained record. That way official data doesn't mix with your own entries.
+The import also shows a **cost overview** (billed doctor visits, pharmacy prices,
+your copay) and its own timeline.
+
+## Verifying
+
+Entries can be marked as **manually verified** (checkmark). Unverified entries
+(e.g. automatically detected) are flagged accordingly and can be confirmed by
+click — so you keep track of what you've personally checked.
+
+## Step by step: add an entry
+
+1. Pick the relevant area on the left (e.g. **Medications**).
+2. Add a new entry and fill in the fields.
+3. Save. Via the actions you can later **edit**, **delete**, or **verify** entries.
+
+## Common questions
+
+- **"Data could not be loaded"** — connection issue; reload the page.
+- **"Where does my import come from?"** — TK-Safe app → export record → upload the
+  ZIP here. Without an export there's nothing to import.
+- **"Why can't I edit imported entries?"** — They are intentionally read-only
+  (fidelity to the original). Add your own details in your own record.
+
+## Tips
+
+- **Import first, then add**: the eGA import saves a lot of typing; add your own
+  details afterwards.
+- **View lab values as a trend** — curves reveal trends more easily than a table.
+- **Use verifying** to distinguish checked from unchecked entries.

--- a/frontend/src/i18n/help/en/users.md
+++ b/frontend/src/i18n/help/en/users.md
@@ -1,0 +1,63 @@
+# Users
+
+## What is this?
+
+This is where you manage **who may log in to HydraHive** — the user accounts and
+their roles. Only **admins** see this area. You also manage **API keys** here:
+long-lived tokens that let external programs (e.g. a script or an MCP client)
+access HydraHive without logging in via username/password.
+
+## The two roles
+
+- **Admin** — may do everything: create/edit/delete users, system settings,
+  modules, VMs/containers, etc.
+- **User** — normal working access (chat, projects, …) but without admin and
+  system rights.
+
+## Step by step
+
+### Create a user
+1. Click **New user**.
+2. Choose a **username** (letters, digits, `_` and `-` only), e.g. `alice`.
+3. Set a **password**.
+4. Pick a **role** (admin or user).
+5. Create — the user can now log in.
+
+### Change password
+Choose **Change password** on the user and set a new one. (As an admin you can do
+this for others too.)
+
+### Edit / delete a user
+Via the actions on each entry. **You cannot delete yourself** — this prevents the
+last admin from locking themselves out.
+
+## API keys
+
+An **API key** is a long-lived token for **machine access** — e.g. so a local tool
+or script can use the HydraHive API without interactive login.
+
+1. Give it a name (e.g. `claude-code-local`) → **Create key**.
+2. **Important:** the key is shown **only once** — copy it immediately and store it
+   safely. Afterwards it can't be viewed again.
+3. **Revoke** (delete) keys you no longer need — the token stops working instantly.
+
+## Common mistakes
+
+- **"Username already exists"** — Name is taken, choose another.
+- **"You cannot delete yourself"** — By design; delete yourself via a second admin
+  account if truly needed.
+- **API key lost** — Not recoverable; create a new one and revoke the old.
+
+## Difference: user login vs. API key vs. credentials
+
+- **Users** — humans logging in via the browser.
+- **API key** — programs addressing HydraHive **from outside** (no login).
+- **Credentials** (separate area) — access that HydraHive agents need to reach
+  **outward** (e.g. a token for a foreign website). Don't confuse them.
+
+## Tips
+
+- **Be sparing with admin rights**: only those who really must manage need admin.
+- **One API key per purpose/tool** — so you can revoke individual ones without
+  affecting others.
+- **Use strong passwords**, especially for admin accounts.

--- a/frontend/src/i18n/help/en/vms.md
+++ b/frontend/src/i18n/help/en/vms.md
@@ -1,0 +1,79 @@
+# Virtual Machines (VMs)
+
+## What is this?
+
+Here you run **full virtual computers** directly on the HydraHive server — real
+operating systems (Linux, Windows …) in an isolated environment. Technically this
+uses **QEMU/KVM** (Linux's native virtualization). You see all VMs as cards, can
+start/stop them, and log in via a **VNC console right in the browser** — like a
+monitor plugged into the VM.
+
+Think of a VM as a **computer inside the computer**: its own disk, its own OS, its
+own network — fully separated from the host.
+
+## What is it good for?
+
+- Set up a **test system** without real hardware.
+- Try a **different operating system** (e.g. Windows on a Linux server).
+- Run a service **in isolation** so it can't touch the main system.
+- Import an existing disk image (`qcow2`) and keep running it.
+
+## Core terms
+
+- **ISO** — an installation image (e.g. the Windows or Ubuntu installer). You
+  upload it once into the **ISO library** and boot new VMs from it.
+- **Disk / qcow2** — the VM's virtual hard drive.
+- **Snapshot** — a frozen state of the VM you can return to later (handy before
+  risky changes).
+- **Bridged / Isolated** — the network mode (see below).
+- **VNC console** — the VM's screen, usable in the browser.
+
+## Step by step: create your first VM
+
+1. **Upload an ISO first**: open the **ISO library** and upload your operating
+   system's installation image (the tip at the top of the page points to this).
+2. Click **New VM**.
+3. Give it a **name** (1–32 chars, starts with a letter, only `a-z A-Z 0-9 -`).
+4. Choose the **boot source**:
+   - **Boot from ISO** — new blank disk + the ISO as install medium (the normal
+     case for a fresh install).
+   - **Imported disk** — take over an existing `qcow2` from a disk import.
+   - **Blank disk** — boots into nothing until you supply a system later.
+5. Choose the **network**:
+   - **Bridged (br0)** — the VM gets its own IP from your LAN (like a real device).
+   - **Isolated** — no network access (maximally sealed off).
+6. Optionally adjust **disk interface / machine type / network device** (defaults
+   usually fit; `virtio` = fastest under KVM, `sata` = more compatible for older
+   guests).
+7. **Create VM**.
+8. Click **Start** → then **Console** to install/operate the OS in the browser.
+
+## The actions on each VM
+
+- **Start** — power up the VM.
+- **Console** — open the VNC screen in the browser.
+- **Stop** — clean shutdown (ACPI, like the "shut down" button).
+- **Power off** — hard off (SIGKILL, like pulling the plug — only when needed).
+- **Snapshots** — save/restore states.
+- **QEMU log** — technical log (helps with boot problems).
+- **Edit / Delete**.
+
+## Common mistakes
+
+- **"No ISOs available"** — Upload an installation image into the ISO library
+  first, then create the VM.
+- **VM won't start / boots into nothing** — With "blank disk" there's no system;
+  boot from an ISO or use an imported disk. The QEMU log gives hints.
+- **No network in the VM** — Network is set to **Isolated**; switch to **Bridged**
+  if the VM should reach the network.
+- **Console stays black** — VM may not be running yet or already shut down; check
+  the card's status.
+
+## Tips
+
+- **Snapshot before risk**: take a snapshot before updates or experiments —
+  returning is one click.
+- **Prefer virtio** when the guest OS supports it (Linux always, Windows with a
+  driver) — noticeably faster.
+- **Shut down cleanly** (Stop/ACPI) rather than "Power off", so the guest file
+  system doesn't get damaged.

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -38,7 +38,10 @@
       "datamining": "Datamining",
       "communication": "Kommunikation",
       "teamchat": "Teamchat",
-      "atelier": "Atelier (Medien)"
+      "atelier": "Atelier (Medien)",
+      "vms": "Virtuelle Maschinen",
+      "containers": "Container",
+      "users": "Benutzer"
     }
   }
 }

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -41,7 +41,8 @@
       "atelier": "Atelier (Medien)",
       "vms": "Virtuelle Maschinen",
       "containers": "Container",
-      "users": "Benutzer"
+      "users": "Benutzer",
+      "patientenakte": "Meine Akte"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -38,7 +38,10 @@
       "datamining": "Datamining",
       "communication": "Communication",
       "teamchat": "Team chat",
-      "atelier": "Atelier (media)"
+      "atelier": "Atelier (media)",
+      "vms": "Virtual Machines",
+      "containers": "Containers",
+      "users": "Users"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -41,7 +41,8 @@
       "atelier": "Atelier (media)",
       "vms": "Virtual Machines",
       "containers": "Containers",
-      "users": "Users"
+      "users": "Users",
+      "patientenakte": "My Record"
     }
   }
 }


### PR DESCRIPTION
## Was
Fortsetzung der In-App-Hilfe (Charge 6). Drei neue ausführliche, einsteigerfreundliche Artikel (de+en), jeweils aus echter i18n/Code verifiziert:

- **vms** — QEMU/KVM: Boot aus ISO/Import/leer, bridged vs. isoliert, VNC-Konsole, Snapshots, ISO-Library, Disk-Import, virtio vs. sata.
- **containers** — LXC via incus: Image/Quick-Images, CPU/RAM-Limits, Tabs (Config/Konsole/Logs/Stats), Vergleichstabelle Container vs. VM.
- **users** — Rollen Admin/Benutzer, Passwort ändern, API-Keys (nur-einmal-Anzeige), klare Abgrenzung Benutzer / API-Key / Credentials.

HelpButton (gelber Blob) in VMsPage, ContainersPage, UsersPage. Handbuch-Übersicht (help.json de+en) erweitert.

## Test
tsc grün. Reine Doku + 3 HelpButton-Einbauten.

> Hinweis: die 3 Pages haben vorbestehende eslint `set-state-in-effect`-Warnungen aus dem Redesign-Commit (nicht aus dieser Charge); CI prüft nur tsc.

Fahrplan: docs/HELP-COVERAGE.md