### PR TITLE
docs(help): Modul-Hilfe — HomeAssistant, Archiver, Blueprint, Spiele, Musik, Tasks, Video-Editor

### DIFF
--- a/frontend/src/i18n/help/de/archiver.md
+++ b/frontend/src/i18n/help/de/archiver.md
@@ -1,0 +1,37 @@
+# Archiver
+
+## Was ist das?
+
+Der **Archiver** ist ein Werkzeug, um **Daten dauerhaft zu sichern und auf
+Laufwerke zu archivieren**. Du verwaltest angeschlossene Laufwerke, startest
+Archivierungs-Jobs, exportierst Daten und kannst Laufwerke prüfen und reparieren.
+
+## Die Bereiche
+
+- **Archivieren** — einen Archivierungs-Job starten (Daten auf ein Ziel sichern).
+- **Laufwerke** — angeschlossene Datenträger sehen und verwalten:
+  **Aktualisieren**, **Remounten** (aushängen + neu einhängen), **Sauber
+  aushängen** (bevor du ein Laufwerk physisch entfernst).
+- **Exportieren** — Daten aus dem Archiv herausholen.
+- **Reparatur** — ein beschädigtes Dateisystem prüfen/reparieren.
+- **Diagnose** — den Zustand von Laufwerken und Jobs analysieren.
+- **Jobs** — laufende und abgeschlossene Archivierungs-Vorgänge mit Status.
+
+## Wichtig
+
+- **Sauber aushängen, bevor du ein Laufwerk abziehst** — sonst drohen Datenverlust
+  oder Dateisystem-Fehler.
+- Reparatur-/Diagnose-Funktionen greifen tief ins Dateisystem — nutze sie mit
+  Bedacht und idealerweise mit einer Sicherung im Rücken.
+
+## Typische Fragen
+
+- **„Mein Laufwerk erscheint nicht"** — In **Laufwerke** auf **Aktualisieren**
+  klicken; ist es korrekt angeschlossen und eingehängt?
+- **„Job hängt/fehlgeschlagen"** — Der Job-Status und die Diagnose geben Hinweise;
+  oft liegt es an Platz oder Zugriffsrechten am Ziel.
+
+## Tipps
+
+- **Vor Reparatur diagnostizieren** — erst schauen, was kaputt ist, dann reparieren.
+- **Genug Zielspeicher** sicherstellen, bevor ein großer Archiv-Job startet.

--- a/frontend/src/i18n/help/de/blueprint.md
+++ b/frontend/src/i18n/help/de/blueprint.md
@@ -1,0 +1,38 @@
+# Blueprint
+
+## Was ist das?
+
+**Blueprint** ist ein visueller **Node-Canvas**, um **Layouts und Abläufe zu
+skizzieren** — statt sie mühsam in Worten zu beschreiben. Du ziehst Bausteine auf
+eine Fläche, beschriftest und verbindest sie. So kannst du einem Agenten (oder
+Kollegen) präzise zeigen, wie eine Seite aussehen oder ein Ablauf funktionieren
+soll — ein **nonverbaler Kanal** für Design- und Funktionswünsche.
+
+## Wozu ist das gut?
+
+Oft reden Mensch und Agent bei GUI-/Funktionswünschen aneinander vorbei: Man
+beschreibt verbal, der andere rät. Mit Blueprint übergibst du **Layout-Bausteine**
+(Seiten-Design) und **Flow-Bausteine** (Ablauf) direkt — anschaulich statt
+missverständlich.
+
+## Kernbegriffe
+
+- **Board** — deine Zeichenfläche (du kannst mehrere haben).
+- **Node/Baustein** — ein Element auf dem Board (aus der Palette gezogen).
+- **Verbindung** — verknüpft Bausteine zu einem Ablauf.
+- **Eigenschaften** — pro Baustein rechts einstellbar (Beschriftung, Details).
+
+## Schritt-für-Schritt
+
+1. Ein **Board** anlegen oder öffnen.
+2. Aus der **Palette** links Bausteine auf die Fläche ziehen.
+3. Bausteine **beschriften** und über Linien **verbinden**.
+4. Über das **Eigenschaften-Panel** rechts Details setzen.
+5. Das Board dient dann als klare Vorlage — z.B. für einen Agenten-Auftrag.
+
+## Tipps
+
+- **Grob vor fein**: Erst die groben Blöcke und ihre Verbindungen, dann Details.
+- **Beschriften nicht vergessen** — ein unbeschrifteter Kasten ist so mehrdeutig
+  wie eine vage Beschreibung.
+- **Mehrere Boards** für verschiedene Ideen/Seiten statt eines überladenen.

