### PR TITLE
feat(media): add visual shot asset editing

### DIFF
--- a/docs/specs/media-ux-p2-1.md
+++ b/docs/specs/media-ux-p2-1.md
@@ -1,0 +1,37 @@
+# Media UX P2.1: Asset-Picker und vollständige Shot-Bearbeitung
+
+## Ziel
+
+Der Regieeditor bearbeitet alle bereits persistierten Shot-Felder und ersetzt manuelle ID-Eingaben durch visuelle Mehrfachauswahl aus den persistenten Media-Asset-Referenzen.
+
+## Dateien
+
+- `frontend/src/features/cockpit/MediaScreenplayOverlay.tsx` — lädt Drehbuch und Referenzen, verwaltet Akte/Szenen/Shots.
+- `frontend/src/features/cockpit/media/MediaShotEditor.tsx` — vollständiges Shot-Formular.
+- `frontend/src/features/cockpit/media/MediaAssetPicker.tsx` — visuelle, typgefilterte Mehrfachauswahl.
+- `frontend/src/features/cockpit/media/shotUpdates.ts` — immutable Shot-Updates und normalisierte Auswahl.
+- `frontend/src/features/cockpit/media/shotUpdates.test.ts` — Update- und Auswahltests.
+
+## Implementierungsreihenfolge
+
+1. Pure Update-Helfer mit Tests für Feldänderung, Asset-Toggle und Charakter-/Asset-Trennung erstellen.
+2. Visuellen Picker für persistente Referenzen erstellen; nicht verfügbare Einträge deaktivieren.
+3. Vollständigen Shot-Editor für Titel, Beschreibung, Dauer, Kamera, Charaktere, Assets und Dialog erstellen.
+4. Regieoverlay auf Komponenten aufteilen und bestehende Screenplay-API unverändert nutzen.
+5. Tests, Build, Offline-Guard und Architekturprüfung ausführen.
+
+## Akzeptanzkriterien
+
+- Alle Shot-Felder sind editierbar und werden über die bestehende Screenplay-API gespeichert.
+- Dauer ist auf 0,1 bis 3600 Sekunden begrenzt.
+- Charaktere werden aus Referenzen vom Typ `character` gewählt.
+- Allgemeine Assets schließen Charakterreferenzen aus.
+- Nicht verfügbare Referenzen bleiben sichtbar, sind aber nicht neu auswählbar.
+- Bereits ausgewählte, später nicht verfügbare IDs gehen beim Bearbeiten nicht still verloren.
+- Es gibt keine manuelle Asset-ID-Eingabe und keine Generierung.
+
+## Nicht enthalten
+
+- Generatorstart oder Batch-Generierung.
+- Timeline-Drag-and-drop oder Export.
+- Neue Backend-Endpunkte oder Datenmigrationen.

--- a/frontend/src/features/cockpit/MediaScreenplayOverlay.tsx
+++ b/frontend/src/features/cockpit/MediaScreenplayOverlay.tsx
@@ -1,24 +1,49 @@
 import { useEffect, useState } from "react"
+import { mediaAssetsApi, type MediaAssetReference } from "./mediaProjectsApi"
+import { mediaWorkspaceApi, type MediaScreenplay, type MediaShot } from "./mediaWorkspaceApi"
+import { MediaShotEditor } from "./media/MediaShotEditor"
+import { updateShot } from "./media/shotUpdates"
 import { CockpitButton } from "./CockpitButton"
 import { CockpitSectionLabel } from "./CockpitPanel"
-import { mediaWorkspaceApi, type MediaScreenplay } from "./mediaWorkspaceApi"
 
 const empty: MediaScreenplay = { title: "", logline: "", acts: [] }
