### PR TITLE
docs(help): Dashboard-Artikel überarbeitet (Widgets, anpassbar)

### DIFF
--- a/docs/HELP-COVERAGE.md
+++ b/docs/HELP-COVERAGE.md
@@ -17,7 +17,7 @@
 
 | Seite | Pfad | Artikel | HelpButton | Loader-Topic | Prio |
 |-------|------|---------|-----------|--------------|------|
-| Dashboard | /dashboard | ✅ (dünn, 1.4k) | ✅ | ✅ | hoch |
+| Dashboard | /dashboard | ✅ (überarbeitet: Widgets, anpassbar) | ✅ | ✅ | hoch |
 | Buddy | / | ✅ | ✅ | ✅ | **sehr hoch** (Startseite) |
 | Werkstatt | /werkstatt | 🟡 (chat.md passt teils) | ✅ (im ChatHeader) | ✅ (chat) | **sehr hoch** |
 | Agenten | /settings/agents | ✅ (3.6k) | ✅ (Empty-State) | ✅ | hoch |

--- a/frontend/src/i18n/help/de/dashboard.md
+++ b/frontend/src/i18n/help/de/dashboard.md
@@ -2,32 +2,71 @@
 
 ## Was ist das?
 
-Das Dashboard ist die Startseite nach dem Login. Hier siehst du auf einen Blick wie viele Agenten, User und aktive Sessions dein HydraHive2 hat. Es ist bewusst minimalistisch gehalten — ausführliche Statistiken findest du auf der **System**-Seite.
+Das **Dashboard** ist deine Startseite für den Systemüberblick: Es zeigt in
+**anpassbaren Kacheln (Widgets)** auf einen Blick, wie es deinem HydraHive geht —
+Systemzustand, Kennzahlen, Token-Verbrauch, Verbindungen, laufende Sessions und
+Server. Du kannst die Kacheln **umsortieren und ausblenden**, damit oben steht,
+was dich am meisten interessiert.
 
-## Was kann ich hier tun?
+## Die Widgets
 
-- **Schnellüberblick** über das System (Anzahl Agents, User, Sessions)
-- Direkter Sprung in die wichtigsten Bereiche über die **linke Navigation**
+- **System-Status** — schneller Gesundheits-Check (ist die KI erreichbar, läuft
+  die Datenbank, sind Workspaces beschreibbar). Der erste Blick, wenn etwas hakt.
+- **Kennzahlen** — die wichtigsten Zahlen: aktive Sessions, Tokens heute u.a.
+- **Token-Verbrauch** — heutiger Verbrauch und Kosten, inkl. Cache-Nutzung.
+  Nützlich, um Ausgaben im Blick zu behalten.
+- **Verbindungen** — Status von **Tailscale** (sicheres Netzwerk) und
+  **AgentLink** (Agent-zu-Agent-Kommunikation).
+- **MiniMax-Nutzung** — Verbrauch, falls du MiniMax als Anbieter nutzt.
+- **Sessions & Agenten** — deine letzten Konversationen und die vorhandenen
+  Agenten, mit direktem Sprung hinein.
+- **Server-Übersicht** — Zustand angebundener Server (falls konfiguriert).
 
-## Wichtige Begriffe
+Oben erscheint zusätzlich ein **Update-Banner**, wenn eine neue Version bereitsteht.
 
-- **Agent** — eine konfigurierbare KI-Persönlichkeit mit eigenem Modell, Tools und System-Prompt
-- **User** — Person die sich am System anmelden kann (Admin, normaler User)
-- **Session** — eine laufende Konversation zwischen User und Agent
+## Kernbegriffe
+
+- **Agent** — eine KI-Persönlichkeit mit eigenem Modell, Werkzeugen und Rolle.
+- **Session** — eine laufende oder vergangene Konversation zwischen dir (oder
+  einem Auslöser) und einem Agenten.
+- **Token** — die Abrechnungseinheit der Sprachmodelle; „Tokens heute" zeigt den
+  Tagesverbrauch.
+- **Widget** — eine einzelne Dashboard-Kachel.
+
+## Dashboard anpassen
+
+Die Kacheln lassen sich über die Steuerung an jeder Kachel (im **Widget-Rahmen**)
+**verschieben** und **ausblenden**. Deine Anordnung wird **lokal im Browser**
+gespeichert — sie bleibt also an diesem Gerät erhalten, ist aber pro Browser/Gerät
+individuell.
 
 ## Schritt-für-Schritt
 
