### PR TITLE
docs(help): Modul-Hilfe — Cryptoboard, Notizbuch, Scratchpad, Deep Research

### DIFF
--- a/frontend/src/i18n/help/de/cryptoboard.md
+++ b/frontend/src/i18n/help/de/cryptoboard.md
@@ -1,0 +1,43 @@
+# Cryptoboard
+
+## Was ist das?
+
+Das **Cryptoboard** ist ein Dashboard für **Kryptowährungen**: Kurse, Charts,
+News und dein persönliches Portfolio an einem Ort. Du behältst Preise im Blick,
+verfolgst deine Bestände und lässt dich bei Kursmarken benachrichtigen — ohne die
+Plattform zu verlassen.
+
+> **Hinweis:** Das ist ein Informations- und Übersichts-Werkzeug, **keine
+> Handelsplattform und keine Anlageberatung.**
+
+## Die Bereiche
+
+- **Übersicht** — Kurse und Marktlage auf einen Blick.
+- **Portfolio** — deine Bestände mit aktuellem Wert.
+- **Auswertung** — Entwicklung und Kennzahlen deines Portfolios.
+- **Trades** — dein Handels-Logbuch (was du wann gekauft/verkauft hast).
+- **Wallets** — deine Wallet-Adressen/Konten.
+- **Vergleich** — mehrere Coins gegenüberstellen.
+- **Alarme** — Benachrichtigungen bei bestimmten Kursmarken.
+- **News** — aktuelle Meldungen zum Markt.
+
+## Alarme einrichten
+
+1. Im Bereich **Alarme** oben einen neuen Alarm erstellen.
+2. **Portfolio** bzw. Coin wählen und eine **Schwelle (€)** setzen.
+3. **Erstellen**. Aktive Alarme stehen unter „Aktive Alarme"; ausgelöste unter
+   „Ausgelöste Alarme".
+
+## Typische Fragen
+
+- **„Meine Bestände fehlen"** — Erst im Bereich **Portfolio**/**Wallets** deine
+  Bestände eintragen.
+- **„Kurse aktualisieren nicht"** — Seite neu laden; die Daten kommen von externen
+  Kursquellen.
+
+## Tipps
+
+- **Alarme statt ständig schauen**: Setz dir eine Kursmarke und lass dich
+  benachrichtigen, statt den Chart im Auge zu behalten.
+- **Trades pflegen**: Ein gepflegtes Handels-Logbuch macht die Auswertung
+  aussagekräftig.

