### PR TITLE
fix(projects): persist agent reasoning depth

### DIFF
--- a/core/src/hydrahive/agents/_config_utils.py
+++ b/core/src/hydrahive/agents/_config_utils.py
@@ -36,6 +36,7 @@ def normalize(cfg: dict) -> dict:
     cfg.setdefault("temperature", DEFAULT_TEMPERATURE)
     cfg.setdefault("max_tokens", DEFAULT_MAX_TOKENS)
     cfg.setdefault("thinking_budget", DEFAULT_THINKING_BUDGET)
+    cfg.setdefault("reasoning_effort", "")
     cfg.setdefault("mcp_servers", [])
     cfg.setdefault("fallback_models", [])
     cfg.setdefault("updated_at", cfg.get("created_at", ""))

--- a/core/src/hydrahive/agents/config.py
+++ b/core/src/hydrahive/agents/config.py
@@ -30,6 +30,7 @@ def create(
     temperature: float,
     max_tokens: int,
     thinking_budget: int,
+    reasoning_effort: str = "",
     mcp_servers: list[str] | None = None,
     fallback_models: list[str] | None = None,
     project_id: str | None = None,
@@ -55,6 +56,7 @@ def create(
         "tools": list(tools), "mcp_servers": list(mcp_servers or []),
         "description": description, "temperature": float(temperature),
         "max_tokens": int(max_tokens), "thinking_budget": int(thinking_budget),
+        "reasoning_effort": reasoning_effort,
         "status": "active", "created_at": now_iso(), "updated_at": now_iso(),
         "external": bool(external),
     }

--- a/core/src/hydrahive/api/routes/_agent_schemas.py
+++ b/core/src/hydrahive/api/routes/_agent_schemas.py
@@ -17,6 +17,7 @@ class AgentCreate(BaseModel):
     temperature: float = 0.7
     max_tokens: int = DEFAULT_MAX_TOKENS
     thinking_budget: int = 0
+    reasoning_effort: str = ""
     mcp_servers: list[str] = []
     fallback_models: list[str] = []
     project_id: str | None = None
@@ -42,6 +43,7 @@ class AgentUpdate(BaseModel):
     temperature: float | None = None
     max_tokens: int | None = None
     thinking_budget: int | None = None
+    reasoning_effort: str | None = None
     mcp_servers: list[str] | None = None
     fallback_models: list[str] | None = None
     domain: str | None = None

--- a/core/src/hydrahive/api/routes/agents.py
+++ b/core/src/hydrahive/api/routes/agents.py
@@ -104,6 +104,7 @@ def create_agent(
             temperature=req.temperature,
             max_tokens=req.max_tokens,
             thinking_budget=req.thinking_budget,
+            reasoning_effort=req.reasoning_effort,
             mcp_servers=req.mcp_servers,
             fallback_models=req.fallback_models,
             project_id=req.project_id,

--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -176,7 +176,8 @@ async def run(
         # Re-Read aus DB damit ein Switch ohne Server-Restart sofort greift.
         _fresh_session = sessions_db.get(session_id)
         model_override = (_fresh_session.metadata or {}).get("model_override") if _fresh_session else None
-        reasoning_effort = (_fresh_session.metadata or {}).get("reasoning_effort") if _fresh_session else None
+        session_effort = (_fresh_session.metadata or {}).get("reasoning_effort") if _fresh_session else None
+        reasoning_effort = session_effort or agent.get("reasoning_effort") or None
         primary_model = model_override or agent["llm_model"]
 
         result: IterationResult | None = None

--- a/core/tests/test_agent_reasoning_default.py
+++ b/core/tests/test_agent_reasoning_default.py
@@ -1,0 +1,21 @@
+from hydrahive.agents._config_utils import normalize
+
+
+def test_old_agent_gets_empty_reasoning_default():
+    assert normalize({})["reasoning_effort"] == ""
+
+
+def test_agent_reasoning_default_is_preserved():
+    assert normalize({"reasoning_effort": "high"})["reasoning_effort"] == "high"
+
+
+def test_session_override_priority_expression():
+    agent = {"reasoning_effort": "high"}
+    session_effort = "low"
+    assert (session_effort or agent.get("reasoning_effort") or None) == "low"
+
+
+def test_agent_default_used_without_session_override():
+    agent = {"reasoning_effort": "high"}
+    session_effort = None
+    assert (session_effort or agent.get("reasoning_effort") or None) == "high"

--- a/docs/plans/project-agent-reasoning-effort.md
+++ b/docs/plans/project-agent-reasoning-effort.md
@@ -1,0 +1,30 @@
+# Plan: Projekt-Agent Reasoning-Tiefe
+
+## Ziel
+
+Projekt-Agenten besitzen einen persistenten `reasoning_effort`-Standard. Das Projekt-Cockpit speichert Modell und Tiefe gemeinsam; der Runner nutzt Session-Override vor Agenten-Standard.
+
+## Dateien
+
+- `core/src/hydrahive/api/routes/_agent_schemas.py` — Agentenfeld akzeptieren.
+- `core/src/hydrahive/agents/config.py` und `_config_utils.py` — Feld speichern/backfillen.
+- `core/src/hydrahive/runner/runner.py` — Priorität auflösen.
+- `frontend/src/features/agents/types.ts`, `chat/types.ts` — Feld typisieren.
+- `frontend/src/features/cockpit/project/ProjectAiSettingsPanel.tsx` — echte Werte, Dirty-State und Save.
+- `core/tests/test_agent_reasoning_default.py` — Priorität und Capability validieren.
+
+## Implementierungsreihenfolge
+
+1. Agent-Schema und Normalisierung um `reasoning_effort` ergänzen.
+2. Auflösung Session > Agent in eine testbare Helper-Funktion ziehen und testen.
+3. Projektpanel an Capability-API anbinden und Modell + Tiefe gemeinsam speichern.
+4. Build, fokussierte Tests und Ruff ausführen.
+5. Commit, PR, CI und Merge.
+
+## Akzeptanzkriterien
+
+- Tiefenänderung aktiviert Speichern.
+- Reload zeigt gespeicherten Agenten-Standard.
+- Session-Override gewinnt; ohne Override greift Agenten-Standard.
+- Modellwechsel aktualisiert erlaubte Tiefen.
+- Kein unterstütztes Modell zeigt keine Attrappen-Auswahl.

--- a/frontend/src/features/agents/types.ts
+++ b/frontend/src/features/agents/types.ts
@@ -12,6 +12,7 @@ export interface Agent {
   temperature: number
   max_tokens: number
   thinking_budget: number
+  reasoning_effort?: string
   status: "active" | "disabled"
   created_at: string
   updated_at: string
@@ -85,6 +86,7 @@ export interface AgentCreate {
   temperature: number
   max_tokens: number
   thinking_budget: number
+  reasoning_effort?: string
   mcp_servers: string[]
   fallback_models: string[]
   owner?: string | null

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -45,6 +45,7 @@ export interface AgentBrief {
   name: string
   type: string
   llm_model: string
+  reasoning_effort?: string
   status: string
   is_buddy?: boolean
 }

--- a/frontend/src/features/cockpit/project/ProjectAiSettingsPanel.tsx
+++ b/frontend/src/features/cockpit/project/ProjectAiSettingsPanel.tsx
@@ -2,131 +2,63 @@ import { useEffect, useMemo, useState } from "react"
 import { Check, RefreshCw } from "lucide-react"
 import { agentsApi } from "@/features/agents/api"
 import { llmModelsApi } from "@/features/llm/api"
+import { useEffortLevels } from "@/features/llm/effort"
 import type { AgentBrief } from "@/features/chat/types"
 import { CockpitButton } from "../CockpitButton"
 
-interface Props {
-  agentId: string | null
-  agents: AgentBrief[]
-  onAgentChanged: (agent: AgentBrief) => void
-}
+interface Props { agentId: string | null; agents: AgentBrief[]; onAgentChanged: (agent: AgentBrief) => void }
 
 export function ProjectAiSettingsPanel({ agentId, agents, onAgentChanged }: Props) {
   const agent = useMemo(() => agents.find((item) => item.id === agentId) ?? null, [agents, agentId])
   const [models, setModels] = useState<string[]>([])
   const [model, setModel] = useState("")
-  const [depth, setDepth] = useState("normal")
+  const [depth, setDepth] = useState("")
   const [loadingModels, setLoadingModels] = useState(false)
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const effortLevels = useEffortLevels(model)
 
   useEffect(() => {
     setModel(agent?.llm_model ?? "")
-    setMessage(null)
-    setError(null)
-  }, [agent?.id, agent?.llm_model])
+    setDepth(agent?.reasoning_effort ?? "")
+    setMessage(null); setError(null)
+  }, [agent?.id, agent?.llm_model, agent?.reasoning_effort])
 
   useEffect(() => {
-    let alive = true
-    setLoadingModels(true)
-    llmModelsApi.byModality("chat")
-      .then((result) => {
-        if (!alive) return
-        setModels(result.models.map((item) => item.id))
-      })
-      .catch(() => { if (alive) setModels([]) })
-      .finally(() => { if (alive) setLoadingModels(false) })
+    let alive = true; setLoadingModels(true)
+    llmModelsApi.byModality("chat").then((result) => { if (alive) setModels(result.models.map((item) => item.id)) })
+      .catch(() => { if (alive) setModels([]) }).finally(() => { if (alive) setLoadingModels(false) })
     return () => { alive = false }
   }, [])
 
-  const availableModels = useMemo(() => {
-    const seen = new Set<string>()
-    const next: string[] = []
-    for (const item of [agent?.llm_model, ...models]) {
-      if (!item || seen.has(item)) continue
-      seen.add(item)
-      next.push(item)
-    }
-    return next
-  }, [agent?.llm_model, models])
+  useEffect(() => {
+    if (depth && effortLevels.length > 0 && !effortLevels.includes(depth)) setDepth("")
+  }, [depth, effortLevels])
+
+  const availableModels = useMemo(() => Array.from(new Set([agent?.llm_model, ...models].filter(Boolean) as string[])), [agent?.llm_model, models])
+  const dirty = Boolean(agent && model.trim() && (model.trim() !== agent.llm_model || depth !== (agent.reasoning_effort ?? "")))
 
   async function save() {
     if (!agent || !model.trim()) return
-    setSaving(true)
-    setMessage(null)
-    setError(null)
+    setSaving(true); setMessage(null); setError(null)
     try {
-      const updated = await agentsApi.update(agent.id, { llm_model: model.trim() })
-      onAgentChanged({
-        id: updated.id,
-        name: updated.name,
-        type: updated.type,
-        llm_model: updated.llm_model,
-        status: updated.status,
-        is_buddy: false,
-      })
-      setModel(updated.llm_model)
-      setMessage("Modell gespeichert. Neue Chat-Aufrufe nutzen dieses LLM.")
-    } catch {
-      setError("Modell konnte nicht gespeichert werden.")
-    } finally {
-      setSaving(false)
-    }
+      const updated = await agentsApi.update(agent.id, { llm_model: model.trim(), reasoning_effort: depth })
+      const next = { ...agent, llm_model: updated.llm_model, reasoning_effort: updated.reasoning_effort ?? "" }
+      onAgentChanged(next); setModel(next.llm_model); setDepth(next.reasoning_effort ?? "")
+      setMessage("Modell und Thinking-Tiefe gespeichert. Neue Aufrufe nutzen diese Vorgabe.")
+    } catch { setError("KI-Einstellungen konnten nicht gespeichert werden.") }
+    finally { setSaving(false) }
   }
 
-  const dirty = Boolean(agent && model.trim() && model.trim() !== agent.llm_model)
-
-  return (
-    <div className="space-y-3">
-      {!agent ? (
-        <p className="text-xs text-[#8d9ab0]">Kein Projekt-Agent ausgewählt.</p>
-      ) : (
-        <>
-          <div>
-            <label className="mb-1 block text-xs text-[#8d9ab0]">Modell</label>
-            <select
-              value={model}
-              disabled={loadingModels || availableModels.length === 0}
-              onChange={(event) => setModel(event.target.value)}
-              className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm font-semibold text-[#e8eef8] outline-none hover:border-[#46617f] disabled:opacity-50"
-            >
-              {loadingModels ? <option value={model}>Lade Modelle…</option> : null}
-              {!loadingModels && availableModels.length === 0 ? <option value="">Keine Modelle konfiguriert</option> : null}
-              {availableModels.map((item) => <option key={item} value={item}>{item}</option>)}
-            </select>
-            <p className="mt-1 text-[11px] text-[#8d9ab0]">
-              Aktuell am Projekt-Agenten: <span className="font-mono text-[#69d7ff]">{agent.llm_model}</span>
-            </p>
-          </div>
-
-          <div>
-            <label className="mb-1 block text-xs text-[#8d9ab0]">Tiefe</label>
-            <select
-              value={depth}
-              onChange={(event) => setDepth(event.target.value)}
-              className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm font-semibold text-[#e8eef8] outline-none hover:border-[#46617f]"
-            >
-              <option value="fast">Schnell</option>
-              <option value="normal">Normal</option>
-              <option value="deep">Tief</option>
-              <option value="max">Maximal</option>
-            </select>
-            <p className="mt-1 text-[11px] text-[#8d9ab0]">Tiefe ist vorbereitet; gespeichert wird aktuell das Modell.</p>
-          </div>
-
-          {error ? <p className="text-xs text-rose-300">{error}</p> : null}
-          {message ? <p className="text-xs text-emerald-300">{message}</p> : null}
-
-          <div className="flex gap-2">
-            <CockpitButton tone="primary" disabled={!dirty || saving} onClick={() => void save()}>
-              {saving ? <RefreshCw size={12} className="mr-1 inline animate-spin" /> : <Check size={12} className="mr-1 inline" />}
-              Speichern
-            </CockpitButton>
-            <CockpitButton disabled={!dirty || saving} onClick={() => setModel(agent.llm_model)}>Zurücksetzen</CockpitButton>
-          </div>
-        </>
-      )}
-    </div>
-  )
+  return <div className="space-y-3">
+    {!agent ? <p className="text-xs text-[#8d9ab0]">Kein Projekt-Agent ausgewählt.</p> : <>
+      <div><label className="mb-1 block text-xs text-[#8d9ab0]">Modell</label><select value={model} disabled={loadingModels || !availableModels.length} onChange={(event) => setModel(event.target.value)} className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm font-semibold text-[#e8eef8] outline-none hover:border-[#46617f] disabled:opacity-50">{loadingModels && <option value={model}>Lade Modelle…</option>}{availableModels.map((item) => <option key={item} value={item}>{item}</option>)}</select><p className="mt-1 text-[11px] text-[#8d9ab0]">Aktuell: <span className="font-mono text-[#69d7ff]">{agent.llm_model}</span></p></div>
+      <div><label className="mb-1 block text-xs text-[#8d9ab0]">Thinking-Tiefe</label><select value={depth} disabled={!effortLevels.length} onChange={(event) => setDepth(event.target.value)} className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm font-semibold text-[#e8eef8] outline-none hover:border-[#46617f] disabled:opacity-50"><option value="">Modellstandard</option>{effortLevels.map((level) => <option key={level} value={level}>{effortLabel(level)}</option>)}</select><p className="mt-1 text-[11px] text-[#8d9ab0]">Standard für den Projekt-Agenten. Eine Session-Auswahl hat Vorrang.</p></div>
+      {error && <p className="text-xs text-rose-300">{error}</p>}{message && <p className="text-xs text-emerald-300">{message}</p>}
+      <div className="flex gap-2"><CockpitButton tone="primary" disabled={!dirty || saving} onClick={() => void save()}>{saving ? <RefreshCw size={12} className="mr-1 inline animate-spin" /> : <Check size={12} className="mr-1 inline" />}Speichern</CockpitButton><CockpitButton disabled={!dirty || saving} onClick={() => { setModel(agent.llm_model); setDepth(agent.reasoning_effort ?? "") }}>Zurücksetzen</CockpitButton></div>
+    </>}
+  </div>
 }
+
+function effortLabel(level: string) { return ({ low: "Low", medium: "Medium", high: "High", xhigh: "Extra High", max: "Max", ultra: "Ultra" } as Record<string, string>)[level] ?? level }


### PR DESCRIPTION
## Fix
- Projekt-KI-Panel zeigt echte modellabhängige Tiefen
- Tiefenänderung aktiviert Speichern
- Modell und reasoning_effort werden am Projekt-Agenten gespeichert
- Runner-Priorität: Session-Override > Agenten-Standard > Modellstandard
- alte Agenten erhalten leeren kompatiblen Default

## Tests
- 34 fokussierte Backendtests grün
- Ruff grün
- Frontend-Build grün
- Cockpit-Guard grün