-### Erste Erkundung
+### Erster Rundgang
+1. Oben den **System-Status** prüfen — alles grün? Dann läuft die Basis.
+2. Bei **Sessions & Agenten** eine bestehende Konversation öffnen oder einen
+   Agenten ansehen.
+3. Über die **linke Navigation** in die Arbeitsbereiche springen (Buddy,
+   Werkstatt, Projekte …).
 
-1. Klick auf **Chat** in der linken Sidebar
-2. Klick auf **+ Neu** und wähle deinen Master-Agent
-3. Schreibe eine erste Nachricht — der Agent antwortet live
+### Wenn etwas nicht funktioniert
+Zeigt der **System-Status** ein Problem (z.B. KI nicht erreichbar), findest du die
+Details und Einstellungen unter **System** bzw. **LLM-Konfiguration**.
 
-### System-Status prüfen
+## Häufige Fragen
 
-Wenn etwas nicht funktioniert, schau in **System** in der Sidebar — dort steht ob LLM erreichbar ist, ob die DB läuft und ob Workspaces beschreibbar sind.
+- **„Zahlen wirken veraltet"** — Das Dashboard lädt beim Öffnen; ein Seiten-Refresh
+  holt den aktuellen Stand.
+- **„Ein Widget interessiert mich nicht"** — Blende es aus; die anderen rücken auf.
+- **„Wo sind ausführliche System-Details?"** — Auf der **System**-Seite (mehr
+  Tiefe als das kompakte Dashboard).
+- **„Kein Agent / keine Session sichtbar"** — Beim ersten Start gibt es nur den
+  Master-Agenten; weitere legst du unter **Agenten** an.
 
-## Häufige Fehler
+## Tipps
 
-- **Keine Agents sichtbar** — beim ersten Start wird nur der Master-Agent für Admin auto-erstellt. Für mehr Agents siehe **Agenten**-Seite.
-- **Anzeige aktualisiert sich nicht** — Browser-Refresh hilft. Auto-Refresh kommt mit der System-Seite.
+- **Wichtigstes nach oben**: Sortier die Kacheln so, dass dein häufigster Blick
+  (z.B. Token-Verbrauch oder System-Status) ganz oben ist.
+- **Token-Verbrauch im Auge behalten**, wenn Kosten eine Rolle spielen — das
+  Widget zeigt Tagesverbrauch und Cache-Ersparnis.
+- **System-Status zuerst** bei jeder Störung — er sagt dir in Sekunden, wo es klemmt.

--- a/frontend/src/i18n/help/en/dashboard.md
+++ b/frontend/src/i18n/help/en/dashboard.md
@@ -2,32 +2,67 @@
 
 ## What is this?
 
-The Dashboard is your landing page after login. At a glance you see how many agents, users, and active sessions your HydraHive2 has. It's intentionally minimal — detailed statistics live on the **System** page.
+The **dashboard** is your home page for a system overview: in **customizable tiles
+(widgets)** it shows at a glance how your HydraHive is doing — system health, key
+metrics, token usage, connections, running sessions, and servers. You can
+**reorder and hide** the tiles so the things you care about most sit at the top.
 
-## What can I do here?
+## The widgets
 