--- a/frontend/src/i18n/help/de/boardgames.md
+++ b/frontend/src/i18n/help/de/boardgames.md
@@ -1,0 +1,34 @@
+# Brettspiele
+
+## Was ist das?
+
+Klassische **Brettspiele** (z.B. Schach) direkt in HydraHive — zum Entspannen
+oder um die Spielstärke der KI auszuprobieren. Du spielst zu zweit an einem Gerät,
+gegen den Computer oder gegen ein **KI-Modell**.
+
+## Spielmodi
+
+- **2 Spieler (ein Gerät)** — Hotseat: ihr wechselt euch am selben Bildschirm ab.
+- **Gegen Computer** — gegen die eingebaute Spiel-Logik.
+- **Gegen ein KI-Modell** — ein echtes Sprachmodell zieht gegen dich. Du wählst
+  vorher das Modell aus.
+
+## Schritt-für-Schritt
+
+1. Ein Spiel wählen (z.B. **Schach**).
+2. **Spielmodus** wählen (Hotseat / Computer / KI-Modell).
+3. Bei „Gegen ein KI-Modell": ein **Modell auswählen**.
+4. **Partie starten** und ziehen.
+
+## Gut zu wissen
+
+- Beim KI-Modus kann es einen **Notzug** geben, falls das Modell keinen gültigen
+  Zug liefert — dann springt eine einfache Spiel-Logik ein, damit die Partie
+  weiterläuft.
+- Spielstärke und -stil hängen beim KI-Modus stark vom gewählten Modell ab.
+
+## Tipps
+
+- **Zum Testen der KI**: Spiel eine Partie „Gegen ein KI-Modell" — ein
+  anschaulicher Weg zu sehen, wie gut ein Modell plant.
+- **Locker bleiben**: Das ist die Spaß-Ecke, kein Turnier.

--- a/frontend/src/i18n/help/de/homeassistant.md
+++ b/frontend/src/i18n/help/de/homeassistant.md
@@ -1,0 +1,37 @@
+# Home Assistant
+
+## Was ist das?
+
+Dieses Modul bindet dein **Home Assistant Smart Home** an HydraHive an: Du siehst
+deine **Geräte** (Lampen, Schalter, Sensoren, Thermostate …) und kannst sie
+**direkt schalten** — ohne die Home-Assistant-App zu öffnen. Auch dein Agent kann
+darüber Geräte steuern.
+
+## Was kann ich hier tun?
+
+- **Geräte sehen**: alle Entities mit ihrem aktuellen Zustand.
+- **Schalten**: Lampen an/aus, Schalter umlegen, Szenen auslösen usw.
+- **Suchen**: über das Suchfeld nach Name oder `entity_id` filtern.
+- **Favoriten**: häufig genutzte Geräte markieren und per **Nur Favoriten**
+  einblenden.
+- **Aktualisieren**: den aktuellen Zustand neu laden.
+
+## Voraussetzung
+
+Es muss eine **Verbindung zu deinem Home-Assistant-Server** eingerichtet sein
+(Adresse + Zugangs-Token). Ohne diese Anbindung erscheinen keine Geräte. Die
+Verbindung wird in den System-/Verbindungseinstellungen hinterlegt.
+
+## Typische Fragen
+
+- **„Keine passenden Geräte gefunden"** — Entweder ist die Anbindung nicht
+  eingerichtet, oder der Suchbegriff passt auf kein Gerät. Suchfeld leeren und
+  **Aktualisieren**.
+- **„Schalten reagiert nicht"** — Prüfe, ob Home Assistant erreichbar ist und die
+  Entity wirklich schaltbar ist (Sensoren zeigen nur an, sie schalten nicht).
+
+## Tipps
+
+- **Favoriten setzen** für die Geräte, die du täglich brauchst — spart das Suchen.
+- **entity_id merken**: Über die genaue `entity_id` findest du ein Gerät am
+  schnellsten (auch wenn der Anzeigename mehrdeutig ist).

