### PR TITLE
feat(media): add production workspace foundation

### DIFF
--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -45,6 +45,7 @@ from hydrahive.api.routes.projects_info import router as projects_info_router
 from hydrahive.api.routes.projects_files import router as projects_files_router
 from hydrahive.api.routes.projects_files_write import router as projects_files_write_router
 from hydrahive.api.routes.media_projects import router as media_projects_router
+from hydrahive.api.routes.media_prompts import router as media_prompts_router
 from hydrahive.api.routes.projects_git import router as projects_git_router
 from hydrahive.api.routes.projects_samba import router as projects_samba_router
 from hydrahive.api.routes.projects_servers import router as projects_servers_router
@@ -128,6 +129,7 @@ app.include_router(projects_info_router)
 app.include_router(projects_files_router)
 app.include_router(projects_files_write_router)
 app.include_router(media_projects_router)
+app.include_router(media_prompts_router)
 app.include_router(projects_git_router)
 app.include_router(projects_samba_router)
 app.include_router(projects_servers_router)

--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -44,6 +44,7 @@ from hydrahive.api.routes.projects import router as projects_router
 from hydrahive.api.routes.projects_info import router as projects_info_router
 from hydrahive.api.routes.projects_files import router as projects_files_router
 from hydrahive.api.routes.projects_files_write import router as projects_files_write_router
+from hydrahive.api.routes.media_projects import router as media_projects_router
 from hydrahive.api.routes.projects_git import router as projects_git_router
 from hydrahive.api.routes.projects_samba import router as projects_samba_router
 from hydrahive.api.routes.projects_servers import router as projects_servers_router
@@ -126,6 +127,7 @@ app.include_router(projects_router)
 app.include_router(projects_info_router)
 app.include_router(projects_files_router)
 app.include_router(projects_files_write_router)
+app.include_router(media_projects_router)
 app.include_router(projects_git_router)
 app.include_router(projects_samba_router)
 app.include_router(projects_servers_router)

