### PR TITLE
fix(projects): move actions out of topbar

### DIFF
--- a/docs/specs/project-actions-location.md
+++ b/docs/specs/project-actions-location.md
@@ -1,0 +1,31 @@
+# Project-Cockpit: Fachaktionen aus der globalen Topbar verlagern
+
+## Was
+
+Alle projektspezifischen Aktionen werden aus der globalen Cockpit-Topbar entfernt und in das linke Panel **Projekt** verlagert. Dort werden sie in **Projekt**, **Verwalten** und **Auswerten** gegliedert.
+
+## Warum
+
+Die globale Topbar ist mit zehn Projektaktionen überladen und vermischt globale Navigation mit fachlicher Projektverwaltung. Die Aktionen sollen dort liegen, wo das aktive Projekt ausgewählt und beschrieben wird.
+
+## Wie
+
+- Die globale Topbar erhält im Project-Cockpit keine `extraActions` und keinen zusätzlichen Projekt-Einstellungen-Sprung mehr.
+- Im geöffneten Projektpanel stehen direkt **Neues Projekt** und **Projekt bearbeiten**.
+- **Verwalten** enthält Zugriff, Server, Mounts, Git und Integrationen.
+- **Auswerten** enthält Statistiken, Sessions und Audit.
+- Gruppen sind kompakt auf- und zuklappbar; alle vorhandenen Handler und Overlays werden weiterverwendet.
+- Ohne aktives Projekt bleiben projektgebundene Aktionen deaktiviert.
+
+## Akzeptanzkriterien
+
+- Die globale Topbar zeigt keine projektspezifischen Fachaktionen mehr.
+- Alle bisherigen Projektaktionen bleiben im linken Projektpanel erreichbar.
+- Aktionen sind klar in Verwalten und Auswerten gruppiert.
+- Neues Projekt bleibt prominent erreichbar.
+- Build und Cockpit-Offline-Guard sind grün.
+
+## Nicht enthalten
+
+- Änderungen an den Verwaltungs-Overlays oder APIs.
+- Apps-, Avatar-, Logout- oder Hilfe-Funktionen der globalen Topbar.

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -27,6 +27,7 @@ import { ProjectGitTreePanel } from "./project/ProjectGitTreePanel"
 import { ProjectWorkspacePanel } from "./project/ProjectWorkspacePanel"
 import { ProjectSelector } from "./project/ProjectSelector"
 import { ProjectTasksPanel } from "./project/ProjectTasksPanel"