--- a/frontend/src/i18n/help/de/minigames.md
+++ b/frontend/src/i18n/help/de/minigames.md
@@ -1,0 +1,24 @@
+# Minigames
+
+## Was ist das?
+
+Eine Sammlung kleiner **Retro-Spiele** für zwischendurch — z.B. **Snake**,
+**Space Invaders** und **Frogger**. Highscores landen in einer **Bestenliste**.
+
+## Bedienung
+
+- Ein Spiel anklicken → los geht's.
+- **Steuerung:** Pfeiltasten oder **WASD**.
+- **Neustart:** Leertaste.
+- **Schließen:** ESC.
+
+## Bestenliste
+
+Deine Punkte werden gespeichert und in der **Bestenliste** angezeigt. Schlägst du
+deinen bisherigen Wert, erscheint „Persönlicher Rekord!".
+
+## Tipps
+
+- **Kurze Pause gefällig?** Genau dafür sind die Minigames da.
+- **Highscore jagen**: Deine Scores stehen in der Bestenliste — versuch, ganz nach
+  oben zu kommen.

--- a/frontend/src/i18n/help/de/musicplayer.md
+++ b/frontend/src/i18n/help/de/musicplayer.md
@@ -1,0 +1,33 @@
+# Musik
+
+## Was ist das?
+
+Ein **Musik-Player** für deine Audio-Dateien und die im **Atelier generierte
+Musik**. Du legst Tracks in eine Playlist, spielst sie ab und steuerst
+Wiedergabe, Zufall und Wiederholung — inklusive Equalizer.
+
+## Was kann ich hier tun?
+
+- **Abspielen / Pause**, **Vorheriger / Nächster** Titel.
+- **Zufallswiedergabe** (Shuffle) und **Wiederholen** — inkl. „Titel wiederholen"
+  (einen Song in Schleife).
+- **MP3 hochladen** — eigene Dateien hinzufügen.
+- **Generierte Musik** — die im Atelier erzeugten Stücke direkt hören.
+
+## Schritt-für-Schritt
+
+1. **MP3 hochladen** oder unter **Generierte Musik** ein Stück wählen.
+2. Track anklicken → **Abspielen**.
+3. Über die Bedienleiste Zufall/Wiederholung nach Wunsch einstellen.
+
+## Typische Fragen
+
+- **„Noch keine Tracks"** — Erst etwas **hochladen** oder im Atelier Musik
+  generieren.
+- **„Upload fehlgeschlagen"** — Prüfe Dateiformat/-größe; unterstützt werden
+  Audio-Dateien (z.B. MP3).
+
+## Tipps
+
+- **Atelier + Player kombinieren**: Erst im Atelier ein Stück generieren, dann hier
+  in Ruhe anhören.

