### PR TITLE
fix(projects): expose create action in cockpit topbar

### DIFF
--- a/docs/specs/legacy-vs-cockpit-gap-audit.md
+++ b/docs/specs/legacy-vs-cockpit-gap-audit.md
@@ -1,0 +1,82 @@
+# Funktionsaudit: altes Design vs. Cockpits
+
+Stand: 2026-07-11
+
+## Methode
+
+Verglichen wurden die letzte vollständige alte Projektverwaltung vor Commit `c34dc397` (`ProjectsPage`, `ProjectForm`, `ProjectList`) sowie die alte Navigations-/Feature-Inventur mit dem aktuellen Cockpit auf `main` nach PR #282. Bewertet wird Funktionalität, nicht optische Gleichheit.
+
+## Blocker / sofort benötigt
+
+### Projekte
+
+1. **Projekt anlegen war unsichtbar.** Ursache: Aktion lag im ausgeblendeten `CockpitShell`-Header. Fix PR #283 setzt die Aktion in die sichtbare Topbar.
+2. **Direkte Projekt-Basisbearbeitung fehlt im Cockpit.** Altes Design erlaubte Name, Beschreibung und Status direkt zu ändern und zu speichern. Neu gibt es nur Beschreibung als Text und einen Link zur alten Settings-Seite.
+3. **Projekt löschen fehlt im Cockpit.** Altes `SettingsTab` hatte den kontrollierten Delete-Flow.
+4. **Mitgliederverwaltung fehlt im Cockpit.** Altes `OverviewTab`/`MemberManager` konnte Mitglieder pflegen.
+5. **Server-/VM-/Container-Zuordnung fehlt.** Altes `ServersTab` war vollständig eingebettet.
+6. **Mount-/SMB-Verwaltung fehlt.** Altes `MountsTab` war vollständig eingebettet.
+7. **Audit-Log fehlt.** Altes `AuditTab` zeigte sensible Projektänderungen.
+
+Diese Funktionen existieren weiterhin unter `/settings/projects`, sind im neuen Cockpit aber nicht als Arbeitsflächen vorhanden. Der Settings-Link verhindert Totalverlust, ist jedoch keine vollständige Migration.
+
+## Wichtig / weiterhin benötigt
+
+### Projekte
+
+- Projekt-Notizen bearbeiten (`NotesTab`).
+- Projektstatistik: Sessions, Nachrichten, Tokens, letzte Aktivität (`StatsTab`).
+- Vollständige Sessionliste mit Status/Zeit statt nur Chat-Dropdown (`SessionsTab`).
+- Spezialisten-/Allowed-Specialists-Verwaltung (`SpecialistsTab`).
+- Vollständige Git-Verwaltung: Clone/Init/Remote/Delete und Repo-Details. Das Cockpit zeigt Status/Tree und lokale Gitea-Aktionen, aber nicht sämtliche alte Detailflows.
+- Projekt-MCP, Plugin-Overrides, Samba und weitere Projekt-Overrides aus `SettingsTab` als Cockpit-Overlay statt nur externer Link.
+
+### Globales Cockpit
+
+- Topbar ist auf schmalen Bildschirmen nicht responsiv; Navigation und Aktionen können überlaufen.
+- Profil-Button ist kein echtes Avatar-/Logout-Menü wie im alten Layout.
+- Globales Bento-/Apps-Menü fehlt auf Cockpit-Routen. Module sind daher nur über direkte Cockpit-/Settings-Links erreichbar.
+- Kontextbezogene Hilfe nutzt nur `/help`; das frühere `HelpButton`-Verhalten fehlt.
+- Breadcrumb/Seitentitel und Theme-Navigation sind durch die Cockpit-Topbar ersetzt; funktional okay, aber tiefe Unterseiten sind weniger klar.
+
+### Buddy
+
+- Reaction-Video-Registry und echte lokale Reaktionsvideos fehlen.
+- Wühlkiste fehlt.
+- Widget-Reihenfolge und Sichtbarkeit sind nicht vollständig serverseitig steuerbar.
+- Musik/Games/Scratchpad sind gegenüber alten echten Modulen teilweise nur reduziert eingebunden beziehungsweise verlinkt.
+
+### Media
+
+- Arbeitsfähiger Slice ist vorhanden. Für komfortable Nutzung fehlen dennoch Drag-and-drop auf der Timeline, audiovisuelle Playhead-Vorschau, Export-Job im Hintergrund mit Abbruch/Fortschritt und Asset-Picker statt manueller Asset-ID-Eingabe.
+- Regie-Datenmodell enthält Shot-Felder, das aktuelle kompakte UI bearbeitet aber noch nicht alle Felder vollständig.
+- Generatoren bleiben bewusst im Atelier; das ist sicher, aber der Übergang von Regie/Prompt zu einem bestätigten Generatorjob braucht noch ein explizites Gate.
+
+### Vault
+
+- Vault ist weiterhin hauptsächlich ein sicherer Hub/Link-Sammlung, kein vollständiger Container.
+- Vault Lock/Timeout fehlt.
+- Dokumenten-Upload, PDF-Text, OCR und FTS fehlen.
+- Sensibler Chat-Kontext-Guard und Audit fehlen.
+
+### Admin
+
+- Admin-Cockpit bündelt Links/Status, ersetzt aber noch nicht alle alten Verwaltungsseiten.
+- Kompakte Logs, Rollenmodell, Integrationsübersicht und Admin-Chat-Kontext fehlen.
+
+## Nice-to-have
+
+- Cockpit-Aktionen und Labels vollständig i18n-fähig machen.
+- Mobile Panels als Drawer statt nur Desktop-Grid.
+- Empty-/Error-States vereinheitlichen.
+- Overlay-Fokusfalle und Fokus-Rückgabe ergänzen.
+- Cockpit-Topbar mit Avatar, Update-Indikator und Apps-Menü konsolidieren; Footer-Update bleibt als sichere Rückfallebene.
+
+## Empfohlene Reihenfolge
+
+1. Projektverwaltung vollständig ins Cockpit zurückholen: Basis, Mitglieder, Löschen, Server, Mounts, Audit, Notizen, Stats.
+2. Globale Cockpit-Topbar funktional vervollständigen: responsive Nav, Apps/Bento, Avatar/Logout, kontextuelle Hilfe.
+3. Media-UX härten: Asset-Picker, Preview, Drag-and-drop, Hintergrundexport.
+4. Buddy echte Widgets/Reaction Assets.
+5. Vault-Sicherheits- und Dokumentenschicht.
+6. Admin-Konsolidierung.