--- a/frontend/src/i18n/help/de/deepresearch.md
+++ b/frontend/src/i18n/help/de/deepresearch.md
@@ -1,0 +1,42 @@
+# Deep Research
+
+## Was ist das?
+
+**Deep Research** führt für dich eine **gründliche, mehrstufige Web-Recherche**
+durch und liefert am Ende einen **zitierten Bericht** mit Quellen. Statt einer
+schnellen Antwort plant es die Suche, durchforstet mehrere Quellen und fasst das
+Ergebnis strukturiert zusammen — ideal für Überblicke, Vergleiche und
+Faktenchecks mit Belegen.
+
+> Eine Recherche dauert **einige Minuten** — das ist gewollt (Tiefe statt Tempo).
+
+## Schritt-für-Schritt
+
+1. Links im Eingabefeld deine **Frage/das Thema** eingeben (je präziser, desto
+   besser).
+2. **Recherche starten**.
+3. Der Fortschritt läuft live mit („Recherchiere …"). Du kannst warten oder später
+   wiederkommen.
+4. Fertige Läufe erscheinen in der Liste; ein Klick öffnet den **Bericht** samt
+   **Quellen**.
+
+## Typische Fragen
+
+- **„Noch keine Recherchen"** — Normal am Anfang; stell links eine Frage.
+- **„Recherche fehlgeschlagen"** — Meist ein temporäres Problem (Netz/Quelle);
+  einfach neu starten. Sehr breite Fragen ggf. konkreter fassen.
+- **„Dauert lange"** — Ein vollständiger Lauf braucht Minuten; das ist normal.
+
+## Wann Deep Research, wann normale Suche?
+
+- **Deep Research** — für **Berichte, Überblicke, Vergleiche, Faktenchecks** mit
+  Quellen. Dauert, liefert Tiefe.
+- **Normale Websuche** (im Chat) — für eine **einzelne schnelle Info** oder aktuelle
+  Zahl.
+
+## Tipps
+
+- **Präzise Frage stellen**: „Vergleiche X und Y bzgl. Z" liefert bessere Berichte
+  als ein einzelnes Stichwort.
+- **Quellen prüfen**: Der Bericht zitiert seine Quellen — bei wichtigen Themen kurz
+  gegenchecken.

--- a/frontend/src/i18n/help/de/notizbuch.md
+++ b/frontend/src/i18n/help/de/notizbuch.md
@@ -1,0 +1,35 @@
+# Notizbuch
+
+## Was ist das?
+
+Das **Notizbuch** ist ein einfacher Ort für **Texte und Notizen** — Gedanken,
+Ideen, Anleitungen, To-do-Listen. Notizen unterstützen **Markdown** (Überschriften,
+Listen, Fettdruck) und lassen sich zwischen **Bearbeiten** und **Vorschau**
+umschalten.
+
+## Schritt-für-Schritt
+
+1. **Neue Notiz** klicken.
+2. Titel und Inhalt schreiben (Markdown erlaubt).
+3. **Speichern**.
+4. Mit **Vorschau** siehst du die formatierte Fassung, mit **Bearbeiten** gehst du
+   zurück zum Text.
+5. Nicht mehr benötigte Notizen **löschen**.
+
+## Typische Fragen
+
+- **„Noch keine Notizen"** — Ganz normal am Anfang; leg mit **Neue Notiz** los.
+- **„Meine Formatierung wird nicht angezeigt"** — Im **Vorschau**-Modus schauen;
+  im Bearbeiten-Modus siehst du den rohen Markdown-Text.
+
+## Tipps
+
+- **Markdown nutzen**: `#` für Überschriften, `-` für Listen, `- [ ]` für
+  Checkboxen.
+- **Ein Thema pro Notiz** — leichter wiederzufinden als eine Riesen-Notiz.
+
+## Abgrenzung
+
+- **Notizbuch** — dauerhafte, betitelte Notizen für dich.
+- **Scratchpad** — ein schneller gemeinsamer Zettel zwischen dir und dem Agenten.
+- **Meine Akte** — strukturierte Gesundheitsdaten (kein Freitext-Notizbuch).

--- a/frontend/src/i18n/help/de/scratchpad.md
+++ b/frontend/src/i18n/help/de/scratchpad.md
@@ -1,0 +1,36 @@
+# Scratchpad
+
+## Was ist das?
+
+Das **Scratchpad** ist ein schneller **gemeinsamer Notizzettel** zwischen dir und
+deinem Agenten. Du hältst hier lose Ideen, Notizen und Aufgaben fest — und der
+Agent kann sie lesen, wenn eine Aufgabe darauf Bezug nimmt. Es speichert
+automatisch, während du tippst.
+
+## Die zwei Bereiche
+
+- **Meine Ideen** — dein Bereich. Hier schreibst **nur du**. Der Agent liest ihn,
+  wenn es zur Aufgabe passt.
+- **Agent-Notizen** — hier schreibt **nur der Agent** seine eigenen Notizen. Dein
+  Bereich bleibt ihm zum Schreiben tabu.
+
+## Bedienung
+
+- Einfach in **Meine Ideen** lostippen — es speichert automatisch (du siehst
+  „speichert…" / „gespeichert").
+- **Markdown** wird unterstützt, inklusive Checkboxen: `- [ ]` für offen, `- [x]`
+  für erledigt.
+- **Agent-Notizen** kannst du bei Bedarf **leeren** (mit Bestätigung).
+
+## Wann Scratchpad, wann Notizbuch?
+
+- **Scratchpad** — schnelle, formlose Zettelwirtschaft, **geteilt mit dem Agenten**;
+  ideal für „merk dir das" und laufende Gedanken.
+- **Notizbuch** — dauerhafte, betitelte Notizen, eher als eigenes Archiv.
+
+## Tipps
+
+- **Aufgaben als Checkboxen**: `- [ ] noch offen` — der Agent sieht deine Liste
+  und kann sie berücksichtigen.
+- **Kurz halten**: Das Scratchpad ist der Notizzettel, nicht das Archiv — Größeres
+  gehört ins Notizbuch.

--- a/frontend/src/i18n/help/en/cryptoboard.md
+++ b/frontend/src/i18n/help/en/cryptoboard.md
@@ -1,0 +1,41 @@
+# Cryptoboard
+
+## What is this?
+
+The **Cryptoboard** is a dashboard for **cryptocurrencies**: prices, charts, news,
+and your personal portfolio in one place. You keep an eye on prices, track your
+holdings, and get notified at price levels — without leaving the platform.
+
+> **Note:** This is an information and overview tool, **not a trading platform and
+> not investment advice.**
+
+## The areas
+
+- **Overview** — prices and market situation at a glance.
+- **Portfolio** — your holdings with current value.
+- **Analytics** — your portfolio's performance and metrics.
+- **Trades** — your trade log (what you bought/sold and when).
+- **Wallets** — your wallet addresses/accounts.
+- **Compare** — put several coins side by side.
+- **Alerts** — notifications at certain price levels.
+- **News** — current market headlines.
+
+## Setting up alerts
+
+1. In the **Alerts** area, create a new alert at the top.
+2. Choose a **portfolio**/coin and set a **threshold (€)**.
+3. **Create**. Active alerts appear under "Active alerts"; triggered ones under
+   "Triggered alerts".
+
+## Common questions
+
+- **"My holdings are missing"** — First enter your holdings in **Portfolio** /
+  **Wallets**.
+- **"Prices don't update"** — Reload the page; data comes from external price
+  sources.
+
+## Tips
+
+- **Alerts instead of constant watching**: set a price level and get notified
+  rather than watching the chart.
+- **Maintain trades**: a well-kept trade log makes the analytics meaningful.

--- a/frontend/src/i18n/help/en/deepresearch.md
+++ b/frontend/src/i18n/help/en/deepresearch.md
@@ -1,0 +1,39 @@
+# Deep Research
+
+## What is this?
+
+**Deep Research** performs a **thorough, multi-step web research** for you and
+delivers a **cited report** with sources at the end. Instead of a quick answer it
+plans the search, combs through several sources, and summarizes the result in a
+structured way — ideal for overviews, comparisons, and fact-checks with evidence.
+
+> A research run takes **a few minutes** — that's intentional (depth over speed).
+
+## Step by step
+
+1. Enter your **question/topic** in the input field on the left (the more precise,
+   the better).
+2. **Start research**.
+3. Progress runs live ("Researching …"). You can wait or come back later.
+4. Finished runs appear in the list; a click opens the **report** including
+   **sources**.
+
+## Common questions
+
+- **"No research yet"** — Normal at the start; ask a question on the left.
+- **"Research failed"** — Usually a temporary issue (network/source); just restart.
+  Phrase very broad questions more specifically.
+- **"Takes a while"** — A full run takes minutes; that's normal.
+
+## When Deep Research, when normal search?
+
+- **Deep Research** — for **reports, overviews, comparisons, fact-checks** with
+  sources. Takes time, delivers depth.
+- **Normal web search** (in chat) — for a **single quick fact** or current number.
+
+## Tips
+
+- **Ask a precise question**: "Compare X and Y regarding Z" yields better reports
+  than a single keyword.
+- **Check sources**: the report cites its sources — for important topics, verify
+  briefly.

--- a/frontend/src/i18n/help/en/notizbuch.md
+++ b/frontend/src/i18n/help/en/notizbuch.md
@@ -1,0 +1,32 @@
+# Notebook
+
+## What is this?
+
+The **Notebook** is a simple place for **text and notes** — thoughts, ideas,
+guides, to-do lists. Notes support **Markdown** (headings, lists, bold) and can be
+toggled between **Edit** and **Preview**.
+
+## Step by step
+
+1. Click **New note**.
+2. Write a title and content (Markdown allowed).
+3. **Save**.
+4. **Preview** shows the formatted version, **Edit** takes you back to the text.
+5. **Delete** notes you no longer need.
+
+## Common questions
+
+- **"No notes yet"** — Perfectly normal at the start; begin with **New note**.
+- **"My formatting isn't shown"** — Look in **Preview** mode; in edit mode you see
+  the raw Markdown text.
+
+## Tips
+
+- **Use Markdown**: `#` for headings, `-` for lists, `- [ ]` for checkboxes.
+- **One topic per note** — easier to find than one giant note.
+
+## How it differs
+
+- **Notebook** — permanent, titled notes for you.
+- **Scratchpad** — a quick shared pad between you and the agent.
+- **My Record** — structured health data (not a free-text notebook).

--- a/frontend/src/i18n/help/en/scratchpad.md
+++ b/frontend/src/i18n/help/en/scratchpad.md
@@ -1,0 +1,35 @@
+# Scratchpad
+
+## What is this?
+
+The **Scratchpad** is a quick **shared notepad** between you and your agent. You
+jot down loose ideas, notes, and tasks here — and the agent can read them when a
+task refers to them. It saves automatically as you type.
+
+## The two areas
+
+- **My Ideas** — your area. **Only you** write here. The agent reads it when
+  relevant to a task.
+- **Agent Notes** — **only the agent** writes its own notes here. Your area stays
+  off-limits for it to write.
+
+## How to use
+
+- Just start typing in **My Ideas** — it saves automatically (you see "saving…" /
+  "saved").
+- **Markdown** is supported, including checkboxes: `- [ ]` for open, `- [x]` for
+  done.
+- You can **clear** the **Agent Notes** if needed (with confirmation).
+
+## When Scratchpad, when Notebook?
+
+- **Scratchpad** — quick, informal jotting, **shared with the agent**; ideal for
+  "remember this" and running thoughts.
+- **Notebook** — permanent, titled notes, more like your own archive.
+
+## Tips
+
+- **Tasks as checkboxes**: `- [ ] still open` — the agent sees your list and can
+  take it into account.
+- **Keep it short**: the scratchpad is the notepad, not the archive — bigger stuff
+  belongs in the Notebook.

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -42,7 +42,11 @@
       "vms": "Virtuelle Maschinen",
       "containers": "Container",
       "users": "Benutzer",
-      "patientenakte": "Meine Akte"
+      "patientenakte": "Meine Akte",
+      "cryptoboard": "Cryptoboard",
+      "notizbuch": "Notizbuch",
+      "scratchpad": "Scratchpad",
+      "deepresearch": "Deep Research"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -42,7 +42,11 @@
       "vms": "Virtual Machines",
       "containers": "Containers",
       "users": "Users",
-      "patientenakte": "My Record"
+      "patientenakte": "My Record",
+      "cryptoboard": "Cryptoboard",
+      "notizbuch": "Notebook",
+      "scratchpad": "Scratchpad",
+      "deepresearch": "Deep Research"
     }
   }
 }


### PR DESCRIPTION
Vier neue Modul-Hilfe-Artikel (de+en), aus echter Modul-i18n verifiziert:
- **cryptoboard** — Kurse/Portfolio/Alarme/News (Hinweis: keine Anlageberatung)
- **notizbuch** — Markdown-Notizen, Edit/Vorschau, Abgrenzung zu Scratchpad/Akte
- **scratchpad** — gemeinsamer Zettel (Meine Ideen vs. Agent-Notizen), Auto-Save
- **deepresearch** — mehrstufige Web-Recherche mit Quellen, wann vs. normale Suche

HelpButtons liegen im modules-Repo (bereits auf main). tsc grün (via Modul-Spiegel).