--- a/frontend/src/i18n/help/de/tasks.md
+++ b/frontend/src/i18n/help/de/tasks.md
@@ -1,0 +1,38 @@
+# Aufgaben (Tasks)
+
+## Was ist das?
+
+Eine **Aufgabenverwaltung**, die über alle Chat-Sitzungen hinweg erhalten bleibt.
+Anders als eine Notiz im Chat (die mit der Sitzung endet) sind Tasks **dauerhaft**
+— sie sind der zuverlässige Ort für „das muss noch gemacht werden".
+
+Das Besondere: **Auch dein Agent** kann Aufgaben selbst anlegen, aktualisieren und
+abhaken — z.B. wenn du im Gespräch sagst „das machen wir später".
+
+## Was kann ich hier tun?
+
+- **Aufgaben anlegen** mit Titel, optionaler Beschreibung und Priorität.
+- **Status setzen**: offen → in Arbeit → erledigt (oder abgebrochen).
+- **Aufgaben einem Projekt zuordnen**.
+- Nach Status **filtern**, um den Überblick zu behalten.
+
+## Schritt-für-Schritt
+
+1. Eine neue Aufgabe mit **Titel** anlegen.
+2. Optional **Beschreibung** und **Priorität** (niedrig/mittel/hoch) setzen.
+3. Während der Arbeit den **Status** aktualisieren.
+4. Erledigtes auf **fertig** setzen — es bleibt als Verlauf erhalten.
+
+## Warum Tasks statt Chat-Notiz?
+
+- **Chat-Notiz** — lebt nur in der aktuellen Sitzung.
+- **Task** — bleibt über alle Sitzungen; der Agent kann ihn wiederfinden und
+  fortführen. Ideal für mehrstufige oder länger laufende Vorhaben.
+
+## Tipps
+
+- **Klare Titel**: „Login-Bug fixen" ist besser wiederauffindbar als „Bug".
+- **Prioritäten setzen**, wenn viel offen ist — dann siehst du sofort, was zuerst
+  dran ist.
+- **Projekte nutzen**: Tasks einem Projekt zuordnen hält verschiedene Vorhaben
+  getrennt.

--- a/frontend/src/i18n/help/de/videoeditor.md
+++ b/frontend/src/i18n/help/de/videoeditor.md
@@ -1,0 +1,41 @@
+# Video-Editor
+
+## Was ist das?
+
+Ein **Video-Schnittstudio** direkt im Browser, projekt-gebunden. Du lädst Videos
+hoch (oder nimmst welche aus dem Projekt), ordnest sie auf einer **Timeline** an,
+schneidest, legst Audiospuren darunter und **exportierst** das fertige Video.
+
+## Was kann ich hier tun?
+
+- **Video hochladen** oder **aus Projekt hinzufügen** (Videos aus dem
+  Projekt-Workspace).
+- Clips auf der **Timeline** anordnen, trimmen und schneiden.
+- **Audiospuren** hinzufügen und mischen.
+- Das Ergebnis **exportieren**.
+
+## Voraussetzung
+
+Der Editor ist **projekt-gebunden** — du brauchst zuerst ein **Projekt**.
+Erscheint „Keine Projekte vorhanden", lege zuerst unter *Projekte* eins an.
+
+## Schritt-für-Schritt
+
+1. Projekt wählen (oder anlegen).
+2. **Video hochladen** oder **Aus Projekt hinzufügen**.
+3. Clips auf die Timeline ziehen, in Reihenfolge bringen und schneiden.
+4. Optional Audio hinzufügen.
+5. **Exportieren** → fertiges Video.
+
+## Typische Fragen
+
+- **„Noch keine Videos"** — Erst eins **hochladen** oder aus dem Projekt hinzufügen.
+- **„Keine Videos im Projekt gefunden"** — Im Projekt-Workspace liegen (noch) keine
+  Videodateien; z.B. im Atelier welche erzeugen oder hochladen.
+- **„bereits hinzugefügt"** — Der Clip ist schon auf der Timeline.
+
+## Tipps
+
+- **Erst grob, dann fein**: Clips in Reihenfolge bringen, dann die Feinschnitte.
+- **Zusammenspiel mit dem Atelier**: Dort erzeugte Clips lassen sich hier zu einem
+  Film zusammensetzen.

--- a/frontend/src/i18n/help/en/archiver.md
+++ b/frontend/src/i18n/help/en/archiver.md
@@ -1,0 +1,36 @@
+# Archiver
+
+## What is this?
+
+The **Archiver** is a tool to **permanently back up data and archive it to
+drives**. You manage connected drives, start archiving jobs, export data, and can
+check and repair drives.
+
+## The areas
+
+- **Archive** — start an archiving job (back up data to a target).
+- **Drives** — see and manage connected media: **Refresh**, **Remount** (unmount +
+  mount again), **Safe unmount** (before you physically remove a drive).
+- **Export** — get data back out of the archive.
+- **Repair** — check/repair a damaged file system.
+- **Diagnostics** — analyze the state of drives and jobs.
+- **Jobs** — running and finished archiving operations with status.
+
+## Important
+
+- **Safely unmount before removing a drive** — otherwise you risk data loss or
+  file-system errors.
+- Repair/diagnostic functions reach deep into the file system — use them carefully
+  and ideally with a backup in place.
+
+## Common questions
+
+- **"My drive doesn't appear"** — Click **Refresh** in **Drives**; is it properly
+  connected and mounted?
+- **"Job stuck/failed"** — The job status and diagnostics give hints; often it's
+  space or permissions at the target.
+
+## Tips
+
+- **Diagnose before repairing** — first see what's broken, then repair.
+- **Ensure enough target space** before starting a large archive job.