--- a/frontend/src/features/cockpit/CockpitTopbar.tsx
+++ b/frontend/src/features/cockpit/CockpitTopbar.tsx
@@ -1,9 +1,11 @@
+import type { ReactNode } from "react"
 import { CockpitButton } from "./CockpitButton"
 
 interface Props {
   active: "projects" | "buddy" | "media" | "vault" | "admin"
   context?: string
   action?: { label: string; path: string }
+  extraActions?: ReactNode
 }
 
 const nav = [
@@ -15,7 +17,7 @@ const nav = [
   { id: "help", label: "Hilfe", path: "/help" },
 ] as const
 
-export function CockpitTopbar({ active, context, action }: Props) {
+export function CockpitTopbar({ active, context, action, extraActions }: Props) {
   return (
     <header className="flex h-[58px] shrink-0 items-center gap-[18px] border-b border-[#2a364b] bg-gradient-to-b from-[#131b2a] to-[#0e1420] px-[18px]">
       <button onClick={() => window.open("/projects", "_self")} className="font-black tracking-[-0.03em] text-[#e8eef8]">HydraHive</button>
@@ -37,6 +39,7 @@ export function CockpitTopbar({ active, context, action }: Props) {
       </nav>
       <div className="flex-1" />
       {context ? <div className="hidden text-xs text-[#8d9ab0] lg:block">{context}</div> : null}
+      {extraActions}
       {action ? <CockpitButton onClick={() => window.open(action.path, "_self")}>{action.label}</CockpitButton> : null}
       <CockpitButton onClick={() => window.open("/settings", "_self")}>Profil</CockpitButton>
     </header>

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -98,6 +98,7 @@ export function ProjectCockpitPage() {
       <CockpitTopbar
         active="projects"
         context={activeProject ? `Projekt bleibt gespeichert: ${activeProject.name}` : undefined}
+        extraActions={<CockpitButton tone="primary" onClick={() => setCreateProjectOpen(true)}>+ Neues Projekt</CockpitButton>}
         action={{ label: "Projekt-Einstellungen", path: "/settings/projects" }}
       />
       {error && <div className="mx-[10px] mt-[10px] shrink-0 rounded-[4px] border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{error}</div>}


### PR DESCRIPTION
## Ursache\nProjectCockpitPage setzt hideHeader, der vorhandene + Neues Projekt-Button lag aber im ausgeblendeten CockpitShell-Header.\n\n## Fix\n- CockpitTopbar unterstützt zusätzliche Aktionen\n- + Neues Projekt ist auf /projects dauerhaft sichtbar\n\n## Tests\n- npm run build\n- npm run check:cockpit-offline\n- git diff --check\n