-const id = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+const makeId = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+const newShot = (): MediaShot => ({ id: makeId("shot"), title: "Neuer Shot", description: "", duration: 5, camera: "", character_ids: [], asset_ids: [], dialogue: "" })
 
 export function MediaScreenplayOverlay({ projectId, mediaSlug, onClose }: { projectId: string; mediaSlug: string; onClose: () => void }) {
   const [value, setValue] = useState<MediaScreenplay>(empty)
+  const [references, setReferences] = useState<MediaAssetReference[]>([])
   const [message, setMessage] = useState("Lädt…")
-  useEffect(() => { mediaWorkspaceApi.getScreenplay(projectId, mediaSlug).then((data) => { setValue(data); setMessage("Regie geladen") }).catch(() => setMessage("Regie nicht erreichbar")) }, [projectId, mediaSlug])
-  const save = async () => { try { setValue(await mediaWorkspaceApi.saveScreenplay(projectId, mediaSlug, value)); setMessage("Gespeichert") } catch { setMessage("Speichern fehlgeschlagen") } }
-  const updateAct = (ai: number, title: string) => setValue((old) => ({ ...old, acts: old.acts.map((act, index) => index === ai ? { ...act, title } : act) }))
+
+  useEffect(() => {
+    Promise.all([mediaWorkspaceApi.getScreenplay(projectId, mediaSlug), mediaAssetsApi.list(projectId, mediaSlug)])
+      .then(([screenplay, assets]) => { setValue(screenplay); setReferences(assets); setMessage("Regie und Referenzen geladen") })
+      .catch(() => setMessage("Regie oder Referenzen nicht erreichbar"))
+  }, [projectId, mediaSlug])
+
+  async function save() {
+    try { setValue(await mediaWorkspaceApi.saveScreenplay(projectId, mediaSlug, value)); setMessage("Gespeichert") }
+    catch { setMessage("Speichern fehlgeschlagen") }
+  }
+
+  function updateScene(ai: number, si: number, changes: { title?: string; description?: string }) {
+    setValue((old) => ({ ...old, acts: old.acts.map((act, x) => x === ai ? { ...act, scenes: act.scenes.map((scene, y) => y === si ? { ...scene, ...changes } : scene) } : act) }))
+  }
+
+  function removeShot(ai: number, si: number, hi: number) {
+    setValue((old) => ({ ...old, acts: old.acts.map((act, x) => x === ai ? { ...act, scenes: act.scenes.map((scene, y) => y === si ? { ...scene, shots: scene.shots.filter((_, z) => z !== hi) } : scene) } : act) }))
+  }
 
   return <div className="fixed inset-0 z-50 grid place-items-center bg-black/80 p-4" role="dialog" aria-modal="true" aria-labelledby="screenplay-title">
-    <section className="flex h-[min(820px,94dvh)] w-full max-w-6xl flex-col overflow-hidden rounded-[4px] border border-[#46617f] bg-[#151c2b]">
+    <section className="flex h-[min(860px,95dvh)] w-full max-w-7xl flex-col overflow-hidden rounded-[4px] border border-[#46617f] bg-[#151c2b]">
       <header className="flex items-center justify-between border-b border-[#2a364b] p-4"><div><CockpitSectionLabel>Regie</CockpitSectionLabel><h2 id="screenplay-title" className="text-lg font-semibold text-[#e8eef8]">Akt → Szene → Shot</h2></div><div className="flex gap-2"><CockpitButton onClick={onClose}>Schließen</CockpitButton><CockpitButton tone="primary" onClick={save}>Speichern</CockpitButton></div></header>
-      <div className="grid gap-3 border-b border-[#2a364b] p-4 md:grid-cols-2"><label className="text-xs text-[#8d9ab0]">Filmtitel<input value={value.title} onChange={(e) => setValue({ ...value, title: e.target.value })} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-[#e8eef8]" /></label><label className="text-xs text-[#8d9ab0]">Logline<input value={value.logline} onChange={(e) => setValue({ ...value, logline: e.target.value })} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-[#e8eef8]" /></label></div>
-      <main className="min-h-0 flex-1 overflow-y-auto p-4"><div className="space-y-4">{value.acts.map((act, ai) => <section key={act.id} className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3"><div className="flex gap-2"><input value={act.title} onChange={(e) => updateAct(ai, e.target.value)} className="min-w-0 flex-1 bg-transparent font-semibold text-[#e8eef8] outline-none" /><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.filter((_, index) => index !== ai) }))}>Akt löschen</CockpitButton><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.map((a, index) => index === ai ? { ...a, scenes: [...a.scenes, { id: id("scene"), title: "Neue Szene", description: "", shots: [] }] } : a) }))}>Szene +</CockpitButton></div><div className="mt-3 space-y-3">{act.scenes.map((scene, si) => <article key={scene.id} className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-3"><input value={scene.title} onChange={(e) => setValue((old) => ({ ...old, acts: old.acts.map((a, x) => x === ai ? { ...a, scenes: a.scenes.map((s, y) => y === si ? { ...s, title: e.target.value } : s) } : a) }))} className="w-full bg-transparent text-sm font-semibold text-[#e8eef8] outline-none" /><textarea value={scene.description} onChange={(e) => setValue((old) => ({ ...old, acts: old.acts.map((a, x) => x === ai ? { ...a, scenes: a.scenes.map((s, y) => y === si ? { ...s, description: e.target.value } : s) } : a) }))} placeholder="Szenenbeschreibung" className="mt-2 w-full rounded-[3px] border border-[#2a364b] bg-[#111827] p-2 text-xs text-[#d7deea]" /><div className="mt-2 flex justify-end"><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.map((a, x) => x === ai ? { ...a, scenes: a.scenes.map((s, y) => y === si ? { ...s, shots: [...s.shots, { id: id("shot"), title: "Neuer Shot", description: "", duration: 5, camera: "", character_ids: [], asset_ids: [], dialogue: "" }] } : s) } : a) }))}>Shot +</CockpitButton></div><div className="mt-2 grid gap-2 md:grid-cols-2">{scene.shots.map((shot, hi) => <div key={shot.id} className="rounded-[3px] border border-[#2a364b] bg-[#151c2b] p-2"><input value={shot.title} onChange={(e) => setValue((old) => ({ ...old, acts: old.acts.map((a, x) => x === ai ? { ...a, scenes: a.scenes.map((s, y) => y === si ? { ...s, shots: s.shots.map((h, z) => z === hi ? { ...h, title: e.target.value } : h) } : s) } : a) }))} className="w-full bg-transparent text-sm text-[#e8eef8] outline-none" /><p className="mt-1 text-[10px] text-[#8d9ab0]">{shot.duration}s · {shot.camera || "Kamera offen"}</p></div>)}</div></article>)}</div></section>)}</div><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: [...old.acts, { id: id("act"), title: `Akt ${old.acts.length + 1}`, scenes: [] }] }))} className="mt-4">Akt hinzufügen</CockpitButton></main>
+      <div className="grid gap-3 border-b border-[#2a364b] p-4 md:grid-cols-2"><TextField label="Filmtitel" value={value.title} onChange={(title) => setValue({ ...value, title })} /><TextField label="Logline" value={value.logline} onChange={(logline) => setValue({ ...value, logline })} /></div>
+      <main className="min-h-0 flex-1 overflow-y-auto p-4"><div className="space-y-4">{value.acts.map((act, ai) => <section key={act.id} className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3"><div className="flex flex-wrap gap-2"><input value={act.title} onChange={(event) => setValue((old) => ({ ...old, acts: old.acts.map((item, index) => index === ai ? { ...item, title: event.target.value } : item) }))} className="min-w-48 flex-1 bg-transparent font-semibold text-[#e8eef8] outline-none" /><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.filter((_, index) => index !== ai) }))}>Akt löschen</CockpitButton><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.map((item, index) => index === ai ? { ...item, scenes: [...item.scenes, { id: makeId("scene"), title: "Neue Szene", description: "", shots: [] }] } : item) }))}>Szene +</CockpitButton></div><div className="mt-3 space-y-3">{act.scenes.map((scene, si) => <article key={scene.id} className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-3"><input value={scene.title} onChange={(event) => updateScene(ai, si, { title: event.target.value })} className="w-full bg-transparent text-sm font-semibold text-[#e8eef8] outline-none" /><textarea value={scene.description} onChange={(event) => updateScene(ai, si, { description: event.target.value })} placeholder="Szenenbeschreibung" className="mt-2 w-full rounded-[3px] border border-[#2a364b] bg-[#111827] p-2 text-xs text-[#d7deea]" /><div className="my-3 flex justify-end"><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: old.acts.map((item, x) => x === ai ? { ...item, scenes: item.scenes.map((entry, y) => y === si ? { ...entry, shots: [...entry.shots, newShot()] } : entry) } : item) }))}>Shot +</CockpitButton></div><div className="grid gap-3 xl:grid-cols-2">{scene.shots.map((shot, hi) => <MediaShotEditor key={shot.id} shot={shot} references={references} onChange={(changes) => setValue((old) => updateShot(old, ai, si, hi, changes))} onRemove={() => removeShot(ai, si, hi)} />)}</div></article>)}</div></section>)}</div><CockpitButton onClick={() => setValue((old) => ({ ...old, acts: [...old.acts, { id: makeId("act"), title: `Akt ${old.acts.length + 1}`, scenes: [] }] }))} className="mt-4">Akt hinzufügen</CockpitButton></main>
       <footer className="border-t border-[#2a364b] p-3 text-xs text-[#8d9ab0]">{message} · Keine Generierung wird durch Speichern gestartet.</footer>
     </section>
   </div>
+}
+
+function TextField({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return <label className="text-xs text-[#8d9ab0]">{label}<input value={value} onChange={(event) => onChange(event.target.value)} className="mt-1 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] p-2 text-[#e8eef8]" /></label>
 }

--- a/frontend/src/features/cockpit/media/MediaAssetPicker.tsx
+++ b/frontend/src/features/cockpit/media/MediaAssetPicker.tsx
@@ -1,0 +1,23 @@
+import { Check, ImageOff } from "lucide-react"
+import type { MediaAssetReference } from "../mediaProjectsApi"
+
+export function MediaAssetPicker({ assets, selected, onToggle, emptyLabel }: {
+  assets: MediaAssetReference[]
+  selected: string[]
+  onToggle: (id: string) => void
+  emptyLabel: string
+}) {
+  const unknown = selected.filter((id) => !assets.some((asset) => asset.id === id))
+  if (!assets.length && !unknown.length) return <p className="rounded-[3px] border border-dashed border-[#2a364b] p-3 text-xs text-[#718097]">{emptyLabel}</p>
+
+  return <div className="grid gap-2 sm:grid-cols-2">
+    {assets.map((asset) => {
+      const active = selected.includes(asset.id)
+      return <button key={asset.id} type="button" disabled={!asset.available && !active} onClick={() => onToggle(asset.id)} className={`flex min-w-0 items-start gap-2 rounded-[3px] border p-2 text-left ${active ? "border-[#69d7ff] bg-[#163047]" : "border-[#2a364b] bg-[#101724]"} disabled:cursor-not-allowed disabled:opacity-50`}>
+        <span className={`mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded border ${active ? "border-[#69d7ff] bg-[#69d7ff] text-[#08111c]" : "border-[#46617f]"}`}>{active && <Check size={11} />}</span>
+        <span className="min-w-0"><strong className="block truncate text-xs text-[#e8eef8]">{asset.label}</strong><span className="block truncate text-[10px] text-[#718097]">{asset.kind} · {asset.rel_path}</span>{!asset.available && <span className="mt-1 flex items-center gap-1 text-[10px] text-amber-300"><ImageOff size={10} />Quelle nicht verfügbar</span>}</span>
+      </button>
+    })}
+    {unknown.map((id) => <button key={id} type="button" onClick={() => onToggle(id)} className="flex items-start gap-2 rounded-[3px] border border-amber-500/30 bg-amber-500/5 p-2 text-left"><span className="mt-0.5 grid h-4 w-4 shrink-0 place-items-center rounded border border-[#69d7ff] bg-[#69d7ff] text-[#08111c]"><Check size={11} /></span><span className="min-w-0"><strong className="block truncate text-xs text-amber-200">Unbekannte Referenz</strong><span className="block truncate text-[10px] text-[#718097]">{id} · zum Entfernen anklicken</span></span></button>)}
+  </div>
+}

--- a/frontend/src/features/cockpit/media/MediaShotEditor.tsx
+++ b/frontend/src/features/cockpit/media/MediaShotEditor.tsx
@@ -1,0 +1,24 @@
+import type { MediaAssetReference } from "../mediaProjectsApi"
+import type { MediaShot } from "../mediaWorkspaceApi"
+import { MediaAssetPicker } from "./MediaAssetPicker"
+import { clampDuration, toggleReference } from "./shotUpdates"
+
+export function MediaShotEditor({ shot, references, onChange, onRemove }: {
+  shot: MediaShot
+  references: MediaAssetReference[]
+  onChange: (changes: Partial<MediaShot>) => void
+  onRemove: () => void
+}) {
+  const characters = references.filter((asset) => asset.kind === "character")
+  const assets = references.filter((asset) => asset.kind !== "character")
+  const field = "w-full rounded-[3px] border border-[#2a364b] bg-[#101724] px-2 py-1.5 text-xs text-[#e8eef8] outline-none focus:border-[#46617f]"
+
+  return <article className="space-y-3 rounded-[4px] border border-[#2a364b] bg-[#151c2b] p-3">
+    <div className="flex gap-2"><label className="min-w-0 flex-1 text-[10px] uppercase tracking-wider text-[#718097]">Shot-Titel<input value={shot.title} onChange={(event) => onChange({ title: event.target.value })} className={`${field} mt-1 text-sm font-semibold`} /></label><button type="button" onClick={onRemove} className="self-end rounded-[3px] border border-rose-500/30 px-2 py-1.5 text-xs text-rose-300 hover:bg-rose-500/10">Entfernen</button></div>
+    <label className="block text-[10px] uppercase tracking-wider text-[#718097]">Beschreibung<textarea value={shot.description} onChange={(event) => onChange({ description: event.target.value })} rows={3} className={`${field} mt-1 resize-y`} /></label>
+    <div className="grid gap-2 sm:grid-cols-[130px_1fr]"><label className="text-[10px] uppercase tracking-wider text-[#718097]">Dauer (Sek.)<input type="number" min="0.1" max="3600" step="0.1" value={shot.duration} onChange={(event) => onChange({ duration: clampDuration(event.target.valueAsNumber) })} className={`${field} mt-1`} /></label><label className="text-[10px] uppercase tracking-wider text-[#718097]">Kamera<input value={shot.camera} onChange={(event) => onChange({ camera: event.target.value })} placeholder="z. B. Totale, langsamer Dolly-in" className={`${field} mt-1`} /></label></div>
+    <label className="block text-[10px] uppercase tracking-wider text-[#718097]">Dialog / Voiceover<textarea value={shot.dialogue} onChange={(event) => onChange({ dialogue: event.target.value })} rows={2} className={`${field} mt-1 resize-y`} /></label>
+    <fieldset><legend className="mb-2 text-[10px] uppercase tracking-wider text-[#718097]">Charaktere</legend><MediaAssetPicker assets={characters} selected={shot.character_ids} onToggle={(id) => onChange({ character_ids: toggleReference(shot.character_ids, id) })} emptyLabel="Noch keine Charakter-Referenzen im Media-Projekt." /></fieldset>
+    <fieldset><legend className="mb-2 text-[10px] uppercase tracking-wider text-[#718097]">Assets</legend><MediaAssetPicker assets={assets} selected={shot.asset_ids} onToggle={(id) => onChange({ asset_ids: toggleReference(shot.asset_ids, id) })} emptyLabel="Noch keine Asset-Referenzen im Media-Projekt." /></fieldset>
+  </article>
+}

--- a/frontend/src/features/cockpit/media/shotUpdates.ts
+++ b/frontend/src/features/cockpit/media/shotUpdates.ts
@@ -1,0 +1,29 @@
+import type { MediaScreenplay, MediaShot } from "../mediaWorkspaceApi"
+
+export function updateShot(
+  screenplay: MediaScreenplay,
+  actIndex: number,
+  sceneIndex: number,
+  shotIndex: number,
+  changes: Partial<MediaShot>,
+): MediaScreenplay {
+  return {
+    ...screenplay,
+    acts: screenplay.acts.map((act, ai) => ai !== actIndex ? act : {
+      ...act,
+      scenes: act.scenes.map((scene, si) => si !== sceneIndex ? scene : {
+        ...scene,
+        shots: scene.shots.map((shot, hi) => hi === shotIndex ? { ...shot, ...changes } : shot),
+      }),
+    }),
+  }
+}
+
+export function toggleReference(ids: string[], id: string): string[] {
+  return ids.includes(id) ? ids.filter((value) => value !== id) : [...ids, id]
+}
+
+export function clampDuration(value: number): number {
+  if (!Number.isFinite(value)) return 5
+  return Math.min(3600, Math.max(0.1, value))
+}


### PR DESCRIPTION
## Was\n- vollständige Bearbeitung aller Shot-Felder\n- visueller Mehrfach-Picker für persistente Charakter- und Asset-Referenzen\n- nicht verfügbare und unbekannte Referenzen sicher behandeln\n- Dauer auf Backend-Grenzen begrenzen\n- keine Generierung oder automatischer Jobstart\n\n## Tests\n- npm run build\n- npm run check:cockpit-offline\n- pytest -q tests/test_media_workspace_api.py\n- git diff --check\n