### PR TITLE
fix(codex): align context and preserve cache state

### DIFF
--- a/core/src/hydrahive/api/routes/sessions_messages.py
+++ b/core/src/hydrahive/api/routes/sessions_messages.py
@@ -110,10 +110,11 @@ def get_tokens(
     agent = agent_config.get(s.agent_id)
     history = messages_db.list_for_llm(session_id) if agent else []
     used = total_tokens(history)
-    window = context_window_for(agent["llm_model"]) if agent else 0
+    model = ((s.metadata or {}).get("model_override") or agent["llm_model"]) if agent else ""
+    window = context_window_for(model) if agent else 0
     threshold = (
         compact_threshold_tokens(
-            agent["llm_model"],
+            model,
             threshold_pct=int(agent.get("compact_threshold_pct", DEFAULT_COMPACT_THRESHOLD_PCT)),
             reserve_tokens=agent.get("compact_reserve_tokens"),
         )
@@ -124,7 +125,7 @@ def get_tokens(
     # max_turns (window-skaliert), nicht nur an der Token-Schwelle. Ohne diese
     # Zahl wirkt ein turn-getriggerter Compact „verfrüht" (Balken steht < 100%).
     max_turns = (
-        (agent.get("compact_max_turns") or default_max_turns(agent["llm_model"]))
+        (agent.get("compact_max_turns") or default_max_turns(model))
         if agent
         else 0
     )

--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -242,12 +242,14 @@ METADATA: dict[str, dict[str, Any]] = {
     # OpenAI Codex (ChatGPT Plus/Pro via OAuth — Responses-API).
     # Context-Windows: gpt-5-Klasse hat ~272k bei OpenAI dokumentiert; codex-Varianten
     # geben ~400k im Codex-Backend frei. Tool-Use bei allen Codex-Modellen.
-    "openai-codex/gpt-5.6-sol":          {"context_window": 1_000_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
-    "openai-codex/gpt-5.6-terra":        {"context_window": 1_000_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
-    "openai-codex/gpt-5.6-luna":         {"context_window": 1_000_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
-    "openai-codex/gpt-5.5":              {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
-    "openai-codex/gpt-5.4":              {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
-    "openai-codex/gpt-5.4-mini":         {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    # Codex OAuth uses the usable windows published by the Codex client, not the
+    # larger API-key windows (official openai/codex models.json).
+    "openai-codex/gpt-5.6-sol":          {"context_window": 372_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    "openai-codex/gpt-5.6-terra":        {"context_window": 372_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    "openai-codex/gpt-5.6-luna":         {"context_window": 372_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    "openai-codex/gpt-5.5":              {"context_window": 272_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    "openai-codex/gpt-5.4":              {"context_window": 272_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
+    "openai-codex/gpt-5.4-mini":         {"context_window": 272_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
     "openai-codex/gpt-5.3-codex":        {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
     "openai-codex/gpt-5.3-codex-spark":  {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},
     "openai-codex/gpt-5.2":              {"context_window": 400_000, "tool_use": True, "category": "code", "family": "gpt-codex"},

--- a/core/src/hydrahive/runner/_call.py
+++ b/core/src/hydrahive/runner/_call.py
@@ -46,6 +46,9 @@ _ALLOWED_FIELDS = {
     "tool_use": {"type", "id", "name", "input"},
     "thinking": {"type", "thinking", "signature"},
     "tool_result": {"type", "tool_use_id", "content", "is_error"},
+    # Opaque provider state only; never rendered. Required for stateless Codex
+    # reasoning continuity and prompt-cache efficiency.
+    "codex_reasoning": {"type", "encrypted_content", "model"},
 }
 
 

--- a/core/src/hydrahive/runner/_codex_convert.py
+++ b/core/src/hydrahive/runner/_codex_convert.py
@@ -35,7 +35,9 @@ def tools_to_codex(tools: list[dict]) -> list[dict]:
     return out
 
 
-def messages_to_codex(messages: list[dict], system_prompt: str = "") -> tuple[str, list[dict]]:
+def messages_to_codex(
+    messages: list[dict], system_prompt: str = "", model: str = "",
+) -> tuple[str, list[dict]]:
     """Anthropic-messages → (instructions, input_items).
 
     instructions: System-Prompt-String.
@@ -87,6 +89,10 @@ def messages_to_codex(messages: list[dict], system_prompt: str = "") -> tuple[st
                 btype = b.get("type")
                 if btype == "text":
                     text_parts.append(b.get("text", ""))
+                elif btype == "codex_reasoning" and b.get("model") == model:
+                    encrypted = b.get("encrypted_content")
+                    if encrypted:
+                        items.append({"type": "reasoning", "encrypted_content": encrypted})
                 elif btype == "tool_use":
                     tool_uses.append(b)
             joined = "".join(text_parts)

--- a/core/src/hydrahive/runner/_codex_provider.py
+++ b/core/src/hydrahive/runner/_codex_provider.py
@@ -36,8 +36,11 @@ _DEFAULT_INSTRUCTIONS = "You are a helpful assistant."
 def _build_payload(
     *, model: str, system_prompt: str, messages: list[dict], tools: list[dict],
     reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> dict:
-    instructions, input_items = messages_to_codex(messages, system_prompt)
+    instructions, input_items = messages_to_codex(
+        messages, system_prompt, model=f"openai-codex/{model}",
+    )
     payload: dict[str, Any] = {
         "model": model,
         "input": input_items,
@@ -48,6 +51,8 @@ def _build_payload(
         "parallel_tool_calls": True,
         "instructions": instructions or _DEFAULT_INSTRUCTIONS,
     }
+    if max_tokens:
+        payload["max_output_tokens"] = max_tokens
     if reasoning_effort:
         from hydrahive.llm.reasoning_effort import effort_levels_for_model
         if reasoning_effort in effort_levels_for_model(f"openai-codex/{model}"):
@@ -85,11 +90,12 @@ async def codex_stream(
     *, access_token: str, account_id: str, model: str,
     system_prompt: str, messages: list[dict], tools: list[dict],
     reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> AsyncIterator[dict]:
     """HH2-normalisierte Stream-Events aus Codex."""
     payload = _build_payload(
         model=model, system_prompt=system_prompt, messages=messages, tools=tools,
-        reasoning_effort=reasoning_effort,
+        reasoning_effort=reasoning_effort, max_tokens=max_tokens,
     )
     text_index: int | None = None
     fn_index: dict[str, int] = {}
@@ -98,6 +104,7 @@ async def codex_stream(
     fn_order: list[str] = []
     text_buf = ""
     usage_in = usage_out = cache_read = 0
+    reasoning_items: list[dict] = []
 
     yield {"type": "message_start"}
 
@@ -135,9 +142,20 @@ async def codex_stream(
                     text_buf += delta
                     yield {"type": "text_delta", "index": text_index, "text": delta}
 
-                elif t == "response.output_item.added":
+                elif t in ("response.output_item.added", "response.output_item.done"):
                     item = ev.get("item", {}) or {}
-                    if item.get("type") != "function_call":
+                    if item.get("type") == "reasoning":
+                        encrypted = item.get("encrypted_content")
+                        if encrypted and not any(
+                            block.get("encrypted_content") == encrypted for block in reasoning_items
+                        ):
+                            reasoning_items.append({
+                                "type": "codex_reasoning", "encrypted_content": encrypted,
+                                "model": f"openai-codex/{model}",
+                            })
+                        continue
+                    # Function calls are initialized on added; done would duplicate them.
+                    if t != "response.output_item.added" or item.get("type") != "function_call":
                         continue
                     item_id = item.get("id", "")
                     call_id = item.get("call_id", "") or item_id
@@ -179,7 +197,7 @@ async def codex_stream(
     if text_index is not None:
         yield {"type": "block_stop", "index": text_index}
 
-    blocks: list[dict] = []
+    blocks: list[dict] = list(reasoning_items)
     if text_buf:
         blocks.append({"type": "text", "text": text_buf})
     for fn_id in fn_order:
@@ -210,6 +228,7 @@ async def codex_call(
     *, access_token: str, account_id: str, model: str,
     system_prompt: str, messages: list[dict], tools: list[dict],
     reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> tuple[list[dict], str, dict[str, int]]:
     """Non-streaming Wrapper. Verbraucht codex_stream und gibt das finale
     message_stop-Event als (blocks, stop_reason, usage) zurück."""
@@ -217,7 +236,7 @@ async def codex_call(
     async for ev in codex_stream(
         access_token=access_token, account_id=account_id, model=model,
         system_prompt=system_prompt, messages=messages, tools=tools,
-        reasoning_effort=reasoning_effort,
+        reasoning_effort=reasoning_effort, max_tokens=max_tokens,
     ):
         if ev.get("type") == "message_stop":
             final = ev

--- a/core/src/hydrahive/runner/llm_bridge.py
+++ b/core/src/hydrahive/runner/llm_bridge.py
@@ -90,6 +90,7 @@ async def call_with_tools(
             messages=messages,
             tools=tools,
             reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
         )
 
     # Alle anderen Provider (OpenAI mit API-Key, NVIDIA, Groq, Mistral, Gemini,

--- a/core/src/hydrahive/runner/llm_bridge_stream.py
+++ b/core/src/hydrahive/runner/llm_bridge_stream.py
@@ -82,6 +82,7 @@ async def stream_with_tools(
             messages=messages,
             tools=tools,
             reasoning_effort=reasoning_effort,
+            max_tokens=max_tokens,
         ):
             yield ev
         return

--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -147,9 +147,17 @@ async def run(
     for iteration in range(max_iterations):
         yield IterationStart(iteration=iteration + 1)
 
+        # Session-Modell vor der Compaction auflösen, damit Fenster und LLM-Call
+        # garantiert dasselbe Modell verwenden.
+        _fresh_session = sessions_db.get(session_id)
+        model_override = (_fresh_session.metadata or {}).get("model_override") if _fresh_session else None
+        primary_model = model_override or agent["llm_model"]
+        session_effort = (_fresh_session.metadata or {}).get("reasoning_effort") if _fresh_session else None
+        reasoning_effort = session_effort or agent.get("reasoning_effort") or None
+
         history = []
         async for _item in prepare_history(
-            session_id, model=agent["llm_model"], compact_model=compact_model,
+            session_id, model=primary_model, compact_model=compact_model,
             compact_tool_limit=compact_tool_limit, compact_reserve=compact_reserve,
             compact_threshold_pct=compact_threshold_pct,
             compact_max_turns=compact_max_turns,
@@ -171,14 +179,6 @@ async def run(
             recall_cards=recall_cards,
             recall_search=recall_search,
         )
-
-        # Pro-Session-Override (Chat-Header-Switcher) gewinnt vor Agent-Default.
-        # Re-Read aus DB damit ein Switch ohne Server-Restart sofort greift.
-        _fresh_session = sessions_db.get(session_id)
-        model_override = (_fresh_session.metadata or {}).get("model_override") if _fresh_session else None
-        session_effort = (_fresh_session.metadata or {}).get("reasoning_effort") if _fresh_session else None
-        reasoning_effort = session_effort or agent.get("reasoning_effort") or None
-        primary_model = model_override or agent["llm_model"]
 
         result: IterationResult | None = None
         t0 = time.monotonic()

--- a/core/tests/test_codex_context.py
+++ b/core/tests/test_codex_context.py
@@ -1,0 +1,35 @@
+from hydrahive.compaction.tokens import context_window_for
+from hydrahive.runner._codex_convert import messages_to_codex
+from hydrahive.runner._codex_provider import _build_payload
+
+
+def test_codex_oauth_context_windows_match_official_client():
+    assert context_window_for("openai-codex/gpt-5.6-sol") == 372_000
+    assert context_window_for("openai-codex/gpt-5.6-terra") == 372_000
+    assert context_window_for("openai-codex/gpt-5.6-luna") == 372_000
+    assert context_window_for("openai-codex/gpt-5.5") == 272_000
+    assert context_window_for("openai-codex/gpt-5.4") == 272_000
+    assert context_window_for("openai-codex/gpt-5.4-mini") == 272_000
+
+
+def test_codex_payload_sets_output_limit():
+    payload = _build_payload(
+        model="gpt-5.6-sol", system_prompt="", messages=[], tools=[], max_tokens=32_000,
+    )
+    assert payload["max_output_tokens"] == 32_000
+
+
+def test_encrypted_reasoning_replayed_for_same_model_only():
+    messages = [{"role": "assistant", "content": [
+        {"type": "codex_reasoning", "encrypted_content": "opaque", "model": "openai-codex/gpt-5.6-sol"},
+        {"type": "text", "text": "done"},
+    ]}]
+    _, same = messages_to_codex(messages, model="openai-codex/gpt-5.6-sol")
+    _, switched = messages_to_codex(messages, model="openai-codex/gpt-5.5")
+    assert {"type": "reasoning", "encrypted_content": "opaque"} in same
+    assert all(item.get("type") != "reasoning" for item in switched)
+
+
+def test_codex_payload_requests_cache_replay_material():
+    payload = _build_payload(model="gpt-5.5", system_prompt="", messages=[], tools=[])
+    assert "reasoning.encrypted_content" in payload["include"]

--- a/docs/plans/codex-context-and-cache-fix.md
+++ b/docs/plans/codex-context-and-cache-fix.md
@@ -1,0 +1,34 @@
+# Plan: Codex Context und Cache
+
+## Ziel
+
+HydraHive verwendet für Codex-OAuth die offiziellen nutzbaren Kontextfenster, berechnet Compaction und Tokenmeter anhand des effektiven Session-Modells, übergibt das Output-Limit und bewahrt verschlüsselte Reasoning-Items für zustandslose Folgeaufrufe. OpenAIs automatischer Prompt-Cache wird korrekt gemessen.
+
+## Dateien
+
+- `core/src/hydrahive/llm/_catalog_data.py` — offizielle Codex-OAuth-Fenster.
+- `core/src/hydrahive/runner/runner.py` — effektives Modell vor Compaction bestimmen.
+- `core/src/hydrahive/api/routes/sessions_messages.py` — Tokenmeter nutzt Session-Override.
+- `core/src/hydrahive/runner/_codex_provider.py` — max_output_tokens, Reasoning-Items, cached_tokens.
+- `core/src/hydrahive/runner/_codex_convert.py` — verschlüsselten Reasoning-State modellgebunden replayen.
+- `core/src/hydrahive/runner/_call.py` — internen Codex-State sicher persistieren.
+- `frontend/src/features/agents/CompactionSection.tsx` — UI-Fallbacks an Backend-Defaults angleichen.
+- `core/tests/test_codex_context.py` — Kontext-, Payload-, Replay- und Override-Tests.
+
+## Reihenfolge
+
+1. Offizielle Context-Windows eintragen und testen.
+2. Effektives Session-Modell für Compaction/Tokenmeter verwenden.
+3. Codex-Payload um Output-Limit ergänzen.
+4. Reasoning-Items aus SSE erfassen, intern speichern und nur beim gleichen Codex-Modell replayen.
+5. Cache-Telemetrie über `usage.input_tokens_details.cached_tokens` verifizieren.
+6. UI-Fallbacks korrigieren; Tests, Ruff und Build ausführen.
+
+## Akzeptanzkriterien
+
+- GPT-5.6 nutzt 372k, GPT-5.5/5.4/5.4-mini 272k im Codex-OAuth-Pfad.
+- Session-Modelloverride bestimmt Tokenmeter und Compaction.
+- Codex erhält `max_output_tokens`.
+- Verschlüsseltes Reasoning wird gespeichert und beim selben Modell erneut gesendet, bei Modellwechsel nicht.
+- Cache-Hits erscheinen weiterhin als `cache_read_tokens`.
+- Keine Secrets oder entschlüsseltes internes Reasoning werden gespeichert.

--- a/frontend/src/features/agents/CompactionSection.tsx
+++ b/frontend/src/features/agents/CompactionSection.tsx
@@ -16,10 +16,10 @@ export function CompactionSection({ agent, models, onChange }: Props) {
   const compactModel = agent.compact_model ?? ""
   const toolLimit = agent.compact_tool_result_limit ?? 2000
   const reserve = agent.compact_reserve_tokens ?? 16384
-  const thresholdPct = agent.compact_threshold_pct ?? 100
+  const thresholdPct = agent.compact_threshold_pct ?? 75
   const maxTurns = agent.compact_max_turns ?? ""
   const liveMax = agent.tool_result_max_chars ?? 12000
-  const cacheTtl = agent.cache_ttl ?? "1h"
+  const cacheTtl = agent.cache_ttl ?? "5m"
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## Fix
- Codex-OAuth-Fenster laut offizieller openai/codex models.json: 372k für 5.6, 272k für 5.5/5.4
- Compaction und Tokenmeter nutzen effektives Session-Modell
- max_output_tokens wird an Codex gesendet
- verschlüsselte Reasoning-Items werden zustandslos und modellgebunden fortgeführt
- automatischer OpenAI Prompt Cache bleibt aktiv; cached_tokens werden als cache_read_tokens erfasst
- Compaction-UI-Fallbacks auf 75% und 5m korrigiert

## Sicherheit
- nur opakes encrypted_content gespeichert, kein Klartext-Reasoning
- Reasoning-State wird bei Modellwechsel nicht replayed

## Tests
- 45 fokussierte Tests grün
- Ruff grün
- Frontend-Build und Cockpit-Guard grün