### PR TITLE
fix(build): Core ohne Module baubar (TS2307 Atelier-Import)

### DIFF
--- a/frontend/scripts/gen-modules.mjs
+++ b/frontend/scripts/gen-modules.mjs
@@ -29,5 +29,6 @@ export const moduleNav: unknown[] = [${nav}]
 export const moduleI18n: unknown[] = [${i18n}]
 export const moduleBuddyWidgets: unknown[] = _mods.flatMap(m => _opt(m, "buddyWidgets"))
 export const moduleWorkspaceTabs: unknown[] = _mods.flatMap(m => _opt(m, "workspaceTabs"))
+export const moduleSlotBlocks: unknown[] = _mods.flatMap(m => _opt(m, "slotBlocks"))
 `)
 console.log(`[gen-modules] ${ids.length} Modul(e): ${ids.join(", ") || "(keine)"}`)

--- a/frontend/src/features/themetemplates/registry.tsx
+++ b/frontend/src/features/themetemplates/registry.tsx
@@ -14,7 +14,7 @@ import { FederationPage } from "@/features/federation/FederationPage"
 import { StreamingPage } from "@/features/streaming/StreamingPage"
 import { McpPage } from "@/features/mcp/McpPage"
 import { ZahnfeePage } from "@/features/zahnfee/ZahnfeePage"
-import { AtelierPage } from "@/modules/atelier/AtelierPage"
+import { moduleSlotBlocks } from "@/modules/index.generated"
 import { TailscaleCard } from "@/features/system/TailscaleCard"
 import { AgentLinkCard } from "@/features/system/AgentLinkCard"
 import { MinimaxUsageCard } from "@/features/system/MinimaxUsageCard"
@@ -55,7 +55,6 @@ export const SLOT_BLOCKS: SlotBlock[] = [
   { name: "communication", label: "Kommunikation", render: flowPage(CommunicationPage) },
 
   // Kreativ / Automation
-  { name: "atelier", label: "Atelier (Bildgenerator)", render: flowPage(AtelierPage) },
   { name: "butler", label: "Butler (Automation)", render: fullPage(ButlerPage) },
 
   // Auswertung / Wissen
@@ -76,6 +75,10 @@ export const SLOT_BLOCKS: SlotBlock[] = [
   { name: "tailscale", label: "Tailscale-Status", render: () => <TailscaleCard /> },
   { name: "agentlink", label: "AgentLink-Status", render: () => <AgentLinkCard /> },
   { name: "minimax", label: "MiniMax-Nutzung", render: () => <MinimaxUsageCard /> },
+
+  // Modul-Bausteine (z.B. Atelier) — nur vorhanden wenn das Modul installiert
+  // ist. Kein harter Core→Modul-Import, damit der Core ohne Module baubar bleibt.
+  ...(moduleSlotBlocks as SlotBlock[]),
 ]
 
 export function getBlock(name: string): SlotBlock | undefined {


### PR DESCRIPTION
## Warum
Ein frischer Core-Clone (ohne das separate `hydrahive2-modules`-Repo) bricht bei der normalen Installation (`npm run build`) mit:
```
src/features/themetemplates/registry.tsx:17:29 - error TS2307:
Cannot find module '@/modules/atelier/AtelierPage'
```

## Ursache
`themetemplates/registry.tsx` importierte `AtelierPage` **hart statisch** aus dem Atelier-**Modul** und umging damit den optionalen Modul-Mechanismus (`gen-modules`). Der Core konnte so nie ohne Module bauen.

Tückisch: **`tsc --noEmit` (CI) tolerierte** den fehlenden Import, **`tsc -b` (Installer via `npm run build`) nicht** → CI war grün, die echte Installation rot. Deshalb fiel es erst beim Aufsetzen eines Testservers auf.

## Fix (nutzt das bestehende optionale Muster wie `buddyWidgets`/`workspaceTabs`)
- `gen-modules.mjs`: sammelt zusätzlich `moduleSlotBlocks` aus den installierten Modulen.
- `registry.tsx`: harter `AtelierPage`-Import entfernt; stattdessen `...(moduleSlotBlocks as SlotBlock[])` an die `SLOT_BLOCKS`-Liste angehängt.
- Der Atelier-Slotblock wird jetzt vom **Modul selbst** exportiert (`slotBlocks` in `hydrahive2-modules/atelier`, bereits gepusht).

## Verhalten
- **Ohne Module**: `moduleSlotBlocks = []` → Build grün (Bug behoben).
- **Mit Modul**: Atelier-Baustein voll vorhanden — **es fällt nichts weg**.

## Verifiziert
- `npm run build` mit **0 Modulen** → `✓ built`, exit 0 (exakte Repro von Tills Fehler).
- `npm run build`/`tsc -b` **mit** Atelier-Modul → exit 0, Atelier-Baustein funktioniert.

## Nicht in Scope
Kein Verhalten geändert außer der Modul-Entkopplung. Der Fix gehört zusammen mit dem Modul-Commit `atelier: slotBlocks-Export` (modules-Repo, main).
