### PR TITLE
feat(cockpit): add global apps and user menus

### DIFF
--- a/docs/specs/cockpit-global-menus.md
+++ b/docs/specs/cockpit-global-menus.md
@@ -1,0 +1,41 @@
+# Cockpit-Chrome P2: Apps, Benutzer und kontextuelle Hilfe
+
+## Was
+
+Die globale Cockpit-Topbar erhält drei klar getrennte globale Funktionen: einen App-Launcher, kontextuelle Seitenhilfe und ein Benutzer-Menü mit Profil, Einstellungen und Logout.
+
+## Warum
+
+Cockpit-Routen umgehen das normale Layout und verlieren dadurch zentrale globale Funktionen. Der bisherige generische Profil-Button ist kein echtes Benutzer-Menü und die globale Hilfe führt nur auf eine allgemeine Seite statt zur passenden Cockpit-Hilfe.
+
+## Wie
+
+- **Apps** öffnet einen kompakten Launcher aus der bestehenden zentralen Navigation und berücksichtigt Rollen.
+- **Hilfe** öffnet den vorhandenen `HelpDrawer` mit einem zum Cockpit passenden Thema: Projekte → projects, Buddy → buddy, Media → atelier, Vault → patientenakte, Admin → system.
+- Das Benutzer-Menü zeigt Benutzername und Rolle und bietet Profil, Einstellungen und Logout.
+- Logout verwendet ausschließlich den bestehenden Auth-Store und navigiert anschließend zu `/login`.
+- Auf kleinen und mittleren Displays liegen dieselben globalen Funktionen im responsiven Cockpit-Menü.
+- Es entstehen keine neuen Auth-, Navigations- oder Hilfe-APIs.
+
+## Implementierungsreihenfolge
+
+1. App-Launcher und Benutzer-Menü als kleine Cockpit-Komponenten erstellen.
+2. Kontextuelle Hilfe in die Topbar einhängen.
+3. Desktop- und responsive Menüdarstellung verbinden.
+4. Build, Offline-Guard, Security- und Architekturprüfung ausführen.
+
+## Akzeptanzkriterien
+
+- Apps sind aus jedem Cockpit erreichbar und nach Rolle gefiltert.
+- Profil und Einstellungen sind erreichbar.
+- Logout entfernt die bestehende Session und führt zu `/login`.
+- Hilfe öffnet den vorhandenen Drawer mit passendem Thema.
+- Desktop-Topbar bleibt ruhig und enthält nur globale Funktionen.
+- Responsive Menüführung bleibt funktionsfähig.
+- Update-Footer und Cockpit-Inhalte bleiben unverändert.
+
+## Nicht enthalten
+
+- Neue Apps oder Navigationsziele.
+- Änderungen am Auth-Backend.
+- Neue Hilfe-Engine oder neue Backend-Endpunkte.

