### PR TITLE
docs(help): Admin-Hilfe — Zahnfee, Plugins, Federation, Streaming, Extensions

### DIFF
--- a/frontend/src/features/extensions/ExtensionsPage.tsx
+++ b/frontend/src/features/extensions/ExtensionsPage.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 import { Package, RefreshCw, Container, Terminal } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { fetchExtensions, authHeaders } from "./api"
 import { ExtensionCard } from "./ExtensionCard"
 import { InstallModal } from "./InstallModal"
@@ -89,6 +90,7 @@ export function ExtensionsPage() {
         <div className="flex items-center gap-3">
           <Package className="text-violet-400" size={20} />
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
+          <HelpButton topic="extensions" />
           <span className="text-xs text-zinc-500">
             {t("installed_count", { installed: extensions.filter((e) => e.installed).length, total: extensions.length })}
           </span>

--- a/frontend/src/features/federation/FederationPage.tsx
+++ b/frontend/src/features/federation/FederationPage.tsx
@@ -5,6 +5,7 @@ import { Globe, Plus } from "lucide-react"
 import { federationApi } from "./api"
 import type { Workstation } from "./types"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { WorkstationCard } from "./_WorkstationCard"
 import { AddWorkstationDialog } from "./_AddDialog"
 import { ClientConnectionsSection } from "./_ClientConnectionsSection"
@@ -47,6 +48,7 @@ export function FederationPage() {
             <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
             <p className="text-xs text-zinc-500 mt-0.5">{t("subtitle")}</p>
           </div>
+          <HelpButton topic="federation" />
         </div>
         <button
           onClick={() => setShowAdd(true)}

--- a/frontend/src/features/plugins/PluginsPage.tsx
+++ b/frontend/src/features/plugins/PluginsPage.tsx
@@ -5,6 +5,7 @@ import { HubCard, InstalledCard } from "./PluginCard"
 import { usePlugins } from "./usePlugins"
 import { RestartModal } from "@/shared/RestartModal"
 import { useRestart } from "@/shared/useRestart"
+import { HelpButton } from "@/i18n/HelpButton"
 
 type Tab = "hub" | "installed"
 
@@ -22,6 +23,7 @@ export function PluginsPage() {
         <div className="flex items-center gap-3">
           <Puzzle className="text-violet-400" size={20} />
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
+          <HelpButton topic="plugins" />
         </div>
         <button onClick={restart.open}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/[5%] border border-white/[8%] text-zinc-300 text-xs font-medium hover:bg-white/[8%] transition-colors">

--- a/frontend/src/features/streaming/StreamingPage.tsx
+++ b/frontend/src/features/streaming/StreamingPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Film, Search } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
 import { streamingApi } from "./api"
 import type { ScrapeResult, StreamingCredentials, StreamingJob } from "./types"
 import { CredentialsForm } from "./_CredentialsForm"
@@ -96,6 +97,7 @@ export function StreamingPage() {
           <h1 className="text-xl font-semibold text-zinc-100">{t("title")}</h1>
           <p className="text-xs text-zinc-500 mt-0.5">{t("subtitle")}</p>
         </div>
+        <HelpButton topic="streaming" />
       </div>
 
       <CredentialsForm creds={creds} onSaved={loadCreds} />

--- a/frontend/src/features/zahnfee/ZahnfeePage.tsx
+++ b/frontend/src/features/zahnfee/ZahnfeePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 import { Loader2, Play, Settings as SettingsIcon } from "lucide-react"
 import { rgbFor } from "@/shared/colors"
+import { HelpButton } from "@/i18n/HelpButton"
 import { zahnfeeApi, type Briefing } from "./api"
 
 function Section({ title, content, accent }: { title: string; content: string; accent: string }) {
@@ -71,6 +72,7 @@ export function ZahnfeePage() {
           <h1 className="text-xl font-bold text-zinc-100">Zahnfee</h1>
           <p className="text-sm text-zinc-500">{t("subtitle")}</p>
         </div>
+        <HelpButton topic="zahnfee" />
         <Link
           to="/settings"
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-xs transition-colors"

--- a/frontend/src/i18n/help/de/extensions.md
+++ b/frontend/src/i18n/help/de/extensions.md
@@ -1,0 +1,45 @@
+# Extensions
+
+## Was ist das?
+
+**Extensions** sind **externe Zusatzdienste**, die HydraHive um größere Fähigkeiten
+erweitern — z.B. ein Matrix-Server für den Teamchat oder andere Integrationen. Sie
+laufen als eigener Dienst, entweder **nativ** auf dem Server oder in **Docker**.
+
+## Was kann ich hier tun?
+
+- Verfügbare Extensions nach **Kategorie** durchsehen (installiert / nicht
+  installiert).
+- Eine Extension **installieren**, **deinstallieren** oder (falls sie eine
+  Oberfläche hat) **öffnen**.
+- Den **Status** sehen: Nicht installiert / Aktiv / läuft-aber-nicht-erreichbar.
+
+## Nativ vs. Docker
+
+- **Nativ** — der Dienst läuft direkt auf dem Server.
+- **Docker** — der Dienst läuft in einem Container. Dafür muss **Docker verfügbar**
+  sein (die Seite zeigt an, ob Docker installiert ist).
+
+## Schritt-für-Schritt
+
+1. Eine Extension auswählen.
+2. **Installieren** (bei Docker-Extensions muss Docker vorhanden sein).
+3. Nach der Installation zeigt der Status **Aktiv**; hat die Extension eine
+   Oberfläche, kannst du sie **Öffnen**.
+
+## Typische Fragen
+
+- **„Docker ist nicht installiert"** — Für Docker-basierte Extensions muss zuerst
+  Docker auf dem Server eingerichtet werden.
+- **„läuft, aber nicht erreichbar"** — Der Dienst startet, ist aber (noch) nicht
+  ansprechbar; kurz warten oder das Extension-Log prüfen.
+
+## Abgrenzung
+
+- **Extension** — externer **Dienst/Integration** (nativ oder Docker).
+- **Plugin** — Agenten-**Werkzeuge** im Hintergrund.
+- **Modul** — eine **Seite/Feature** in HydraHive.
+
+## Tipps
+
+- **Nur bei Bedarf installieren** — jeder laufende Dienst braucht Ressourcen.

--- a/frontend/src/i18n/help/de/federation.md
+++ b/frontend/src/i18n/help/de/federation.md
@@ -1,0 +1,38 @@
+# Federation
+
+## Was ist das?
+
+**Federation** verbindet deine HydraHive-Instanz mit **anderen Agent-Systemen
+(Workstations)** über das **A2A-Protokoll** (Agent-to-Agent). So kann dein Agent
+Aufgaben an entfernte, ferngesteuerte Agent-Systeme übergeben — z.B. an einen
+Spezialisten auf einer anderen Maschine.
+
+## Kernbegriffe
+
+- **Workstation** — ein anderes, A2A-kompatibles Agent-System, das du hier
+  registrierst.
+- **Token** — das **Zugangsgeheimnis** der Ziel-Workstation. Ohne gültigen Token
+  keine Verbindung.
+- **TLS** — ob die Verbindung verschlüsselt läuft.
+
+## Schritt-für-Schritt
+
+1. **Hinzufügen** → **Workstation hinzufügen**.
+2. Adresse und den **Token** der Ziel-Workstation eintragen (der Token stammt von
+   der Gegenstelle).
+3. Speichern — registrierte Workstations erscheinen in der Liste mit Status
+   („Token konfiguriert" / „Kein Token", TLS an/aus).
+
+## Typische Fragen
+
+- **„Noch keine Workstations registriert"** — Normal am Anfang; mit **Erste
+  Workstation hinzufügen** starten.
+- **„Kein Token"** — Die Workstation hat kein gültiges Zugangsgeheimnis; ohne das
+  klappt die Verbindung nicht.
+
+## Tipps
+
+- **Token sicher behandeln**: Er ist das Zugangsgeheimnis zur Gegenstelle — wie ein
+  Passwort.
+- **TLS bevorzugen**, wenn die Verbindung über ein Netzwerk läuft, das nicht
+  vollständig vertrauenswürdig ist.

--- a/frontend/src/i18n/help/de/plugins.md
+++ b/frontend/src/i18n/help/de/plugins.md
@@ -1,0 +1,37 @@
+# Plugins
+
+## Was ist das?
+
+**Plugins** erweitern HydraHive um zusätzliche **Werkzeuge/Funktionen** für die
+Agenten. Anders als Module (die eigene Seiten mitbringen) fügen Plugins meist
+Funktionen im Hintergrund hinzu. Du installierst sie aus einem **Hub** und
+verwaltest sie hier.
+
+## Die zwei Reiter
+
+- **Hub** — der Katalog verfügbarer Plugins. Von hier **installierst** du.
+- **Installiert** — deine aktiven Plugins mit Status (**geladen** oder **Fehler**).
+
+## Schritt-für-Schritt
+
+1. Reiter **Hub** öffnen → ein Plugin auswählen → **Installieren**.
+2. Unter **Installiert** siehst du den Status.
+3. Bei Bedarf **Aktualisieren**, **Neu installieren** oder **Entfernen**.
+
+## Typische Fragen
+
+- **„Keine Plugins im Hub gefunden"** — Der Hub-Index konnte nicht geladen werden
+  (Netz/Quelle); später erneut versuchen.
+- **„Fehler" statt „geladen"** — Das Plugin konnte nicht starten. **Neu
+  installieren** oder das Plugin-Log prüfen.
+
+## Abgrenzung: Plugin vs. Modul vs. Extension
+
+- **Plugin** — erweitert **Agenten-Werkzeuge/Funktionen** (meist ohne eigene Seite).
+- **Modul** — bringt eine **eigene Seite/Feature** in HydraHive (z.B. Atelier).
+- **Extension** — externe Zusatzdienste/Integrationen (eigener Bereich).
+
+## Tipps
+
+- **Nur installieren, was du brauchst** — jedes aktive Plugin ist Fläche für
+  Probleme; weniger ist wartungsärmer.

--- a/frontend/src/i18n/help/de/streaming.md
+++ b/frontend/src/i18n/help/de/streaming.md
@@ -1,0 +1,33 @@
+# Streaming-Downloader
+
+## Was ist das?
+
+Der **Streaming-Downloader** lädt Videos/Episoden von einer Quelle herunter und
+legt sie so ab, dass sie z.B. in **Plex** eingebunden werden können. Du gibst eine
+Adresse an, lässt die verfügbaren Episoden auflisten und wählst aus, was geladen
+werden soll.
+
+## Schritt-für-Schritt
+
+1. Im Feld die **Adresse** der Serie/Staffel einfügen.
+2. **Episoden laden** — die verfügbaren Folgen werden aufgelistet.
+3. Einzeln auswählen oder **Alle wählen** / **Alle abwählen**.
+4. **„N laden"** startet die Downloads. Laufende Downloads kannst du **abbrechen**,
+   fertige/fehlerhafte **löschen**.
+
+## Typische Fragen
+
+- **„Download-Fehler"** — Die Quelle war nicht erreichbar oder das Format nicht
+  ladbar; Adresse prüfen und erneut versuchen.
+- **„Keine Episoden"** — Die Adresse führt auf keine erkennbare Episodenliste;
+  prüfe, ob es die richtige Übersichts-URL ist.
+
+## Hinweis
+
+Lade nur Inhalte herunter, zu denen du **berechtigt** bist. Der Downloader ist ein
+technisches Werkzeug; die Verantwortung für die Nutzung liegt bei dir.
+
+## Tipps
+
+- **Erst Episoden laden, dann auswählen** — so lädst du gezielt nur, was du
+  brauchst.

--- a/frontend/src/i18n/help/de/zahnfee.md
+++ b/frontend/src/i18n/help/de/zahnfee.md
@@ -1,0 +1,34 @@
+# Zahnfee
+
+## Was ist das?
+
+Die **Zahnfee** ist ein **Nacht-Agent**: Sie arbeitet, während du schläfst, und
+legt dir zum Morgen ein **Briefing** bereit — eine Zusammenfassung des Wichtigsten
+für deinen Start in den Tag. Der Name spielt darauf an, dass „über Nacht" etwas
+passiert, ohne dass du zusehen musst.
+
+## Was kann ich hier tun?
+
+- **Aktuelles Briefing** ansehen — die zuletzt erzeugte Zusammenfassung (mit
+  Zeitstempel, wann sie generiert wurde).
+- **Einstellungen**: die Zahnfee **aktivieren/deaktivieren** und das **Modell**
+  wählen, mit dem das Briefing erstellt wird.
+
+## Schritt-für-Schritt
+
+1. Unter **Einstellungen** die Zahnfee **aktivieren**.
+2. Ein **Modell** wählen (bestimmt Qualität/Kosten des Briefings).
+3. Ab dann wird nachts automatisch ein Briefing erstellt; morgens findest du es
+   unter **Aktuelles Briefing**.
+
+## Typische Fragen
+
+- **„Kein Briefing da"** — Ist die Zahnfee **aktiviert** und ein Modell gewählt?
+  Das erste Briefing entsteht erst im nächsten Nacht-Lauf.
+- **„Briefing ist veraltet"** — Der Zeitstempel „Generiert/Stand" zeigt, von wann
+  es ist; das nächste kommt im nächsten Lauf.
+
+## Tipps
+
+- **Passendes Modell**: Für ein tägliches Briefing muss es kein Top-Modell sein —
+  ein günstigeres reicht meist und spart Kosten.

--- a/frontend/src/i18n/help/en/extensions.md
+++ b/frontend/src/i18n/help/en/extensions.md
@@ -1,0 +1,43 @@
+# Extensions
+
+## What is this?
+
+**Extensions** are **external add-on services** that expand HydraHive with larger
+capabilities — e.g. a Matrix server for team chat or other integrations. They run
+as their own service, either **natively** on the server or in **Docker**.
+
+## What can I do here?
+
+- Browse available extensions by **category** (installed / not installed).
+- **Install**, **uninstall**, or (if it has a UI) **open** an extension.
+- See the **status**: Not installed / Active / running-but-unreachable.
+
+## Native vs. Docker
+
+- **Native** — the service runs directly on the server.
+- **Docker** — the service runs in a container. This requires **Docker to be
+  available** (the page shows whether Docker is installed).
+
+## Step by step
+
+1. Pick an extension.
+2. **Install** (for Docker extensions, Docker must be present).
+3. After installation the status shows **Active**; if the extension has a UI, you
+   can **Open** it.
+
+## Common questions
+
+- **"Docker is not installed"** — For Docker-based extensions, Docker must be set
+  up on the server first.
+- **"running but unreachable"** — The service starts but isn't reachable (yet);
+  wait a moment or check the extension log.
+
+## How it differs
+
+- **Extension** — external **service/integration** (native or Docker).
+- **Plugin** — agent **tools** in the background.
+- **Module** — a **page/feature** in HydraHive.
+
+## Tips
+
+- **Install only when needed** — every running service uses resources.

--- a/frontend/src/i18n/help/en/federation.md
+++ b/frontend/src/i18n/help/en/federation.md
@@ -1,0 +1,36 @@
+# Federation
+
+## What is this?
+
+**Federation** connects your HydraHive instance with **other agent systems
+(workstations)** via the **A2A protocol** (agent-to-agent). This lets your agent
+hand tasks to remote, remotely controlled agent systems — e.g. a specialist on
+another machine.
+
+## Core terms
+
+- **Workstation** — another A2A-compatible agent system that you register here.
+- **Token** — the **access secret** of the target workstation. No valid token, no
+  connection.
+- **TLS** — whether the connection is encrypted.
+
+## Step by step
+
+1. **Add** → **Add workstation**.
+2. Enter the target workstation's address and **token** (the token comes from the
+   other side).
+3. Save — registered workstations appear in the list with status ("token
+   configured" / "no token", TLS on/off).
+
+## Common questions
+
+- **"No workstations registered yet"** — Normal at the start; begin with **Add your
+  first workstation**.
+- **"No token"** — The workstation has no valid access secret; without it the
+  connection won't work.
+
+## Tips
+
+- **Handle the token securely**: it's the access secret to the other side — like a
+  password.
+- **Prefer TLS** when the connection runs over a network that isn't fully trusted.

--- a/frontend/src/i18n/help/en/plugins.md
+++ b/frontend/src/i18n/help/en/plugins.md
@@ -1,0 +1,36 @@
+# Plugins
+
+## What is this?
+
+**Plugins** extend HydraHive with additional **tools/functions** for the agents.
+Unlike modules (which bring their own pages), plugins mostly add functionality in
+the background. You install them from a **hub** and manage them here.
+
+## The two tabs
+
+- **Hub** — the catalog of available plugins. You **install** from here.
+- **Installed** — your active plugins with status (**loaded** or **error**).
+
+## Step by step
+
+1. Open the **Hub** tab → pick a plugin → **Install**.
+2. Under **Installed** you see the status.
+3. As needed, **Update**, **Reinstall**, or **Remove**.
+
+## Common questions
+
+- **"No plugins found in the hub"** — The hub index couldn't be loaded
+  (network/source); try again later.
+- **"Error" instead of "loaded"** — The plugin failed to start. **Reinstall** or
+  check the plugin log.
+
+## Plugin vs. module vs. extension
+
+- **Plugin** — extends **agent tools/functions** (usually no own page).
+- **Module** — brings its **own page/feature** into HydraHive (e.g. Atelier).
+- **Extension** — external add-on services/integrations (separate area).
+
+## Tips
+
+- **Only install what you need** — every active plugin is surface for problems;
+  less is easier to maintain.

--- a/frontend/src/i18n/help/en/streaming.md
+++ b/frontend/src/i18n/help/en/streaming.md
@@ -1,0 +1,31 @@
+# Streaming downloader
+
+## What is this?
+
+The **streaming downloader** downloads videos/episodes from a source and stores
+them so they can be used e.g. in **Plex**. You provide an address, list the
+available episodes, and pick what to download.
+
+## Step by step
+
+1. Paste the **address** of the series/season into the field.
+2. **Load episodes** — the available episodes are listed.
+3. Select individually or **Select all** / **Deselect all**.
+4. **"Download N"** starts the downloads. You can **cancel** running downloads and
+   **delete** finished/failed ones.
+
+## Common questions
+
+- **"Download error"** — The source was unreachable or the format not loadable;
+  check the address and try again.
+- **"No episodes"** — The address leads to no recognizable episode list; check that
+  it's the correct overview URL.
+
+## Note
+
+Only download content you're **entitled** to. The downloader is a technical tool;
+responsibility for its use is yours.
+
+## Tips
+
+- **Load episodes first, then select** — so you download only what you need.

--- a/frontend/src/i18n/help/en/zahnfee.md
+++ b/frontend/src/i18n/help/en/zahnfee.md
@@ -1,0 +1,33 @@
+# Tooth Fairy (Zahnfee)
+
+## What is this?
+
+The **Tooth Fairy** is a **night agent**: it works while you sleep and prepares a
+**briefing** for the morning — a summary of the most important things to start
+your day. The name hints that something happens "overnight" without you watching.
+
+## What can I do here?
+
+- **View the current briefing** — the most recently generated summary (with a
+  timestamp of when it was generated).
+- **Settings**: **enable/disable** the Tooth Fairy and choose the **model** used to
+  create the briefing.
+
+## Step by step
+
+1. Under **Settings**, **enable** the Tooth Fairy.
+2. Choose a **model** (determines briefing quality/cost).
+3. From then on a briefing is created automatically at night; in the morning you'll
+   find it under **Current briefing**.
+
+## Common questions
+
+- **"No briefing yet"** — Is the Tooth Fairy **enabled** and a model chosen? The
+  first briefing appears only on the next night run.
+- **"Briefing is outdated"** — The "generated/as of" timestamp shows its date; the
+  next one comes on the next run.
+
+## Tips
+
+- **Suitable model**: for a daily briefing it needn't be a top model — a cheaper
+  one usually suffices and saves cost.

--- a/frontend/src/i18n/locales/de/help.json
+++ b/frontend/src/i18n/locales/de/help.json
@@ -54,7 +54,12 @@
       "minigames": "Minigames",
       "musicplayer": "Musik",
       "tasks": "Aufgaben",
-      "videoeditor": "Video-Editor"
+      "videoeditor": "Video-Editor",
+      "zahnfee": "Zahnfee",
+      "plugins": "Plugins",
+      "federation": "Federation",
+      "streaming": "Streaming",
+      "extensions": "Extensions"
     }
   }
 }

--- a/frontend/src/i18n/locales/en/help.json
+++ b/frontend/src/i18n/locales/en/help.json
@@ -54,7 +54,12 @@
       "minigames": "Minigames",
       "musicplayer": "Music",
       "tasks": "Tasks",
-      "videoeditor": "Video editor"
+      "videoeditor": "Video editor",
+      "zahnfee": "Tooth Fairy",
+      "plugins": "Plugins",
+      "federation": "Federation",
+      "streaming": "Streaming",
+      "extensions": "Extensions"
     }
   }
 }


### PR DESCRIPTION
Fünf neue Hilfe-Artikel (de+en) für die Admin-/Nischen-Seiten, aus echter i18n verifiziert:
- **zahnfee** — Nacht-Agent mit Morgen-Briefing
- **plugins** — Hub/Installiert, Abgrenzung Plugin/Modul/Extension
- **federation** — A2A-Workstations, Token, TLS
- **streaming** — Downloader (Episoden laden/auswählen)
- **extensions** — externe Dienste nativ/Docker

HelpButton (gelber Blob) auf allen 5 Core-Seiten. Alle Topics waren bereits im loader-Union. `tsc -b` grün.

**Damit ist die Lückenliste (HELP-COVERAGE) vollständig** — alle Nav-Seiten und Module haben jetzt Artikel + Hilfe-Button.