-- **Quick overview** of the system (agents, users, sessions count)
-- **Jump into the main areas** via the left navigation
+- **System status** — quick health check (is the AI reachable, is the database
+  running, are workspaces writable). Your first glance when something's off.
+- **Key metrics** — the most important numbers: active sessions, tokens today, etc.
+- **Token usage** — today's usage and cost, including cache usage. Useful to keep
+  an eye on spending.
+- **Connections** — status of **Tailscale** (secure networking) and **AgentLink**
+  (agent-to-agent communication).
+- **MiniMax usage** — consumption if you use MiniMax as a provider.
+- **Sessions & agents** — your recent conversations and the existing agents, with a
+  direct jump in.
+- **Servers overview** — state of connected servers (if configured).
 
-## Key terms
+At the top a **update banner** also appears when a new version is available.
 
-- **Agent** — a configurable AI personality with its own model, tools, and system prompt
-- **User** — a person who can log in (admin or regular user)
-- **Session** — a running conversation between user and agent
+## Core terms
+
+- **Agent** — an AI personality with its own model, tools, and role.
+- **Session** — an ongoing or past conversation between you (or a trigger) and an
+  agent.
+- **Token** — the billing unit of language models; "tokens today" shows daily usage.
+- **Widget** — a single dashboard tile.
+
+## Customize the dashboard
+
+The tiles can be **moved** and **hidden** via the controls on each tile (in the
+**widget frame**). Your arrangement is stored **locally in the browser** — so it
+persists on this device but is individual per browser/device.
 
 ## Step by step
 
-### First exploration
+### First tour
+1. Check **System status** at the top — all green? Then the basics are running.
+2. In **Sessions & agents**, open an existing conversation or view an agent.
+3. Use the **left navigation** to jump into the work areas (Buddy, Workshop,
+   Projects …).
 
-1. Click **Chat** in the left sidebar
-2. Click **+ New** and pick your master agent
-3. Type a first message — the agent answers live
+### When something doesn't work
+If **System status** shows a problem (e.g. AI unreachable), you'll find details and
+settings under **System** or **LLM configuration**.
 
-### Check system status
+## Common questions
 
-If something doesn't work, check **System** in the sidebar — it shows whether the LLM is reachable, the DB is running, and workspaces are writable.
+- **"Numbers look stale"** — The dashboard loads on open; a page refresh fetches
+  the current state.
+- **"A widget doesn't interest me"** — Hide it; the others move up.
+- **"Where are detailed system stats?"** — On the **System** page (more depth than
+  the compact dashboard).
+- **"No agent / no session visible"** — On first start there's only the master
+  agent; create more under **Agents**.
 
-## Common errors
+## Tips
 
-- **No agents visible** — on first start only the master agent for admin is auto-created. For more agents see the **Agents** page.
-- **Display doesn't refresh** — browser refresh helps. Auto-refresh exists on the System page.
+- **Most important up top**: order the tiles so your most frequent glance (e.g.
+  token usage or system status) is at the very top.
+- **Watch token usage** if cost matters — the widget shows daily usage and cache
+  savings.
+- **System status first** for any issue — it tells you in seconds where it's stuck.


### PR DESCRIPTION
## Warum
Der Dashboard-Hilfe-Artikel war der letzte 'dünne' aus der Lückenliste (204 Wörter) und teils veraltet (nannte 'Chat' / '+ Neu' statt der aktuellen Begriffe).

## Was
Neu geschrieben (de+en), aus dem echten Code verifiziert:
- Das Dashboard ist ein **anpassbares Widget-Dashboard** — alle 7 Widgets beschrieben (System-Status, Kennzahlen, Token-Verbrauch, Verbindungen/Tailscale+AgentLink, MiniMax, Sessions & Agenten, Server-Übersicht).
- **Umsortieren/Ausblenden** der Kacheln (localStorage, pro Gerät), Update-Banner.
- Begriffe aktualisiert, Verweise auf System / LLM-Konfiguration / Agenten.

## Test
Reine Doku (Markdown). HelpButton war bereits vorhanden.

Damit ist die Lückenliste bis auf niedrig-Prio-Bereiche (kleine Module, Admin-Seiten) + Phase-3-Feld-Tooltips abgearbeitet.