--- a/frontend/src/features/cockpit/CockpitAppsMenu.tsx
+++ b/frontend/src/features/cockpit/CockpitAppsMenu.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react"
+import { Grid3X3, X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { NAV_GROUPS, visibleItems } from "@/shared/nav-config"
+
+const go = (path: string) => window.open(path, "_self")
+
+export function CockpitAppsMenu({ compact = false }: { compact?: boolean }) {
+  const [open, setOpen] = useState(false)
+  const role = useAuthStore((state) => state.role)
+  const { t } = useTranslation("nav")
+  const items = visibleItems(role).filter((item) => item.path !== "/help")
+
+  return <div className="relative">
+    <button onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-controls="cockpit-apps-menu" className={compact ? "flex w-full items-center gap-2 rounded-[4px] border border-[#2a364b] bg-[#172133] px-3 py-2 text-xs font-bold text-[#e8eef8]" : "rounded-[4px] border border-[#2a364b] bg-[#172133] p-2 text-[#e8eef8] hover:border-[#46617f]"} title="Apps"><Grid3X3 size={16} />{compact && <span>Apps</span>}</button>
+    {open && <><button className="fixed inset-0 z-[119] cursor-default bg-black/40" aria-label="Apps schließen" onClick={() => setOpen(false)} /><section id="cockpit-apps-menu" role="dialog" aria-label="Apps" className="fixed inset-x-3 top-[68px] z-[120] max-h-[calc(100dvh-80px)] overflow-y-auto rounded-[6px] border border-[#2a364b] bg-[#101724] p-4 shadow-2xl sm:absolute sm:inset-x-auto sm:right-0 sm:top-11 sm:w-[520px]"><header className="mb-3 flex items-center justify-between"><div><p className="text-xs uppercase tracking-wider text-[#718097]">HydraHive</p><h2 className="font-semibold text-[#e8eef8]">Apps</h2></div><button onClick={() => setOpen(false)} className="rounded p-2 text-[#8d9ab0] hover:bg-white/5 hover:text-white" aria-label="Apps schließen"><X size={17} /></button></header>{NAV_GROUPS.map((group) => { const grouped = items.filter((item) => item.group === group.key); if (!grouped.length) return null; return <div key={group.key} className="mb-4 last:mb-0"><p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-[#718097]">{t(group.labelKey)}</p><div className="grid grid-cols-2 gap-1 sm:grid-cols-3">{grouped.map((item) => <button key={item.path} onClick={() => go(item.path)} className="flex min-w-0 items-center gap-2 rounded-[4px] border border-transparent px-2 py-2 text-left text-xs text-[#b8c4d8] hover:border-[#2a364b] hover:bg-[#172133] hover:text-white"><item.icon size={14} className="shrink-0 text-[#69d7ff]" /><span className="truncate">{t(item.labelKey)}</span></button>)}</div></div> })}</section></>}
+  </div>
+}

--- a/frontend/src/features/cockpit/CockpitTopbar.tsx
+++ b/frontend/src/features/cockpit/CockpitTopbar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
 import { Menu, MoreHorizontal, X } from "lucide-react"
+import { HelpButton } from "@/i18n/HelpButton"
+import type { HelpTopic } from "@/i18n/help/loader"
 import { CockpitButton } from "./CockpitButton"
+import { CockpitAppsMenu } from "./CockpitAppsMenu"
+import { CockpitUserMenu } from "./CockpitUserMenu"
 
 interface Props {
   active: "projects" | "buddy" | "media" | "vault" | "admin"
@@ -19,6 +23,13 @@ const nav = [
 ] as const
 
 const go = (path: string) => window.open(path, "_self")
+const HELP_TOPICS: Record<Props["active"], HelpTopic> = {
+  projects: "projects",
+  buddy: "buddy",
+  media: "atelier",
+  vault: "patientenakte",
+  admin: "system",
+}
 
 export function CockpitTopbar({ active, context, action, extraActions }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
@@ -54,7 +65,9 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
       <div className="hidden items-center gap-2 2xl:flex">
         {extraActions}
         {action ? <CockpitButton onClick={() => go(action.path)}>{action.label}</CockpitButton> : null}
-        <CockpitButton onClick={() => go("/settings")}>Profil</CockpitButton>
+        <CockpitAppsMenu />
+        <HelpButton topic={HELP_TOPICS[active]} />
+        <CockpitUserMenu />
       </div>
       <button
         ref={triggerRef}
@@ -79,7 +92,9 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
           <div className="grid gap-2 border-t border-[#2a364b] pt-4 sm:border-0 sm:pt-0">
             <div className="contents [&>button]:w-full">{extraActions}</div>
             {action ? <CockpitButton onClick={() => go(action.path)}>{action.label}</CockpitButton> : null}
-            <CockpitButton onClick={() => go("/settings")}>Profil</CockpitButton>
+            <CockpitAppsMenu compact />
+            <HelpButton topic={HELP_TOPICS[active]} className="w-full justify-center" />
+            <CockpitUserMenu compact />
           </div>
         </section>
       </>}

--- a/frontend/src/features/cockpit/CockpitUserMenu.tsx
+++ b/frontend/src/features/cockpit/CockpitUserMenu.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react"
+import { LogOut, Settings, User, X } from "lucide-react"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+
+const go = (path: string) => window.open(path, "_self")
+
+export function CockpitUserMenu({ compact = false }: { compact?: boolean }) {
+  const [open, setOpen] = useState(false)
+  const username = useAuthStore((state) => state.username) ?? "User"
+  const role = useAuthStore((state) => state.role) ?? "user"
+  const logout = useAuthStore((state) => state.logout)
+
+  function signOut() {
+    logout()
+    go("/login")
+  }
+
+  return <div className="relative">
+    <button onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-controls="cockpit-user-menu" className={compact ? "flex w-full items-center gap-2 rounded-[4px] border border-[#2a364b] bg-[#172133] px-3 py-2 text-left text-xs font-bold text-[#e8eef8]" : "flex items-center gap-2 rounded-[4px] border border-[#2a364b] bg-[#172133] px-2.5 py-1.5 text-xs font-bold text-[#e8eef8] hover:border-[#46617f]"}><span className="grid h-6 w-6 place-items-center rounded-full bg-[#27354c] text-[#69d7ff]"><User size={13} /></span><span className="max-w-24 truncate">{username}</span></button>
+    {open && <><button className="fixed inset-0 z-[119] cursor-default" aria-label="Benutzermenü schließen" onClick={() => setOpen(false)} /><section id="cockpit-user-menu" role="menu" className="fixed inset-x-3 top-[68px] z-[120] rounded-[6px] border border-[#2a364b] bg-[#101724] p-2 shadow-2xl sm:absolute sm:inset-x-auto sm:right-0 sm:top-11 sm:w-64"><header className="flex items-center justify-between border-b border-[#2a364b] px-2 py-2"><div className="min-w-0"><p className="truncate text-sm font-semibold text-[#e8eef8]">{username}</p><p className="text-[10px] uppercase tracking-wider text-[#718097]">{role}</p></div><button onClick={() => setOpen(false)} className="rounded p-1.5 text-[#8d9ab0] hover:bg-white/5 hover:text-white" aria-label="Benutzermenü schließen"><X size={15} /></button></header><button role="menuitem" onClick={() => go("/profile")} className="mt-1 flex w-full items-center gap-2 rounded px-2 py-2 text-left text-xs text-[#b8c4d8] hover:bg-[#172133] hover:text-white"><User size={14} />Profil</button><button role="menuitem" onClick={() => go("/settings")} className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-xs text-[#b8c4d8] hover:bg-[#172133] hover:text-white"><Settings size={14} />Einstellungen</button><button role="menuitem" onClick={signOut} className="flex w-full items-center gap-2 rounded px-2 py-2 text-left text-xs text-rose-300 hover:bg-rose-500/10"><LogOut size={14} />Abmelden</button></section></>}
+  </div>
+}


### PR DESCRIPTION
## Was\n- rollenbasierter App-Launcher aus zentraler Navigation\n- kontextuelle Hilfe über vorhandenen HelpDrawer\n- Benutzername und Rolle\n- Profil, Einstellungen und Logout\n- responsive Integration in Cockpit-Menü\n\n## Sicherheit\n- Logout verwendet bestehenden Auth-Store\n- keine neuen Auth- oder Backend-Endpunkte\n- keine Secrets im Code\n\n## Tests\n- npm run build\n- npm run check:cockpit-offline\n- git diff --check\n- Secret-Scan\n