--- a/frontend/src/i18n/help/en/blueprint.md
+++ b/frontend/src/i18n/help/en/blueprint.md
@@ -1,0 +1,38 @@
+# Blueprint
+
+## What is this?
+
+**Blueprint** is a visual **node canvas** to **sketch layouts and flows** — instead
+of laboriously describing them in words. You drag building blocks onto a canvas,
+label them, and connect them. This lets you show an agent (or a colleague)
+precisely how a page should look or a flow should work — a **non-verbal channel**
+for design and functionality requests.
+
+## What is it good for?
+
+People and agents often talk past each other on UI/functionality requests: you
+describe verbally, the other guesses. With Blueprint you hand over **layout blocks**
+(page design) and **flow blocks** (process) directly — visual instead of ambiguous.
+
+## Core terms
+
+- **Board** — your canvas (you can have several).
+- **Node/block** — an element on the board (dragged from the palette).
+- **Connection** — links blocks into a flow.
+- **Properties** — configurable per block on the right (label, details).
+
+## Step by step
+
+1. Create or open a **board**.
+2. Drag blocks from the **palette** on the left onto the canvas.
+3. **Label** blocks and **connect** them with lines.
+4. Set details via the **properties panel** on the right.
+5. The board then serves as a clear template — e.g. for an agent task.
+
+## Tips
+
+- **Coarse before fine**: first the rough blocks and their connections, then
+  details.
+- **Don't forget labels** — an unlabeled box is as ambiguous as a vague
+  description.
+- **Several boards** for different ideas/pages rather than one overloaded one.

--- a/frontend/src/i18n/help/en/boardgames.md
+++ b/frontend/src/i18n/help/en/boardgames.md
@@ -1,0 +1,33 @@
+# Board games
+
+## What is this?
+
+Classic **board games** (e.g. chess) right in HydraHive — to relax or to try out
+the AI's playing strength. You play two-player on one device, against the computer,
+or against an **AI model**.
+
+## Game modes
+
+- **2 players (one device)** — hotseat: take turns at the same screen.
+- **Against computer** — against the built-in game logic.
+- **Against an AI model** — a real language model plays against you. You pick the
+  model beforehand.
+
+## Step by step
+
+1. Choose a game (e.g. **Chess**).
+2. Choose a **game mode** (hotseat / computer / AI model).
+3. For "against an AI model": **pick a model**.
+4. **Start the game** and make your moves.
+
+## Good to know
+
+- In AI mode there may be a **fallback move** if the model doesn't return a valid
+  move — then a simple game logic steps in so the game continues.
+- In AI mode, strength and style depend heavily on the chosen model.
+
+## Tips
+
+- **To test the AI**: play a game "against an AI model" — a vivid way to see how
+  well a model plans.
+- **Stay relaxed**: this is the fun corner, not a tournament.