+import { ProjectActionGroups } from "./project/ProjectActionGroups"
 
 export function ProjectCockpitPage() {
   const prefs = useUserPreferences()
@@ -113,8 +114,6 @@ export function ProjectCockpitPage() {
       <CockpitTopbar
         active="projects"
         context={activeProject ? `Projekt bleibt gespeichert: ${activeProject.name}` : undefined}
-        extraActions={<><CockpitButton onClick={() => setIntegrationsOpen(true)} disabled={!activeProject}>Integrationen</CockpitButton><CockpitButton onClick={() => setGitOpen(true)} disabled={!activeProject}>Git verwalten</CockpitButton><CockpitButton onClick={() => setInsightView("stats")} disabled={!activeProject}>Statistiken</CockpitButton><CockpitButton onClick={() => setInsightView("sessions")} disabled={!activeProject}>Sessions</CockpitButton><CockpitButton onClick={() => setInsightView("audit")} disabled={!activeProject}>Audit</CockpitButton><CockpitButton onClick={() => setMountsOpen(true)} disabled={!activeProject}>Mounts</CockpitButton><CockpitButton onClick={() => setServersOpen(true)} disabled={!activeProject}>Server</CockpitButton><CockpitButton onClick={() => setAccessOpen(true)} disabled={!activeProject}>Zugriff</CockpitButton><CockpitButton onClick={() => setDetailsOpen(true)} disabled={!activeProject}>Projekt bearbeiten</CockpitButton><CockpitButton tone="primary" onClick={() => setCreateProjectOpen(true)}>+ Neues Projekt</CockpitButton></>}
-        action={{ label: "Projekt-Einstellungen", path: "/settings/projects" }}
       />
       {error && <div className="mx-[10px] mt-[10px] shrink-0 rounded-[4px] border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{error}</div>}
       <div className="grid min-h-0 flex-1 gap-[10px] overflow-hidden p-[10px] xl:grid-cols-[270px_minmax(420px,1fr)_360px]">
@@ -128,6 +127,17 @@ export function ProjectCockpitPage() {
           >
             <ProjectSelector projects={projects} activeProjectId={activeProjectId} loading={loading || prefs.loading} onPick={pickProject} />
             {activeProject && <p className="mt-3 line-clamp-3 text-xs text-[#8d9ab0]">{activeProject.description || "Keine Beschreibung."}</p>}
+            <ProjectActionGroups
+              disabled={!activeProject}
+              onCreate={() => setCreateProjectOpen(true)}
+              onEdit={() => setDetailsOpen(true)}
+              onAccess={() => setAccessOpen(true)}
+              onServers={() => setServersOpen(true)}
+              onMounts={() => setMountsOpen(true)}
+              onGit={() => setGitOpen(true)}
+              onIntegrations={() => setIntegrationsOpen(true)}
+              onInsight={setInsightView}
+            />
           </CollapsibleCockpitPanel>
 
           <CollapsibleCockpitPanel

--- a/frontend/src/features/cockpit/project/ProjectActionGroups.tsx
+++ b/frontend/src/features/cockpit/project/ProjectActionGroups.tsx
@@ -1,0 +1,49 @@
+import { useState, type ButtonHTMLAttributes, type ReactNode } from "react"
+import { ChevronDown, ChevronRight } from "lucide-react"
+import { CockpitButton } from "../CockpitButton"
+import type { ProjectInsightView } from "./ProjectInsightsOverlay"
+
+interface Props {
+  disabled: boolean
+  onCreate: () => void
+  onEdit: () => void
+  onAccess: () => void
+  onServers: () => void
+  onMounts: () => void
+  onGit: () => void
+  onIntegrations: () => void
+  onInsight: (view: ProjectInsightView) => void
+}
+
+export function ProjectActionGroups({ disabled, onCreate, onEdit, onAccess, onServers, onMounts, onGit, onIntegrations, onInsight }: Props) {
+  return <div className="mt-3 space-y-2 border-t border-[#2a364b] pt-3">
+    <div className="grid grid-cols-2 gap-2">
+      <CockpitButton tone="primary" onClick={onCreate}>+ Neues Projekt</CockpitButton>
+      <CockpitButton onClick={onEdit} disabled={disabled}>Bearbeiten</CockpitButton>
+    </div>
+    <ActionGroup title="Verwalten">
+      <ActionButton onClick={onAccess} disabled={disabled}>Zugriff</ActionButton>
+      <ActionButton onClick={onServers} disabled={disabled}>Server</ActionButton>
+      <ActionButton onClick={onMounts} disabled={disabled}>Mounts</ActionButton>
+      <ActionButton onClick={onGit} disabled={disabled}>Git</ActionButton>
+      <ActionButton onClick={onIntegrations} disabled={disabled}>Integrationen</ActionButton>
+    </ActionGroup>
+    <ActionGroup title="Auswerten">
+      <ActionButton onClick={() => onInsight("stats")} disabled={disabled}>Statistiken</ActionButton>
+      <ActionButton onClick={() => onInsight("sessions")} disabled={disabled}>Sessions</ActionButton>
+      <ActionButton onClick={() => onInsight("audit")} disabled={disabled}>Audit</ActionButton>
+    </ActionGroup>
+  </div>
+}
+
+function ActionGroup({ title, children }: { title: string; children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  return <div className="rounded-[4px] border border-[#2a364b] bg-[#101724]">
+    <button type="button" onClick={() => setOpen((value) => !value)} aria-expanded={open} className="flex w-full items-center justify-between px-3 py-2 text-left text-xs font-semibold text-[#b8c4d8] hover:bg-white/[3%]"><span>{title}</span>{open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}</button>
+    {open && <div className="grid grid-cols-2 gap-1 border-t border-[#2a364b] p-2">{children}</div>}
+  </div>
+}
+
+function ActionButton(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button {...props} className="rounded-[4px] border border-transparent px-2 py-1.5 text-left text-xs text-[#8d9ab0] hover:border-[#2a364b] hover:bg-[#172133] hover:text-[#e8eef8] disabled:cursor-not-allowed disabled:opacity-40" />
+}


### PR DESCRIPTION
## Was\n- Projekt-Fachaktionen aus globaler Topbar entfernt\n- Neues Projekt und Bearbeiten direkt im Projektpanel\n- Zugriff, Server, Mounts, Git und Integrationen unter Verwalten\n- Statistiken, Sessions und Audit unter Auswerten\n\n## Tests\n- npm run build\n- npm run check:cockpit-offline\n- git diff --check\n