--- a/core/src/hydrahive/api/routes/media_projects.py
+++ b/core/src/hydrahive/api/routes/media_projects.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+
+from hydrahive import media_projects
+from hydrahive.api.middleware.auth import require_auth
+from hydrahive.api.middleware.errors import coded
+from hydrahive.api.routes._project_route_helpers import check_project_access
+from hydrahive.projects import config as project_config
+
+router = APIRouter(prefix="/api/projects/{project_id}/media-projects", tags=["media-projects"])
+
+
+class MediaProjectCreate(BaseModel):
+    slug: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = Field(default="", max_length=4000)
+
+
+class MediaProjectUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=4000)
+
+
+def _authorize(project_id: str, auth: tuple[str, str]) -> None:
+    project = project_config.get(project_id)
+    if not project:
+        raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
+    check_project_access(project, *auth)
+
+
+@router.get("")
+def list_media_projects(project_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> list[dict]:
+    _authorize(project_id, auth)
+    return media_projects.list_all(project_id)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_media_project(project_id: str, body: MediaProjectCreate, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        return media_projects.create(project_id, body.slug, body.name, body.description)
+    except FileExistsError:
+        raise coded(status.HTTP_409_CONFLICT, "media_project_exists")
+    except media_projects.MediaProjectError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "invalid_media_project")
+
+
+@router.get("/{slug}")
+def get_media_project(project_id: str, slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        result = media_projects.get(project_id, slug)
+    except media_projects.MediaProjectError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "invalid_media_project")
+    if result is None:
+        raise coded(status.HTTP_404_NOT_FOUND, "media_project_not_found")
+    return result
+
+
+@router.patch("/{slug}")
+def update_media_project(project_id: str, slug: str, body: MediaProjectUpdate, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        return media_projects.update(project_id, slug, **body.model_dump(exclude_unset=True))
+    except FileNotFoundError:
+        raise coded(status.HTTP_404_NOT_FOUND, "media_project_not_found")
+    except media_projects.MediaProjectError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "invalid_media_project")
+
+
+@router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_media_project(project_id: str, slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> None:
+    _authorize(project_id, auth)
+    try:
+        deleted = media_projects.delete(project_id, slug)
+    except media_projects.MediaProjectError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "invalid_media_project")
+    if not deleted:
+        raise coded(status.HTTP_404_NOT_FOUND, "media_project_not_found")

--- a/core/src/hydrahive/api/routes/media_prompts.py
+++ b/core/src/hydrahive/api/routes/media_prompts.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import BaseModel, Field
+
+from hydrahive import media_prompts
+from hydrahive.api.middleware.auth import require_auth
+from hydrahive.api.middleware.errors import coded
+from hydrahive.api.routes.media_projects import _authorize
+
+router = APIRouter(prefix="/api/projects/{project_id}/media-projects/{media_slug}/prompts", tags=["media-prompts"])
+PromptType = Literal["general", "image", "video", "music", "voice", "storyboard"]
+PromptStatus = Literal["draft", "executed", "archived"]
+
+
+class PromptCreate(BaseModel):
+    slug: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+    type: PromptType
+    title: str = Field(..., min_length=1, max_length=200)
+    body: str = Field(default="", max_length=100_000)
+    model: str = Field(default="", max_length=200)
+    asset_refs: list[str] = Field(default_factory=list, max_length=100)
+
+
+class PromptUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    body: str | None = Field(default=None, max_length=100_000)
+    model: str | None = Field(default=None, max_length=200)
+    status: PromptStatus | None = None
+    asset_refs: list[str] | None = Field(default=None, max_length=100)
+    result_refs: list[str] | None = Field(default=None, max_length=100)
+
+
+def _error(exc: Exception):
+    if isinstance(exc, FileNotFoundError):
+        return coded(status.HTTP_404_NOT_FOUND, "media_project_or_prompt_not_found")
+    if isinstance(exc, FileExistsError):
+        return coded(status.HTTP_409_CONFLICT, "media_prompt_exists")
+    return coded(status.HTTP_400_BAD_REQUEST, "invalid_media_prompt")
+
+
+@router.get("")
+def list_prompts(project_id: str, media_slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)], prompt_type: PromptType | None = Query(default=None, alias="type")) -> list[dict]:
+    _authorize(project_id, auth)
+    try:
+        return media_prompts.list_all(project_id, media_slug, prompt_type)
+    except (FileNotFoundError, media_prompts.MediaPromptError) as exc:
+        raise _error(exc)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_prompt(project_id: str, media_slug: str, body: PromptCreate, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        return media_prompts.create(project_id, media_slug, body.type, body.slug, body.title, body.body, model=body.model, asset_refs=body.asset_refs)
+    except (FileNotFoundError, FileExistsError, media_prompts.MediaPromptError) as exc:
+        raise _error(exc)
+
+
+@router.get("/{prompt_type}/{slug}")
+def get_prompt(project_id: str, media_slug: str, prompt_type: PromptType, slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        result = media_prompts.get(project_id, media_slug, prompt_type, slug)
+    except (FileNotFoundError, media_prompts.MediaPromptError) as exc:
+        raise _error(exc)
+    if result is None:
+        raise coded(status.HTTP_404_NOT_FOUND, "media_prompt_not_found")
+    return result
+
+
+@router.patch("/{prompt_type}/{slug}")
+def update_prompt(project_id: str, media_slug: str, prompt_type: PromptType, slug: str, body: PromptUpdate, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        return media_prompts.update(project_id, media_slug, prompt_type, slug, **body.model_dump(exclude_unset=True))
+    except (FileNotFoundError, media_prompts.MediaPromptError) as exc:
+        raise _error(exc)
+
+
+@router.delete("/{prompt_type}/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_prompt(project_id: str, media_slug: str, prompt_type: PromptType, slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> None:
+    _authorize(project_id, auth)
+    try:
+        deleted = media_prompts.delete(project_id, media_slug, prompt_type, slug)
+    except (FileNotFoundError, media_prompts.MediaPromptError) as exc:
+        raise _error(exc)
+    if not deleted:
+        raise coded(status.HTTP_404_NOT_FOUND, "media_prompt_not_found")

--- a/core/src/hydrahive/media_projects.py
+++ b/core/src/hydrahive/media_projects.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hydrahive.projects._paths import ensure_workspace
+
+_SLUG = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+_DIRS = ("prompts", "assets", "images", "video", "audio", "timeline", "exports")
+
+
+class MediaProjectError(ValueError):
+    pass
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _root(project_id: str) -> Path:
+    return ensure_workspace(project_id) / "media"
+
+
+def _dir(project_id: str, slug: str) -> Path:
+    if not _SLUG.fullmatch(slug):
+        raise MediaProjectError("Ungültiger Media-Projekt-Slug")
+    root = _root(project_id).resolve()
+    target = (root / slug).resolve()
+    if target.parent != root:
+        raise MediaProjectError("Ungültiger Media-Projekt-Pfad")
+    return target
+
+
+def _read(path: Path) -> dict:
+    try:
+        return json.loads((path / "media-project.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MediaProjectError("Media-Projekt konnte nicht gelesen werden") from exc
+
+
+def _write(path: Path, data: dict) -> None:
+    tmp = path / ".media-project.json.tmp"
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, path / "media-project.json")
+    (path / "project.md").write_text(
+        f"# {data['name']}\n\n{data.get('description') or 'Keine Beschreibung.'}\n\n"
+        f"- Heimatprojekt: `{data['project_id']}`\n- Media-Slug: `{data['slug']}`\n",
+        encoding="utf-8",
+    )
+
+
+def list_all(project_id: str) -> list[dict]:
+    root = _root(project_id)
+    if not root.exists():
+        return []
+    result = []
+    for child in sorted(root.iterdir()):
+        if child.is_dir() and _SLUG.fullmatch(child.name) and (child / "media-project.json").is_file():
+            try:
+                result.append(_read(child))
+            except MediaProjectError:
+                continue
+    return result
+
+
+def get(project_id: str, slug: str) -> dict | None:
+    path = _dir(project_id, slug)
+    return _read(path) if (path / "media-project.json").is_file() else None
+
+
+def create(project_id: str, slug: str, name: str, description: str = "") -> dict:
+    path = _dir(project_id, slug)
+    if path.exists():
+        raise FileExistsError(slug)
+    path.mkdir(parents=True)
+    for dirname in _DIRS:
+        (path / dirname).mkdir()
+    now = _now()
+    data = {"version": 1, "slug": slug, "name": name.strip(), "description": description.strip(), "project_id": project_id, "created_at": now, "updated_at": now}
+    _write(path, data)
+    return data
+
+
+def update(project_id: str, slug: str, *, name: str | None = None, description: str | None = None) -> dict:
+    path = _dir(project_id, slug)
+    if not (path / "media-project.json").is_file():
+        raise FileNotFoundError(slug)
+    data = _read(path)
+    if name is not None:
+        data["name"] = name.strip()
+    if description is not None:
+        data["description"] = description.strip()
+    data["updated_at"] = _now()
+    _write(path, data)
+    return data
+
+
+def delete(project_id: str, slug: str) -> bool:
+    path = _dir(project_id, slug)
+    if not path.exists():
+        return False
+    shutil.rmtree(path)
+    return True

--- a/core/src/hydrahive/media_prompts.py
+++ b/core/src/hydrahive/media_prompts.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from hydrahive import media_projects
+
+_SLUG = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+TYPES = frozenset({"general", "image", "video", "music", "voice", "storyboard"})
+STATUSES = frozenset({"draft", "executed", "archived"})
+
+
+class MediaPromptError(ValueError):
+    pass
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _paths(project_id: str, media_slug: str, prompt_type: str, slug: str | None = None) -> tuple[Path, Path | None]:
+    project_path = media_projects._dir(project_id, media_slug)
+    if not (project_path / "media-project.json").is_file():
+        raise FileNotFoundError(media_slug)
+    if prompt_type not in TYPES:
+        raise MediaPromptError("Ungültiger Prompt-Typ")
+    root = (project_path / "prompts" / prompt_type).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    if slug is None:
+        return root, None
+    if not _SLUG.fullmatch(slug):
+        raise MediaPromptError("Ungültiger Prompt-Slug")
+    path = (root / f"{slug}.md").resolve()
+    if path.parent != root:
+        raise MediaPromptError("Ungültiger Prompt-Pfad")
+    return root, path
+
+
+def _read(path: Path) -> dict:
+    try:
+        text = path.read_text(encoding="utf-8")
+        if not text.startswith("---\n"):
+            raise MediaPromptError("Prompt-Metadaten fehlen")
+        frontmatter, separator, body = text[4:].partition("\n---\n")
+        if not separator:
+            raise MediaPromptError("Prompt-Metadaten sind ungültig")
+        data = yaml.safe_load(frontmatter)
+        if not isinstance(data, dict):
+            raise MediaPromptError("Prompt-Metadaten sind ungültig")
+        data["body"] = body.lstrip("\n")
+        return data
+    except (OSError, yaml.YAMLError) as exc:
+        raise MediaPromptError("Prompt konnte nicht gelesen werden") from exc
+
+
+def _write(path: Path, data: dict) -> None:
+    metadata = {key: value for key, value in data.items() if key != "body"}
+    content = f"---\n{yaml.safe_dump(metadata, allow_unicode=True, sort_keys=False)}---\n\n{data.get('body', '').rstrip()}\n"
+    tmp = path.with_suffix(".md.tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def list_all(project_id: str, media_slug: str, prompt_type: str | None = None) -> list[dict]:
+    types = [prompt_type] if prompt_type is not None else sorted(TYPES)
+    result: list[dict] = []
+    for kind in types:
+        root, _ = _paths(project_id, media_slug, kind)
+        for path in sorted(root.glob("*.md")):
+            try:
+                result.append(_read(path))
+            except MediaPromptError:
+                continue
+    return sorted(result, key=lambda item: item.get("updated_at", ""), reverse=True)
+
+
+def get(project_id: str, media_slug: str, prompt_type: str, slug: str) -> dict | None:
+    _, path = _paths(project_id, media_slug, prompt_type, slug)
+    return _read(path) if path and path.is_file() else None
+
+
+def create(project_id: str, media_slug: str, prompt_type: str, slug: str, title: str, body: str, *, model: str = "", asset_refs: list[str] | None = None) -> dict:
+    _, path = _paths(project_id, media_slug, prompt_type, slug)
+    assert path is not None
+    if path.exists():
+        raise FileExistsError(slug)
+    now = _now()
+    data = {"version": 1, "slug": slug, "type": prompt_type, "title": title.strip(), "status": "draft", "model": model.strip(), "asset_refs": asset_refs or [], "result_refs": [], "created_at": now, "updated_at": now, "body": body}
+    _write(path, data)
+    return data
+
+
+def update(project_id: str, media_slug: str, prompt_type: str, slug: str, **changes: object) -> dict:
+    _, path = _paths(project_id, media_slug, prompt_type, slug)
+    assert path is not None
+    if not path.is_file():
+        raise FileNotFoundError(slug)
+    data = _read(path)
+    if "status" in changes and changes["status"] not in STATUSES:
+        raise MediaPromptError("Ungültiger Prompt-Status")
+    for key in ("title", "body", "model", "status", "asset_refs", "result_refs"):
+        if key in changes and changes[key] is not None:
+            data[key] = changes[key]
+    data["updated_at"] = _now()
+    _write(path, data)
+    return data
+
+
+def delete(project_id: str, media_slug: str, prompt_type: str, slug: str) -> bool:
+    _, path = _paths(project_id, media_slug, prompt_type, slug)
+    assert path is not None
+    if not path.is_file():
+        return False
+    path.unlink()
+    return True

--- a/core/tests/test_media_projects_api.py
+++ b/core/tests/test_media_projects_api.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from hydrahive.projects import config as project_config
+from hydrahive.settings import settings
+
+
+def _project(admin_headers):
+    return project_config.create(name="Media Home", description="", members=["testuser"], llm_model="test-model", created_by="admin", init_git=False)
+
+
+def test_media_project_crud_creates_workspace(client, auth_headers, admin_headers):
+    project = _project(admin_headers)
+    base = f"/api/projects/{project['id']}/media-projects"
+    created = client.post(base, headers=auth_headers, json={"slug": "mein-film", "name": "Mein Film", "description": "Test"})
+    assert created.status_code == 201
+
+    root = Path(settings.data_dir) / "workspaces" / "projects" / project["id"] / "media" / "mein-film"
+    assert (root / "media-project.json").is_file()
+    assert (root / "project.md").is_file()
+    assert all((root / name).is_dir() for name in ("prompts", "assets", "images", "video", "audio", "timeline", "exports"))
+
+    listed = client.get(base, headers=auth_headers)
+    assert [item["slug"] for item in listed.json()] == ["mein-film"]
+    patched = client.patch(f"{base}/mein-film", headers=auth_headers, json={"name": "Neuer Titel"})
+    assert patched.status_code == 200
+    assert patched.json()["name"] == "Neuer Titel"
+    assert client.delete(f"{base}/mein-film", headers=auth_headers).status_code == 204
+    assert client.get(f"{base}/mein-film", headers=auth_headers).status_code == 404
+
+
+def test_media_project_rejects_invalid_slug(client, auth_headers, admin_headers):
+    project = _project(admin_headers)
+    response = client.post(f"/api/projects/{project['id']}/media-projects", headers=auth_headers, json={"slug": "../escape", "name": "Bad"})
+    assert response.status_code == 422
+
+
+def test_media_project_requires_project_access(client, auth_headers, admin_headers):
+    project = project_config.create(name="Private", description="", members=[], llm_model="test-model", created_by="admin", init_git=False)
+    response = client.get(f"/api/projects/{project['id']}/media-projects", headers=auth_headers)
+    assert response.status_code == 403

--- a/core/tests/test_media_prompts_api.py
+++ b/core/tests/test_media_prompts_api.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from hydrahive.projects import config as project_config
+from hydrahive.settings import settings
+
+
+def _media_project(client, auth_headers):
+    project = project_config.create(name="Prompt Home", description="", members=["testuser"], llm_model="test-model", created_by="admin", init_git=False)
+    base = f"/api/projects/{project['id']}/media-projects"
+    assert client.post(base, headers=auth_headers, json={"slug": "film", "name": "Film"}).status_code == 201
+    return project, base
+
+
+def test_media_prompt_crud_writes_markdown(client, auth_headers):
+    project, media_base = _media_project(client, auth_headers)
+    base = f"{media_base}/film/prompts"
+    created = client.post(base, headers=auth_headers, json={"slug": "scene-01", "type": "image", "title": "Szene 01", "body": "A cinematic forest", "model": "image-model", "asset_refs": ["characters/hero"]})
+    assert created.status_code == 201
+    assert created.json()["status"] == "draft"
+
+    path = Path(settings.data_dir) / "workspaces" / "projects" / project["id"] / "media" / "film" / "prompts" / "image" / "scene-01.md"
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\nversion: 1")
+    assert "A cinematic forest" in text
+
+    listed = client.get(base, headers=auth_headers)
+    assert [item["slug"] for item in listed.json()] == ["scene-01"]
+    fetched = client.get(f"{base}/image/scene-01", headers=auth_headers)
+    assert fetched.json()["asset_refs"] == ["characters/hero"]
+    patched = client.patch(f"{base}/image/scene-01", headers=auth_headers, json={"status": "executed", "result_refs": ["images/result.png"]})
+    assert patched.status_code == 200
+    assert patched.json()["result_refs"] == ["images/result.png"]
+    assert client.delete(f"{base}/image/scene-01", headers=auth_headers).status_code == 204
+
+
+def test_media_prompt_rejects_invalid_input_and_missing_project(client, auth_headers):
+    _, media_base = _media_project(client, auth_headers)
+    base = f"{media_base}/film/prompts"
+    assert client.post(base, headers=auth_headers, json={"slug": "../bad", "type": "image", "title": "Bad"}).status_code == 422
+    assert client.post(base, headers=auth_headers, json={"slug": "bad", "type": "unknown", "title": "Bad"}).status_code == 422
+    missing = f"{media_base}/missing/prompts"
+    assert client.get(missing, headers=auth_headers).status_code == 404
+
+
+def test_media_prompt_requires_project_access(client, auth_headers):
+    project = project_config.create(name="Private Prompts", description="", members=[], llm_model="test-model", created_by="admin", init_git=False)
+    response = client.get(f"/api/projects/{project['id']}/media-projects/film/prompts", headers=auth_headers)
+    assert response.status_code == 403

--- a/docs/specs/media-project-data-model.md
+++ b/docs/specs/media-project-data-model.md
@@ -1,0 +1,42 @@
+# Plan: Media-Projekt-Datenmodell und Workspace-Struktur
+
+## Ziel
+Media-Projekte werden innerhalb eines zugänglichen HydraHive-Heimatprojekts dateibasiert und offline-first verwaltet. Die API erstellt und pflegt sichere Workspace-Strukturen; das Media-Cockpit zeigt echte Einträge statt Demo-Projekte.
+
+## Dateien
+- `core/src/hydrahive/media_projects.py` — Validierung, sichere dateibasierte CRUD-Operationen und Verzeichnisstruktur.
+- `core/src/hydrahive/api/routes/media_projects.py` — authentifizierte projektgebundene REST-Endpunkte.
+- `core/src/hydrahive/api/main.py` — Router-Registrierung.
+- `core/tests/test_media_projects_api.py` — CRUD, Zugriff, Traversal und Workspace-Struktur.
+- `frontend/src/features/cockpit/mediaProjectsApi.ts` — typisierter API-Client.
+- `frontend/src/features/cockpit/MediaCockpitPage.tsx` — echte Media-Projektliste und Anlegen-Dialog.
+
+## Datenformat
+`media/<slug>/media-project.json` enthält Version, Slug, Name, Beschreibung, Heimatprojekt-ID sowie Erstellungs- und Änderungszeit. `project.md` ist eine menschenlesbare Übersicht. Unterordner: `prompts`, `assets`, `images`, `video`, `audio`, `timeline`, `exports`.
+
+## Implementierungsreihenfolge
+
+### Task 1: Backend und Tests
+- [ ] API-Tests für Create/List/Get/Patch/Delete sowie Zugriff und ungültige Slugs schreiben (RED).
+- [ ] Dateibasierten Store mit atomarem JSON-Schreiben und sicherer Slug-Validierung implementieren.
+- [ ] Projektzugriff vor jeder Operation prüfen.
+- [ ] Tests grün ausführen (GREEN).
+
+### Task 2: Cockpit-Anbindung
+- [ ] Typisierten Client ergänzen.
+- [ ] Demo-Dropdown durch echte projektabhängige Liste ersetzen.
+- [ ] Geschützten Anlegen-Dialog ergänzen; kein Outside-/Escape-Close.
+- [ ] Offline-/Leer-/Fehlerzustände anzeigen.
+
+### Task 3: Verifikation
+- [ ] Backendtests, Frontend-Build und Offline-Guard ausführen.
+- [ ] Security- und Architektur-Review vor Commit.
+
+## Akzeptanzkriterien
+- [ ] Zugriffsberechtigte Nutzer können Media-Projekte CRUD-verwalten.
+- [ ] Ein Create erzeugt die vollständige Workspace-Struktur.
+- [ ] Traversal, ungültige Slugs und fremde Projekte werden abgewiesen.
+- [ ] `/media` verwendet echte Media-Projekte und startet keinerlei LLM-/Generierungsjob.
+
+## Nicht in diesem Plan
+- Promptarchiv-Inhalte, Cross-Projekt-Assets, Rendering, Mediengenerierung, Timeline-Editor und Media-Agent.

--- a/docs/specs/media-prompt-archive.md
+++ b/docs/specs/media-prompt-archive.md
@@ -1,0 +1,47 @@
+# Spec: Media-Promptarchiv
+
+## Was
+
+Jedes Media-Projekt erhält ein menschenlesbares, versionierbares Promptarchiv unter `media/<media-slug>/prompts/<type>/<prompt-slug>.md`. Ein Eintrag enthält YAML-Frontmatter für strukturierte Metadaten und einen Markdown-Textkörper für den eigentlichen Prompt.
+
+Unterstützte Typen: `general`, `image`, `video`, `music`, `voice`, `storyboard`. Status: `draft`, `executed`, `archived`.
+
+## Warum
+
+Prompts müssen unabhängig von einer Datenbank, offline und im Samba-/Git-Workspace nachvollziehbar bleiben. Modell, referenzierte Assets, Ergebnisse und Ausführungsstatus dürfen nicht nur in flüchtigem UI-State liegen.
+
+## Wie
+
+- Projektzugriff wird vor jedem API-Zugriff geprüft.
+- Typ und Slug werden strikt gegen Allowlist/Regex validiert; aufgelöste Pfade müssen im Promptverzeichnis bleiben.
+- Markdown-Dateien werden atomar geschrieben.
+- API unterstützt List, Get, Create, Patch und Delete.
+- Normales Speichern erzeugt ausschließlich einen Draft und startet keinen LLM- oder Medienjob.
+- `executed` dokumentiert nur einen bereits bewusst gestarteten/abgeschlossenen Vorgang samt Ergebnisreferenzen.
+
+## Format
+
+```markdown
+---
+version: 1
+slug: scene-01-keyframe
+type: image
+title: Szene 01 Keyframe
+status: draft
+model: openai/gpt-5-image-mini
+asset_refs: []
+result_refs: []
+created_at: 2026-01-01T12:00:00+00:00
+updated_at: 2026-01-01T12:00:00+00:00
+---
+
+Prompttext
+```
+
+## Akzeptanzkriterien
+
+- CRUD funktioniert ausschließlich innerhalb eines zugänglichen Heimatprojekts und existierenden Media-Projekts.
+- Traversal, unbekannte Typen/Status und ungültige Slugs werden abgewiesen.
+- Dateien bleiben direkt als Markdown lesbar und enthalten vollständige Metadaten.
+- Asset- und Ergebnisreferenzen sind reine Workspace-/HydraHive-Referenzen; beim Speichern wird nichts extern geladen.
+- Kein Archiv-Endpunkt startet Generierung, LLM oder Rendering.

--- a/frontend/src/features/buddy/BuddyPage.tsx
+++ b/frontend/src/features/buddy/BuddyPage.tsx
@@ -120,7 +120,7 @@ export function BuddyPage() {
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <CockpitShell className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[#080b11]" title="Buddy" hideHeader>
+      <CockpitShell className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]" title="Buddy" hideHeader>
         <CockpitTopbar active="buddy" context={state.agent_name} action={{ label: "Buddy-Settings", path: "/buddy/settings" }} />
         <div className="grid min-h-0 flex-1 gap-[10px] overflow-hidden p-[10px] xl:grid-cols-[300px_minmax(520px,1fr)_330px]">
           <BuddyLeftRail state={state} mascotState={mascotState} chatBusy={chat.busy} ttsSpeaking={tts.speaking} projects={projects} localOverviewOpen={localOverviewOpen} onLocalAction={handleBuddyLocalAction} />

--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -32,7 +32,7 @@ export function AdminCockpitPage() {
       title="Admin-Cockpit"
       description="Schaltzentrale für System, User, Module, Integrationen, Credentials und Infrastruktur. Die Route bleibt durch AdminGuard geschützt."
       actions={<CockpitButton tone="primary" onClick={() => openLocalPath("/system")}>System öffnen</CockpitButton>}
-      className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[#080b11]"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]"
       hideHeader
     >
       <CockpitTopbar active="admin" context="Admin" action={{ label: "System öffnen", path: "/system" }} />

--- a/frontend/src/features/cockpit/MediaAssetOverlay.tsx
+++ b/frontend/src/features/cockpit/MediaAssetOverlay.tsx
@@ -1,0 +1,35 @@
+import { useMemo, useState } from "react"
+import { fileUrl } from "@/modules/atelier/api"
+import type { AtelierCharacter, AtelierCI, FilmJob, GalleryItem, VideoJob } from "@/modules/atelier/types"
+import { CockpitButton } from "./CockpitButton"
+import { CockpitSectionLabel } from "./CockpitPanel"
+import { openLocalPath } from "./actionRegistry"
+
+type AssetTab = "all" | "characters" | "style" | "images" | "video" | "audio"
+
+export function MediaAssetOverlay({ tab: initialTab, root, ci, characters, gallery, videos, films, onClose }: { tab: AssetTab; root: string; ci: AtelierCI | null; characters: AtelierCharacter[]; gallery: GalleryItem[]; videos: VideoJob[]; films: FilmJob[]; onClose: () => void }) {
+  const [tab, setTab] = useState<AssetTab>(initialTab)
+  const items = useMemo(() => {
+    if (tab === "characters") return characters.map((item) => ({ id: item.id, title: item.name, detail: item.description || item.style_anchor || "Kein Steckbrief", image: item.references[0] ? fileUrl(`${root}/${item.references[0]}`) : "" }))
+    if (tab === "images") return gallery.map((item) => ({ id: item.rel, title: item.name, detail: item.prompt || item.model || "Galeriebild", image: fileUrl(item.path) }))
+    if (tab === "video") return [...videos.map((item) => ({ id: item.job_id, title: `Clip · ${item.status}`, detail: item.prompt || item.source_rel, image: "" })), ...films.map((item) => ({ id: item.job_id, title: `Film · ${item.status}`, detail: `${item.clips.length} Clips · ${item.resolution}`, image: "" }))]
+    return []
+  }, [tab, characters, gallery, videos, films, root])
+
+  return <div className="fixed inset-0 z-50 grid place-items-center bg-black/80 p-4" role="dialog" aria-modal="true" aria-labelledby="asset-overlay-title">
+    <section className="flex h-[min(780px,92dvh)] w-full max-w-6xl flex-col overflow-hidden rounded-[4px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
+      <header className="flex items-center justify-between border-b border-[#2a364b] p-4"><div><CockpitSectionLabel>Media-Workspace</CockpitSectionLabel><h2 id="asset-overlay-title" className="mt-1 text-lg font-semibold text-[#e8eef8]">Asset-Bibliothek</h2></div><CockpitButton onClick={onClose}>Schließen</CockpitButton></header>
+      <nav className="flex flex-wrap gap-2 border-b border-[#2a364b] bg-[#101724] p-3">{(["all", "characters", "style", "images", "video", "audio"] as AssetTab[]).map((key) => <button key={key} onClick={() => setTab(key)} className={`rounded-[4px] border px-3 py-1.5 text-xs ${tab === key ? "border-[#ffb86b]/60 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] text-[#8d9ab0]"}`}>{labels[key]}</button>)}</nav>
+      <main className="min-h-0 flex-1 overflow-y-auto p-4">
+        {tab === "all" && <div className="grid gap-3 md:grid-cols-3">{summaryCard("Charaktere", characters.length, "characters", setTab)}{summaryCard("Bilder / Keyframes", gallery.length, "images", setTab)}{summaryCard("Clips / Filme", videos.length + films.length, "video", setTab)}{summaryCard("Stil / CI", ci?.style_anchor ? 1 : 0, "style", setTab)}{summaryCard("Musik / Voice", 0, "audio", setTab)}</div>}
+        {tab === "style" && <div className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-4"><h3 className="font-semibold text-[#e8eef8]">Projektstil</h3><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-[#d7deea]">{ci?.style_anchor || "Noch kein Style-Anchor hinterlegt."}</p><div className="mt-4 flex flex-wrap gap-2">{ci?.palette.map((color) => <span key={color} className="h-9 w-16 rounded-[3px] border border-white/20" style={{ background: color }} title={color} />)}</div><p className="mt-4 text-xs text-[#8d9ab0]">Modell: {ci?.default_model || "nicht gesetzt"} · Format: {ci?.aspect_ratio || "nicht gesetzt"}</p><CockpitButton onClick={() => openLocalPath("/atelier")} className="mt-4">CI im Atelier bearbeiten</CockpitButton></div>}
+        {tab === "audio" && <div className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-5"><h3 className="font-semibold text-[#e8eef8]">Musik und Voice</h3><p className="mt-2 text-sm leading-6 text-[#8d9ab0]">Audio-Assets werden über die Musik- und Voice-Werkzeuge erstellt und anschließend dem Media-Projekt referenziert. Diese Ansicht startet keinen Job.</p><div className="mt-4 flex gap-2"><CockpitButton onClick={() => openLocalPath("/music")}>Musik öffnen</CockpitButton><CockpitButton onClick={() => openLocalPath("/atelier")}>Voice / Regie öffnen</CockpitButton></div></div>}
+        {items.length > 0 && <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{items.map((item) => <article key={item.id} className="overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#0d1420]">{item.image ? <img src={item.image} alt="" className="h-40 w-full object-cover" loading="lazy" /> : <div className="grid h-28 place-items-center bg-[#111827] text-xs text-[#46617f]">Keine lokale Vorschau</div>}<div className="p-3"><h3 className="truncate text-sm font-semibold text-[#e8eef8]">{item.title}</h3><p className="mt-1 line-clamp-3 text-xs leading-5 text-[#8d9ab0]">{item.detail}</p></div></article>)}</div>}
+        {tab !== "all" && tab !== "style" && tab !== "audio" && items.length === 0 && <p className="rounded-[4px] border border-dashed border-[#2a364b] p-6 text-center text-sm text-[#8d9ab0]">Noch keine Assets in diesem Bereich. Öffne das Atelier, um Material anzulegen.</p>}
+      </main>
+    </section>
+  </div>
+}
+
+const labels: Record<AssetTab, string> = { all: "Übersicht", characters: "Charaktere", style: "Stil / CI", images: "Bilder", video: "Video", audio: "Musik / Voice" }
+function summaryCard(title: string, count: number, tab: AssetTab, select: (tab: AssetTab) => void) { return <button onClick={() => select(tab)} className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-4 text-left hover:border-[#46617f]"><strong className="text-[#e8eef8]">{title}</strong><span className="mt-2 block font-mono text-2xl text-[#ffb86b]">{count}</span></button> }

--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -10,6 +10,7 @@ import { CockpitTopbar } from "./CockpitTopbar"
 import { openLocalPath } from "./actionRegistry"
 import { mediaProjectsApi, type MediaProject } from "./mediaProjectsApi"
 import { MediaPromptOverlay } from "./MediaPromptOverlay"
+import { MediaAssetOverlay } from "./MediaAssetOverlay"
 
 const productionAreas = [
   { title: "Idee & Prompt", text: "Grundidee, Ziel, Stil", path: "/atelier" },
@@ -36,6 +37,8 @@ export function MediaCockpitPage() {
   const [mediaProjectStatus, setMediaProjectStatus] = useState<"idle" | "loading" | "ready" | "offline">("idle")
   const [createOpen, setCreateOpen] = useState(false)
   const [promptOpen, setPromptOpen] = useState(false)
+  const [assetTab, setAssetTab] = useState<"all" | "characters" | "style" | "images" | "video" | "audio" | null>(null)
+  const [atelierRoot, setAtelierRoot] = useState("")
   const [createName, setCreateName] = useState("")
   const [createDescription, setCreateDescription] = useState("")
   const [createError, setCreateError] = useState("")
@@ -83,21 +86,23 @@ export function MediaCockpitPage() {
     let cancelled = false
     setAtelierStatus("loading")
     Promise.allSettled([
+      atelierApi.meta(projectId),
       atelierApi.getCI(projectId),
       atelierApi.listCharacters(projectId),
       atelierApi.gallery(projectId),
       atelierApi.listVideos(projectId),
       atelierApi.listFilms(projectId),
       atelierApi.presets(),
-    ]).then(([ciResult, charactersResult, galleryResult, videosResult, filmsResult, presetsResult]) => {
+    ]).then(([metaResult, ciResult, charactersResult, galleryResult, videosResult, filmsResult, presetsResult]) => {
       if (cancelled) return
+      if (metaResult.status === "fulfilled") setAtelierRoot(metaResult.value.root)
       if (ciResult.status === "fulfilled") { setCi(ciResult.value); setImageModel(ciResult.value.default_model || "GPT Image Mini") }
       if (charactersResult.status === "fulfilled") setCharacters(charactersResult.value)
       if (galleryResult.status === "fulfilled") setGallery(galleryResult.value)
       if (videosResult.status === "fulfilled") setVideos(videosResult.value)
       if (filmsResult.status === "fulfilled") setFilms(filmsResult.value)
       if (presetsResult.status === "fulfilled") setPresets(presetsResult.value)
-      setAtelierStatus([ciResult, charactersResult, galleryResult, videosResult, filmsResult, presetsResult].some((result) => result.status === "fulfilled") ? "ready" : "offline")
+      setAtelierStatus([metaResult, ciResult, charactersResult, galleryResult, videosResult, filmsResult, presetsResult].some((result) => result.status === "fulfilled") ? "ready" : "offline")
     })
     return () => { cancelled = true }
   }, [projectId])
@@ -105,10 +110,10 @@ export function MediaCockpitPage() {
   const selectedProject = useMemo(() => projects.find((project) => project.id === projectId), [projects, projectId])
   const activeStep = area.includes("Idee") ? 0 : area.includes("Regie") ? 1 : area.includes("Charakter") || area.includes("Stil") ? 2 : 0
   const mediaAssets = useMemo(() => [
-    { kind: "Charakter", name: characters[0]?.name ?? "Atelier-Figuren", count: characters.length, icon: Images, path: "/atelier" },
-    { kind: "Stil", name: ci?.style_anchor ? "CI geladen" : "CI / Look", count: ci?.palette?.length ?? 0, icon: Palette, path: "/atelier" },
-    { kind: "Bild", name: gallery[0]?.name ?? "Keyframes", count: gallery.length, icon: Wand2, path: "/atelier" },
-    { kind: "Clips", name: videos[0]?.status ?? "Videojobs", count: videos.length + films.length, icon: Music2, path: "/videoeditor" },
+    { kind: "Charakter", name: characters[0]?.name ?? "Atelier-Figuren", count: characters.length, icon: Images, tab: "characters" as const },
+    { kind: "Stil", name: ci?.style_anchor ? "CI geladen" : "CI / Look", count: ci?.palette?.length ?? 0, icon: Palette, tab: "style" as const },
+    { kind: "Bild", name: gallery[0]?.name ?? "Keyframes", count: gallery.length, icon: Wand2, tab: "images" as const },
+    { kind: "Clips", name: videos[0]?.status ?? "Videojobs", count: videos.length + films.length, icon: Music2, tab: "video" as const },
   ], [characters, ci, gallery, videos, films])
   const productionSlots = useMemo(() => {
     const imageSlots = gallery.slice(0, 3).map((item, index) => ({
@@ -241,11 +246,11 @@ export function MediaCockpitPage() {
         </main>
 
         <aside className="grid min-h-0 grid-rows-[42%_58%] gap-[10px] overflow-hidden">
-          <CockpitPanel title="Asset-Bibliothek" eyebrow="Material" actions={<CockpitButton onClick={() => openLocalPath("/atelier")}>Import</CockpitButton>} className="min-h-0 overflow-y-auto">
+          <CockpitPanel title="Asset-Bibliothek" eyebrow="Material" actions={<CockpitButton onClick={() => setAssetTab("all")}>Öffnen</CockpitButton>} className="min-h-0 overflow-y-auto">
             <div className="grid grid-cols-2 gap-2">
               {mediaAssets.map((asset) => {
                 const Icon = asset.icon
-                return <button key={asset.kind} onClick={() => openLocalPath(asset.path)} className="h-[76px] rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-left text-xs text-[#8d9ab0] hover:border-[#46617f]"><Icon size={14} className="mb-1 text-[#ffb86b]" />{asset.kind} · {asset.count}<strong className="block truncate text-sm text-[#e8eef8]">{asset.name}</strong></button>
+                return <button key={asset.kind} onClick={() => setAssetTab(asset.tab)} className="h-[76px] rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-left text-xs text-[#8d9ab0] hover:border-[#46617f]"><Icon size={14} className="mb-1 text-[#ffb86b]" />{asset.kind} · {asset.count}<strong className="block truncate text-sm text-[#e8eef8]">{asset.name}</strong></button>
               })}
             </div>
           </CockpitPanel>
@@ -261,6 +266,7 @@ export function MediaCockpitPage() {
         </aside>
       </div>
       {promptOpen && projectId && mediaProject && <MediaPromptOverlay projectId={projectId} mediaSlug={mediaProject} initialBody={jobText} onClose={() => setPromptOpen(false)} />}
+      {assetTab && <MediaAssetOverlay tab={assetTab} root={atelierRoot} ci={ci} characters={characters} gallery={gallery} videos={videos} films={films} onClose={() => setAssetTab(null)} />}
       {createOpen && <div className="fixed inset-0 z-50 grid place-items-center bg-black/75 p-4" role="dialog" aria-modal="true" aria-labelledby="create-media-title">
         <section className="w-full max-w-lg rounded-[4px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
           <header className="border-b border-[#2a364b] p-4"><CockpitSectionLabel>Neues Media-Projekt</CockpitSectionLabel><h2 id="create-media-title" className="mt-1 text-lg font-semibold text-[#e8eef8]">Produktionsworkspace anlegen</h2></header>

--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -8,6 +8,7 @@ import { CockpitPanel, CockpitSectionLabel } from "./CockpitPanel"
 import { CockpitShell } from "./CockpitShell"
 import { CockpitTopbar } from "./CockpitTopbar"
 import { openLocalPath } from "./actionRegistry"
+import { mediaProjectsApi, type MediaProject } from "./mediaProjectsApi"
 
 const productionAreas = [
   { title: "Idee & Prompt", text: "Grundidee, Ziel, Stil", path: "/atelier" },
@@ -29,7 +30,13 @@ export function MediaCockpitPage() {
   const [projects, setProjects] = useState<ProjectBrief[]>([])
   const [projectStatus, setProjectStatus] = useState<"loading" | "ready" | "offline">("loading")
   const [projectId, setProjectId] = useState("")
-  const [mediaProject, setMediaProject] = useState("atelier-clips")
+  const [mediaProjects, setMediaProjects] = useState<MediaProject[]>([])
+  const [mediaProject, setMediaProject] = useState("")
+  const [mediaProjectStatus, setMediaProjectStatus] = useState<"idle" | "loading" | "ready" | "offline">("idle")
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createName, setCreateName] = useState("")
+  const [createDescription, setCreateDescription] = useState("")
+  const [createError, setCreateError] = useState("")
   const [atelierStatus, setAtelierStatus] = useState<"idle" | "loading" | "ready" | "offline">("idle")
   const [ci, setCi] = useState<AtelierCI | null>(null)
   const [characters, setCharacters] = useState<AtelierCharacter[]>([])
@@ -53,6 +60,21 @@ export function MediaCockpitPage() {
       })
       .catch(() => setProjectStatus("offline"))
   }, [])
+
+  useEffect(() => {
+    if (!projectId) return
+    let cancelled = false
+    setMediaProjectStatus("loading")
+    mediaProjectsApi.list(projectId).then((items) => {
+      if (cancelled) return
+      setMediaProjects(items)
+      setMediaProject((current) => items.some((item) => item.slug === current) ? current : (items[0]?.slug ?? ""))
+      setMediaProjectStatus("ready")
+    }).catch(() => {
+      if (!cancelled) setMediaProjectStatus("offline")
+    })
+    return () => { cancelled = true }
+  }, [projectId])
 
   useEffect(() => {
     if (!projectId) return
@@ -106,6 +128,21 @@ export function MediaCockpitPage() {
     return presetNames.length ? presetNames : modes
   }, [presets])
 
+  const createMediaProject = async () => {
+    const name = createName.trim()
+    const slug = name.toLowerCase().normalize("NFKD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64)
+    if (!projectId || !name || !slug) { setCreateError("Bitte einen gültigen Namen eingeben."); return }
+    setCreateError("")
+    try {
+      const created = await mediaProjectsApi.create(projectId, { slug, name, description: createDescription.trim() })
+      setMediaProjects((items) => [...items, created])
+      setMediaProject(created.slug)
+      setCreateOpen(false)
+      setCreateName("")
+      setCreateDescription("")
+    } catch { setCreateError("Media-Projekt konnte nicht angelegt werden.") }
+  }
+
   return (
     <CockpitShell
       eyebrow="Media"
@@ -118,11 +155,10 @@ export function MediaCockpitPage() {
       <CockpitTopbar active="media" context={selectedProject?.name ?? "Projekt: lokal"} action={{ label: "Atelier öffnen", path: "/atelier" }} />
       <div className="grid min-h-0 flex-1 gap-[10px] overflow-hidden p-[10px] xl:grid-cols-[280px_minmax(520px,1fr)_360px]">
         <aside className="panel min-h-0 overflow-y-auto rounded-[4px] border border-[#2a364b] bg-[#151c2b] p-3">
-          <CockpitSectionLabel>Media-Projekt</CockpitSectionLabel>
-          <select value={mediaProject} onChange={(event) => setMediaProject(event.target.value)} className="mt-2 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]">
-            <option value="testfilm">Filmprojekt: Testfilm 90min</option>
-            <option value="atelier-clips">Atelier Clips</option>
-            <option value="buddy-trailer">Buddy Trailer</option>
+          <div className="flex items-center justify-between gap-2"><CockpitSectionLabel>Media-Projekt</CockpitSectionLabel><CockpitButton onClick={() => setCreateOpen(true)}><Plus size={12} className="mr-1 inline" /> Neu</CockpitButton></div>
+          <select value={mediaProject} onChange={(event) => setMediaProject(event.target.value)} disabled={!mediaProjects.length} className="mt-2 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8] disabled:opacity-60">
+            {!mediaProjects.length && <option value="">{mediaProjectStatus === "loading" ? "Media-Projekte laden…" : mediaProjectStatus === "offline" ? "Media-Projekte offline" : "Noch kein Media-Projekt"}</option>}
+            {mediaProjects.map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}
           </select>
 
           <div className="mt-4">
@@ -222,6 +258,18 @@ export function MediaCockpitPage() {
           </section>
         </aside>
       </div>
+      {createOpen && <div className="fixed inset-0 z-50 grid place-items-center bg-black/75 p-4" role="dialog" aria-modal="true" aria-labelledby="create-media-title">
+        <section className="w-full max-w-lg rounded-[4px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
+          <header className="border-b border-[#2a364b] p-4"><CockpitSectionLabel>Neues Media-Projekt</CockpitSectionLabel><h2 id="create-media-title" className="mt-1 text-lg font-semibold text-[#e8eef8]">Produktionsworkspace anlegen</h2></header>
+          <div className="space-y-3 p-4">
+            <label className="block text-xs text-[#8d9ab0]">Name<input autoFocus value={createName} onChange={(event) => setCreateName(event.target.value)} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]" /></label>
+            <label className="block text-xs text-[#8d9ab0]">Beschreibung<textarea value={createDescription} onChange={(event) => setCreateDescription(event.target.value)} rows={4} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]" /></label>
+            <p className="text-xs leading-4 text-[#8d9ab0]">Wird sicher im Workspace des gewählten Heimatprojekts unter <code>media/&lt;slug&gt;</code> angelegt. Kein Generator- oder LLM-Job wird gestartet.</p>
+            {createError && <p className="text-sm text-[#fb7185]">{createError}</p>}
+          </div>
+          <footer className="flex justify-end gap-2 border-t border-[#2a364b] p-3"><CockpitButton onClick={() => setCreateOpen(false)}>Schließen</CockpitButton><CockpitButton tone="primary" onClick={createMediaProject}>Anlegen</CockpitButton></footer>
+        </section>
+      </div>}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -156,7 +156,7 @@ export function MediaCockpitPage() {
       title="Media-Cockpit"
       description="Produktionsarbeitsplatz für Idee, Regie, Assets, Generator-Aufträge und Schnitt — nach Mockup-Parität, aber ohne automatische Generierungs- oder LLM-Jobs."
       actions={<CockpitButton tone="primary" onClick={() => openLocalPath("/atelier")}>Atelier öffnen</CockpitButton>}
-      className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[#080b11]"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]"
       hideHeader
     >
       <CockpitTopbar active="media" context={selectedProject?.name ?? "Projekt: lokal"} action={{ label: "Atelier öffnen", path: "/atelier" }} />

--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -9,6 +9,7 @@ import { CockpitShell } from "./CockpitShell"
 import { CockpitTopbar } from "./CockpitTopbar"
 import { openLocalPath } from "./actionRegistry"
 import { mediaProjectsApi, type MediaProject } from "./mediaProjectsApi"
+import { MediaPromptOverlay } from "./MediaPromptOverlay"
 
 const productionAreas = [
   { title: "Idee & Prompt", text: "Grundidee, Ziel, Stil", path: "/atelier" },
@@ -34,6 +35,7 @@ export function MediaCockpitPage() {
   const [mediaProject, setMediaProject] = useState("")
   const [mediaProjectStatus, setMediaProjectStatus] = useState<"idle" | "loading" | "ready" | "offline">("idle")
   const [createOpen, setCreateOpen] = useState(false)
+  const [promptOpen, setPromptOpen] = useState(false)
   const [createName, setCreateName] = useState("")
   const [createDescription, setCreateDescription] = useState("")
   const [createError, setCreateError] = useState("")
@@ -220,7 +222,7 @@ export function MediaCockpitPage() {
             <div className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3">
               <div className="mb-3 flex items-center justify-between gap-2">
                 <CockpitSectionLabel>Generator-Auftrag</CockpitSectionLabel>
-                <CockpitButton onClick={() => openLocalPath("/atelier")}>Overlay öffnen</CockpitButton>
+                <CockpitButton onClick={() => setPromptOpen(true)} disabled={!projectId || !mediaProject}>Promptarchiv</CockpitButton>
               </div>
               <textarea value={jobText} onChange={(event) => setJobText(event.target.value)} rows={8} className="w-full resize-y rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm leading-5 text-[#e8eef8]" />
               <div className="mt-3 flex flex-wrap gap-2">{modePills.map((mode) => <button key={mode} onClick={() => setJobText((text) => `${text}\n# ${mode}`)} className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-2 py-1 text-xs text-[#d7deea] hover:border-[#46617f]">{mode}</button>)}</div>
@@ -258,6 +260,7 @@ export function MediaCockpitPage() {
           </section>
         </aside>
       </div>
+      {promptOpen && projectId && mediaProject && <MediaPromptOverlay projectId={projectId} mediaSlug={mediaProject} initialBody={jobText} onClose={() => setPromptOpen(false)} />}
       {createOpen && <div className="fixed inset-0 z-50 grid place-items-center bg-black/75 p-4" role="dialog" aria-modal="true" aria-labelledby="create-media-title">
         <section className="w-full max-w-lg rounded-[4px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
           <header className="border-b border-[#2a364b] p-4"><CockpitSectionLabel>Neues Media-Projekt</CockpitSectionLabel><h2 id="create-media-title" className="mt-1 text-lg font-semibold text-[#e8eef8]">Produktionsworkspace anlegen</h2></header>

--- a/frontend/src/features/cockpit/MediaPromptOverlay.tsx
+++ b/frontend/src/features/cockpit/MediaPromptOverlay.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useState } from "react"
+import { CockpitButton } from "./CockpitButton"
+import { CockpitSectionLabel } from "./CockpitPanel"
+import { mediaPromptsApi, type MediaPrompt, type MediaPromptType } from "./mediaProjectsApi"
+
+const types: Array<{ value: MediaPromptType; label: string }> = [
+  { value: "general", label: "Allgemein" }, { value: "storyboard", label: "Storyboard" },
+  { value: "image", label: "Bild" }, { value: "video", label: "Video" },
+  { value: "music", label: "Musik" }, { value: "voice", label: "Voice" },
+]
+
+export function MediaPromptOverlay({ projectId, mediaSlug, initialBody, onClose }: { projectId: string; mediaSlug: string; initialBody: string; onClose: () => void }) {
+  const [items, setItems] = useState<MediaPrompt[]>([])
+  const [selected, setSelected] = useState("")
+  const [type, setType] = useState<MediaPromptType>("storyboard")
+  const [title, setTitle] = useState("Neuer Prompt")
+  const [model, setModel] = useState("")
+  const [body, setBody] = useState(initialBody)
+  const [status, setStatus] = useState("Lädt…")
+  const active = useMemo(() => items.find((item) => `${item.type}/${item.slug}` === selected), [items, selected])
+
+  const reload = () => mediaPromptsApi.list(projectId, mediaSlug).then((data) => { setItems(data); setStatus(data.length ? "Archiv geladen" : "Noch keine Einträge") }).catch(() => setStatus("Archiv nicht erreichbar"))
+  useEffect(() => { void reload() }, [projectId, mediaSlug]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { if (!active) return; setType(active.type); setTitle(active.title); setModel(active.model); setBody(active.body) }, [active])
+
+  const save = async () => {
+    if (!title.trim()) { setStatus("Titel fehlt"); return }
+    setStatus("Speichert…")
+    try {
+      if (active) await mediaPromptsApi.update(projectId, mediaSlug, active.type, active.slug, { title: title.trim(), body, model })
+      else {
+        const slug = title.toLowerCase().normalize("NFKD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64)
+        if (!slug) { setStatus("Ungültiger Titel"); return }
+        await mediaPromptsApi.create(projectId, mediaSlug, { slug, type, title: title.trim(), body, model, asset_refs: [] })
+        setSelected(`${type}/${slug}`)
+      }
+      await reload(); setStatus("Draft gespeichert — kein Job gestartet")
+    } catch { setStatus("Speichern fehlgeschlagen oder Slug bereits vorhanden") }
+  }
+
+  return <div className="fixed inset-0 z-50 grid place-items-center bg-black/80 p-4" role="dialog" aria-modal="true" aria-labelledby="prompt-overlay-title">
+    <section className="grid h-[min(760px,92dvh)] w-full max-w-5xl grid-cols-[260px_1fr] overflow-hidden rounded-[4px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
+      <aside className="overflow-y-auto border-r border-[#2a364b] bg-[#101724] p-3">
+        <CockpitSectionLabel>Promptarchiv</CockpitSectionLabel>
+        <button onClick={() => { setSelected(""); setTitle("Neuer Prompt"); setBody(initialBody); setModel("") }} className="mt-3 w-full rounded-[4px] border border-[#ffb86b]/55 bg-[#ffb86b]/10 p-2 text-left text-sm text-[#ffb86b]">+ Neuer Draft</button>
+        <div className="mt-3 space-y-2">{items.map((item) => <button key={`${item.type}/${item.slug}`} onClick={() => setSelected(`${item.type}/${item.slug}`)} className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-left hover:border-[#46617f]"><strong className="block truncate text-sm text-[#e8eef8]">{item.title}</strong><span className="text-[11px] text-[#8d9ab0]">{item.type} · {item.status}</span></button>)}</div>
+      </aside>
+      <main className="flex min-h-0 flex-col">
+        <header className="flex items-center justify-between border-b border-[#2a364b] p-4"><div><CockpitSectionLabel>Offline-Workspace</CockpitSectionLabel><h2 id="prompt-overlay-title" className="mt-1 text-lg font-semibold text-[#e8eef8]">Prompt bearbeiten</h2></div><CockpitButton onClick={onClose}>Schließen</CockpitButton></header>
+        <div className="grid flex-1 content-start gap-3 overflow-y-auto p-4 md:grid-cols-2">
+          <label className="text-xs text-[#8d9ab0]">Typ<select disabled={!!active} value={type} onChange={(event) => setType(event.target.value as MediaPromptType)} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]">{types.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}</select></label>
+          <label className="text-xs text-[#8d9ab0]">Modell<input value={model} onChange={(event) => setModel(event.target.value)} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]" /></label>
+          <label className="text-xs text-[#8d9ab0] md:col-span-2">Titel<input value={title} onChange={(event) => setTitle(event.target.value)} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]" /></label>
+          <label className="text-xs text-[#8d9ab0] md:col-span-2">Prompt<textarea value={body} onChange={(event) => setBody(event.target.value)} rows={18} className="mt-1 w-full resize-y rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 font-mono text-sm leading-5 text-[#e8eef8]" /></label>
+        </div>
+        <footer className="flex items-center justify-between gap-3 border-t border-[#2a364b] p-3"><p className="text-xs text-[#8d9ab0]">{status}</p><CockpitButton tone="primary" onClick={save}>Draft speichern</CockpitButton></footer>
+      </main>
+    </section>
+  </div>
+}

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -92,7 +92,7 @@ export function ProjectCockpitPage() {
           <CockpitButton tone="primary" onClick={() => setCreateProjectOpen(true)}>+ Neues Projekt</CockpitButton>
         </>
       )}
-      className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[#080b11]"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]"
       hideHeader
     >
       <CockpitTopbar

--- a/frontend/src/features/cockpit/VaultCockpitPage.tsx
+++ b/frontend/src/features/cockpit/VaultCockpitPage.tsx
@@ -39,7 +39,7 @@ export function VaultCockpitPage() {
       title="Vault-Cockpit"
       description="Sensible Bereiche an einem Ort: Patientenakte, Crypto, Dokumente, Notizen, Credentials und private Historie — mit klaren Schutzplanken."
       actions={<CockpitButton tone="primary" onClick={() => openLocalPath("/akte")}>Meine Akte öffnen</CockpitButton>}
-      className="flex h-[100dvh] min-h-0 flex-col overflow-hidden bg-[#080b11]"
+      className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]"
       hideHeader
     >
       <CockpitTopbar active="vault" context="gesperrt nach 15 min" action={{ label: "Meine Akte", path: "/akte" }} />

--- a/frontend/src/features/cockpit/mediaProjectsApi.ts
+++ b/frontend/src/features/cockpit/mediaProjectsApi.ts
@@ -1,0 +1,21 @@
+import { api } from "@/shared/api-client"
+
+export interface MediaProject {
+  version: number
+  slug: string
+  name: string
+  description: string
+  project_id: string
+  created_at: string
+  updated_at: string
+}
+
+export const mediaProjectsApi = {
+  list: (projectId: string) => api.get<MediaProject[]>(`/projects/${projectId}/media-projects`),
+  create: (projectId: string, input: { slug: string; name: string; description: string }) =>
+    api.post<MediaProject>(`/projects/${projectId}/media-projects`, input),
+  update: (projectId: string, slug: string, input: Partial<Pick<MediaProject, "name" | "description">>) =>
+    api.patch<MediaProject>(`/projects/${projectId}/media-projects/${slug}`, input),
+  remove: (projectId: string, slug: string) =>
+    api.delete<void>(`/projects/${projectId}/media-projects/${slug}`),
+}

--- a/frontend/src/features/cockpit/mediaProjectsApi.ts
+++ b/frontend/src/features/cockpit/mediaProjectsApi.ts
@@ -10,6 +10,23 @@ export interface MediaProject {
   updated_at: string
 }
 
+export type MediaPromptType = "general" | "image" | "video" | "music" | "voice" | "storyboard"
+export type MediaPromptStatus = "draft" | "executed" | "archived"
+
+export interface MediaPrompt {
+  version: number
+  slug: string
+  type: MediaPromptType
+  title: string
+  status: MediaPromptStatus
+  model: string
+  asset_refs: string[]
+  result_refs: string[]
+  created_at: string
+  updated_at: string
+  body: string
+}
+
 export const mediaProjectsApi = {
   list: (projectId: string) => api.get<MediaProject[]>(`/projects/${projectId}/media-projects`),
   create: (projectId: string, input: { slug: string; name: string; description: string }) =>
@@ -18,4 +35,16 @@ export const mediaProjectsApi = {
     api.patch<MediaProject>(`/projects/${projectId}/media-projects/${slug}`, input),
   remove: (projectId: string, slug: string) =>
     api.delete<void>(`/projects/${projectId}/media-projects/${slug}`),
+}
+
+const promptBase = (projectId: string, mediaSlug: string) => `/projects/${projectId}/media-projects/${mediaSlug}/prompts`
+
+export const mediaPromptsApi = {
+  list: (projectId: string, mediaSlug: string) => api.get<MediaPrompt[]>(promptBase(projectId, mediaSlug)),
+  create: (projectId: string, mediaSlug: string, input: { slug: string; type: MediaPromptType; title: string; body: string; model: string; asset_refs: string[] }) =>
+    api.post<MediaPrompt>(promptBase(projectId, mediaSlug), input),
+  update: (projectId: string, mediaSlug: string, type: MediaPromptType, slug: string, input: Partial<Pick<MediaPrompt, "title" | "body" | "model" | "status" | "asset_refs" | "result_refs">>) =>
+    api.patch<MediaPrompt>(`${promptBase(projectId, mediaSlug)}/${type}/${slug}`, input),
+  remove: (projectId: string, mediaSlug: string, type: MediaPromptType, slug: string) =>
+    api.delete<void>(`${promptBase(projectId, mediaSlug)}/${type}/${slug}`),
 }

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { useAuthStore } from "@/features/auth/useAuthStore"
 import { UpdateModal } from "@/shared/UpdateModal"
+import { AppFooter } from "@/shared/AppFooter"
 import { useLayoutUpdate } from "./useLayoutUpdate"
 import { BentoMenu } from "./BentoMenu"
 import { NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
@@ -81,9 +82,19 @@ export function Layout() {
   return (
     <>
       {isCockpitRoute ? (
-        <main className="h-[100dvh] overflow-hidden bg-[#080b11]">
-          <Outlet />
-        </main>
+        <div className="flex h-[100dvh] min-h-0 flex-col bg-[#080b11]">
+          <main className="min-h-0 flex-1 overflow-hidden">
+            <Outlet />
+          </main>
+          <AppFooter
+            version={version}
+            commit={commit}
+            updateBehind={updateBehind}
+            moduleUpdateCount={moduleUpdateCount}
+            isAdmin={role === "admin"}
+            onUpdateClick={openUpdateModal}
+          />
+        </div>
       ) : (
         <ActiveLayout chrome={chrome} />
       )}


### PR DESCRIPTION
## Was\n- dateibasiertes Media-Projektmodell mit sicherer CRUD-API\n- Markdown-Promptarchiv mit Cockpit-Overlay\n- echte Asset-Workspace-Ansicht mit Atelier-Vorschauen\n- globalen Update-Footer auf Cockpit-Routen wiederhergestellt\n\n## Verifikation\n- PYTHONPATH=core/src python -m pytest core/tests/test_media_projects_api.py core/tests/test_media_prompts_api.py -q (6 passed)\n- frontend: npm run build\n- frontend: npm run check:cockpit-offline\n- git diff --check\n