--- a/frontend/src/i18n/help/en/homeassistant.md
+++ b/frontend/src/i18n/help/en/homeassistant.md
@@ -1,0 +1,35 @@
+# Home Assistant
+
+## What is this?
+
+This module connects your **Home Assistant smart home** to HydraHive: you see your
+**devices** (lights, switches, sensors, thermostats …) and can **switch them
+directly** — without opening the Home Assistant app. Your agent can control
+devices through it too.
+
+## What can I do here?
+
+- **See devices**: all entities with their current state.
+- **Switch**: lights on/off, toggle switches, trigger scenes, etc.
+- **Search**: filter by name or `entity_id` via the search field.
+- **Favorites**: mark frequently used devices and show them via **Favorites only**.
+- **Refresh**: reload the current state.
+
+## Prerequisite
+
+A **connection to your Home Assistant server** must be set up (address + access
+token). Without it, no devices appear. The connection is configured in the
+system/connection settings.
+
+## Common questions
+
+- **"No matching devices found"** — Either the connection isn't set up, or the
+  search term matches no device. Clear the search field and **Refresh**.
+- **"Switching doesn't react"** — Check that Home Assistant is reachable and the
+  entity is actually switchable (sensors only display, they don't switch).
+
+## Tips
+
+- **Set favorites** for the devices you use daily — saves searching.
+- **Remember the entity_id**: the exact `entity_id` finds a device fastest (even
+  when the display name is ambiguous).

--- a/frontend/src/i18n/help/en/minigames.md
+++ b/frontend/src/i18n/help/en/minigames.md
@@ -1,0 +1,24 @@
+# Minigames
+
+## What is this?
+
+A collection of small **retro games** for a quick break — e.g. **Snake**, **Space
+Invaders**, and **Frogger**. High scores go on a **leaderboard**.
+
+## How to play
+
+- Click a game → off you go.
+- **Controls:** arrow keys or **WASD**.
+- **Restart:** spacebar.
+- **Close:** ESC.
+
+## Leaderboard
+
+Your points are saved and shown on the **leaderboard**. Beat your previous value
+and "Personal best!" appears.
+
+## Tips
+
+- **Need a short break?** That's exactly what the minigames are for.
+- **Chase the high score**: your scores are on the leaderboard — try to reach the
+  top.

--- a/frontend/src/i18n/help/en/musicplayer.md
+++ b/frontend/src/i18n/help/en/musicplayer.md
@@ -1,0 +1,31 @@
+# Music
+
+## What is this?
+
+A **music player** for your audio files and the music **generated in the Atelier**.
+You put tracks into a playlist, play them, and control playback, shuffle, and
+repeat — including an equalizer.
+
+## What can I do here?
+
+- **Play / Pause**, **Previous / Next** track.
+- **Shuffle** and **Repeat** — including "repeat one" (loop a single song).
+- **Upload MP3** — add your own files.
+- **Generated music** — listen to pieces created in the Atelier directly.
+
+## Step by step
+
+1. **Upload an MP3** or pick a piece under **Generated music**.
+2. Click a track → **Play**.
+3. Set shuffle/repeat as you like via the control bar.
+
+## Common questions
+
+- **"No tracks yet"** — First **upload** something or generate music in the Atelier.
+- **"Upload failed"** — Check file format/size; audio files (e.g. MP3) are
+  supported.
+
+## Tips
+
+- **Combine Atelier + player**: generate a piece in the Atelier, then listen to it
+  here at leisure.

--- a/frontend/src/i18n/help/en/tasks.md
+++ b/frontend/src/i18n/help/en/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## What is this?
+
+A **task management** that persists across all chat sessions. Unlike a note in chat
+(which ends with the session), tasks are **permanent** — the reliable place for
+"this still needs doing".
+
+The special part: **your agent** can create, update, and check off tasks itself —
+e.g. when you say "we'll do that later" in conversation.
+
+## What can I do here?
+
+- **Create tasks** with title, optional description, and priority.
+- **Set status**: open → in progress → done (or cancelled).
+- **Assign tasks to a project**.
+- **Filter** by status to keep an overview.
+
+## Step by step
+
+1. Create a new task with a **title**.
+2. Optionally set a **description** and **priority** (low/medium/high).
+3. Update the **status** as you work.
+4. Set completed items to **done** — they remain as history.
+
+## Why tasks instead of a chat note?
+
+- **Chat note** — lives only in the current session.
+- **Task** — persists across sessions; the agent can find and continue it. Ideal
+  for multi-step or longer-running efforts.
+
+## Tips
+
+- **Clear titles**: "fix login bug" is more findable than "bug".
+- **Set priorities** when there's a lot open — then you see what's first at a
+  glance.
+- **Use projects**: assigning tasks to a project keeps different efforts separate.

--- a/frontend/src/i18n/help/en/videoeditor.md
+++ b/frontend/src/i18n/help/en/videoeditor.md
@@ -1,0 +1,39 @@
+# Video editor
+
+## What is this?
+
+A **video editing studio** right in the browser, project-bound. You upload videos
+(or take some from the project), arrange them on a **timeline**, cut, add audio
+tracks, and **export** the finished video.
+
+## What can I do here?
+
+- **Upload a video** or **add from project** (videos from the project workspace).
+- Arrange, trim, and cut clips on the **timeline**.
+- Add and mix **audio tracks**.
+- **Export** the result.
+
+## Prerequisite
+
+The editor is **project-bound** — you need a **project** first. If "No projects
+available" appears, create one under *Projects* first.
+
+## Step by step
+
+1. Choose a project (or create one).
+2. **Upload a video** or **add from project**.
+3. Drag clips onto the timeline, order them, and cut.
+4. Optionally add audio.
+5. **Export** → finished video.
+
+## Common questions
+
+- **"No videos yet"** — First **upload** one or add from the project.
+- **"No videos found in the project"** — There are (yet) no video files in the
+  project workspace; e.g. create some in the Atelier or upload them.
+- **"already added"** — The clip is already on the timeline.
+
+## Tips
+
+- **Coarse first, then fine**: order the clips, then do the fine cuts.
+- **Works with the Atelier**: clips created there can be assembled into a film here.

--- a/frontend/src/i18n/help/loader.ts
+++ b/frontend/src/i18n/help/loader.ts
@@ -17,7 +17,8 @@ export type HelpTopic =
   | "onboarding"
   // Module
   | "atelier" | "patientenakte" | "cryptoboard" | "notizbuch" | "scratchpad"
-  | "deepresearch" | "homeassistant" | "archiver"
+  | "deepresearch" | "homeassistant" | "archiver" | "blueprint" | "boardgames"
+  | "minigames" | "musicplayer" | "tasks" | "videoeditor"
 
 export async function loadHelp(topic: HelpTopic, lang: string): Promise<string> {
   const code = lang.split("-")[0]

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -46,7 +46,15 @@
       "cryptoboard": "Cryptoboard",
       "notizbuch": "Notizbuch",
       "scratchpad": "Scratchpad",
-      "deepresearch": "Deep Research"
+      "deepresearch": "Deep Research",
+      "homeassistant": "Home Assistant",
+      "archiver": "Archiver",
+      "blueprint": "Blueprint",
+      "boardgames": "Brettspiele",
+      "minigames": "Minigames",
+      "musicplayer": "Musik",
+      "tasks": "Aufgaben",
+      "videoeditor": "Video-Editor"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -46,7 +46,15 @@
       "cryptoboard": "Cryptoboard",
       "notizbuch": "Notebook",
       "scratchpad": "Scratchpad",
-      "deepresearch": "Deep Research"
+      "deepresearch": "Deep Research",
+      "homeassistant": "Home Assistant",
+      "archiver": "Archiver",
+      "blueprint": "Blueprint",
+      "boardgames": "Board games",
+      "minigames": "Minigames",
+      "musicplayer": "Music",
+      "tasks": "Tasks",
+      "videoeditor": "Video editor"
     }
   }
 }


### PR DESCRIPTION
Acht neue Modul-Hilfe-Artikel (de+en), aus echter Modul-i18n verifiziert:
- **homeassistant** — Geräte sehen/schalten, Favoriten, Suche
- **archiver** — Laufwerke/Archivieren/Export/Reparatur/Diagnose
- **blueprint** — visueller Node-Canvas für Layouts/Abläufe
- **boardgames** — Schach etc.: Hotseat / Computer / KI-Modell
- **minigames** — Snake/Invaders/Frogger, Bestenliste
- **musicplayer** — Player für Uploads + Atelier-Musik
- **tasks** — persistente Aufgaben, Agent kann selbst pflegen
- **videoeditor** — Timeline-Schnitt, projekt-gebunden

`loader.ts`: HelpTopic-Union um die 6 fehlenden Topics erweitert (sonst TS2322). HelpButtons im modules-Repo (main). `tsc -b` grün (via Modul-Spiegel).

Damit ist die Modul-Doku vollständig.