### PR TITLE
feat(chat): persist project handovers across sessions

### DIFF
--- a/core/src/hydrahive/api/routes/buddy.py
+++ b/core/src/hydrahive/api/routes/buddy.py
@@ -29,9 +29,21 @@ def _user(auth: tuple[str, str]) -> str:
 
 
 @router.post("/clear")
-def buddy_clear(auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+async def buddy_clear(auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
     try:
-        return commands.clear_session(_user(auth))
+        username = _user(auth)
+        state = get_or_create_buddy(username)
+        if state.get("project_id"):
+            from hydrahive.agents import config as agent_config
+            from hydrahive.handover import create_for_session
+            agent = agent_config.get(state["agent_id"])
+            if agent:
+                await create_for_session(
+                    state["session_id"],
+                    model=agent.get("compact_model") or agent["llm_model"],
+                    tool_result_limit=agent.get("compact_tool_result_limit"),
+                )
+        return commands.clear_session(username)
     except LookupError as e:
         raise coded(status.HTTP_404_NOT_FOUND, "buddy_not_found", message=str(e))
 

--- a/core/src/hydrahive/api/routes/sessions.py
+++ b/core/src/hydrahive/api/routes/sessions.py
@@ -51,6 +51,29 @@ def create_session(
     return serialize_session(s)
 
 
+@router.post("/{session_id}/handover")
+async def create_handover(
+    session_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+) -> dict:
+    s = sessions_db.get(session_id)
+    if not s:
+        raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
+    check_owner(s, *auth)
+    if not s.project_id:
+        return {"written": False, "reason": "session_without_project"}
+    agent = agent_config.get(s.agent_id)
+    if not agent:
+        raise coded(status.HTTP_404_NOT_FOUND, "agent_not_found")
+    from hydrahive.handover import create_for_session
+    path = await create_for_session(
+        session_id,
+        model=agent.get("compact_model") or agent["llm_model"],
+        tool_result_limit=agent.get("compact_tool_result_limit"),
+    )
+    return {"written": path is not None}
+
+
 @router.get("/{session_id}")
 def get_session(
     session_id: str,

--- a/core/src/hydrahive/buddy/commands.py
+++ b/core/src/hydrahive/buddy/commands.py
@@ -26,9 +26,12 @@ def _require_buddy(username: str) -> dict:
 def clear_session(username: str) -> dict:
     """Beendet aktuelle Lifetime-Session, legt neue an. Alte bleibt in DB."""
     buddy = _require_buddy(username)
+    current = [s for s in sessions_db.list_for_user(username) if s.agent_id == buddy["id"]]
+    current.sort(key=lambda s: s.created_at, reverse=True)
+    project_id = current[0].project_id if current else None
     new_session = sessions_db.create(
         agent_id=buddy["id"], user_id=username,
-        title=f"{username}'s Buddy", project_id=None,
+        title=f"{username}'s Buddy", project_id=project_id,
     )
     return {
         "ok": True,

--- a/core/src/hydrahive/compaction/compactor.py
+++ b/core/src/hydrahive/compaction/compactor.py
@@ -228,6 +228,15 @@ async def compact_session(
                     snap["summary_chars"] = len(res.summary)
                     snap["summary_tokens_estimate"] = len(res.summary) // 4
                     rec = persist_compaction(session_id, kept, res.summary, ctx, dict(res.details), source=h.name)
+                    if session.project_id:
+                        try:
+                            from hydrahive.handover import write_project_handover
+                            write_project_handover(
+                                session.project_id, session_id=session_id,
+                                agent_id=session.agent_id, summary=res.summary,
+                            )
+                        except Exception as e:
+                            logger.warning("Projekt-Handover nach Compaction fehlgeschlagen: %s", e)
                     snap["compaction_message_id"] = rec.get("id")
                     snap["tokens_after_estimate"] = total_tokens(kept) + snap["summary_tokens_estimate"]
                     return rec
@@ -281,6 +290,15 @@ async def compact_session(
         )
         details = {"facts": facts, **files}
         record = persist_compaction(session_id, kept, summary_text, ctx, details, source=source)
+        if session.project_id:
+            try:
+                from hydrahive.handover import write_project_handover
+                write_project_handover(
+                    session.project_id, session_id=session_id,
+                    agent_id=session.agent_id, summary=summary_text,
+                )
+            except Exception as e:
+                logger.warning("Projekt-Handover nach Compaction fehlgeschlagen: %s", e)
         snap["compaction_message_id"] = record.get("id")
         snap["tokens_after_estimate"] = total_tokens(kept) + snap["summary_tokens_estimate"]
 

--- a/core/src/hydrahive/handover.py
+++ b/core/src/hydrahive/handover.py
@@ -1,0 +1,78 @@
+"""Persistenter Projekt-Arbeitszustand über Compactions und Sessions hinweg."""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hydrahive.compaction.redact import redact
+from hydrahive.compaction.serialize import serialize_for_summary
+from hydrahive.compaction.summarize import summarize
+from hydrahive.db import messages as messages_db
+from hydrahive.db import sessions as sessions_db
+from hydrahive.projects._paths import ensure_workspace
+
+HANDOVER_RELATIVE_PATH = Path(".hydrahive/HANDOVER.md")
+
+
+def path_for_project(project_id: str) -> Path:
+    return ensure_workspace(project_id) / HANDOVER_RELATIVE_PATH
+
+
+def write_project_handover(project_id: str, *, session_id: str, agent_id: str, summary: str) -> Path:
+    """Schreibt redigiert und atomar; der Zielpfad wird allein aus project_id abgeleitet."""
+    target = path_for_project(project_id)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    body = redact(
+        "# Projekt-Handover\n\n"
+        f"- Projekt-ID: `{project_id}`\n"
+        f"- Quell-Session: `{session_id}`\n"
+        f"- Agent-ID: `{agent_id}`\n"
+        f"- Aktualisiert: `{datetime.now(timezone.utc).isoformat()}`\n\n"
+        "Diese Übergabe ist Arbeitskontext aus der vorherigen Session. "
+        "Prüfe Datei- und Git-Zustand, bevor du Änderungen vornimmst.\n\n"
+        f"{summary.strip()}\n"
+    )
+    tmp = target.with_suffix(f".tmp-{os.getpid()}")
+    tmp.write_text(body, encoding="utf-8")
+    os.replace(tmp, target)
+    return target
+
+
+def read_project_handover(project_id: str) -> str | None:
+    path = path_for_project(project_id)
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    return text or None
+
+
+def prompt_for_new_session(session_id: str) -> str | None:
+    """Nur eine noch leere Projekt-Session bekommt die Übergabe als Startkontext."""
+    session = sessions_db.get(session_id)
+    if not session or not session.project_id or messages_db.list_for_session(session_id, limit=1):
+        return None
+    text = read_project_handover(session.project_id)
+    if not text:
+        return None
+    return "[Projekt-Handover aus der vorherigen Session]\n" + text
+
+
+async def create_for_session(session_id: str, *, model: str, tool_result_limit: int | None = None) -> Path | None:
+    """Erzeugt eine hochwertige Übergabe aus dem vollständigen sichtbaren Verlauf."""
+    session = sessions_db.get(session_id)
+    if not session or not session.project_id:
+        return None
+    history = messages_db.list_for_llm(session_id)
+    if not history:
+        return None
+    kwargs = {} if tool_result_limit is None else {"tool_result_limit": tool_result_limit}
+    summary = await summarize(
+        model=model,
+        serialized_history=serialize_for_summary(history, **kwargs),
+        previous_summary=messages_db.get_latest_summary(session_id),
+    )
+    return write_project_handover(
+        session.project_id, session_id=session.id, agent_id=session.agent_id, summary=summary,
+    )

--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -111,6 +111,8 @@ async def run(
     tool_schemas = schemas_for(local_tools) + mcp_schemas + plugin_schemas
     allowed_tools = local_tools + [s["name"] for s in mcp_schemas]
 
+    from hydrahive.handover import prompt_for_new_session
+    handover_system = prompt_for_new_session(session_id)
     messages_db.append(session_id, "user", user_input)
 
     last_assistant_id: str | None = None
@@ -171,7 +173,7 @@ async def run(
             base_system_prompt,
             extra_system=extra_system,
             workspace=workspace,
-            summary=messages_db.get_latest_summary(session_id),
+            summary=messages_db.get_latest_summary(session_id) or handover_system,
             skills=agent_skills,
             longterm_memory=bool(agent.get("longterm_memory")),
             tool_schemas=tool_schemas,

--- a/core/tests/test_project_handover.py
+++ b/core/tests/test_project_handover.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hydrahive import handover
+
+
+def test_write_read_redacts_and_uses_project_workspace(monkeypatch, tmp_path):
+    workspace = tmp_path / "project"
+    monkeypatch.setattr(handover, "ensure_workspace", lambda _pid: workspace)
+
+    path = handover.write_project_handover(
+        "p1", session_id="s1", agent_id="a1",
+        summary="## Goal\nShip it\nAuthorization: Bearer secret-token",
+    )
+
+    assert path == workspace / ".hydrahive" / "HANDOVER.md"
+    text = handover.read_project_handover("p1")
+    assert text and "## Goal" in text
+    assert "secret-token" not in text
+    assert not list(path.parent.glob("*.tmp-*"))
+
+
+def test_prompt_only_for_empty_project_session(monkeypatch):
+    session = SimpleNamespace(id="s1", project_id="p1")
+    monkeypatch.setattr(handover.sessions_db, "get", lambda _sid: session)
+    monkeypatch.setattr(handover, "read_project_handover", lambda _pid: "state")
+    monkeypatch.setattr(handover.messages_db, "list_for_session", lambda *_a, **_k: [])
+    assert "state" in handover.prompt_for_new_session("s1")
+
+    monkeypatch.setattr(handover.messages_db, "list_for_session", lambda *_a, **_k: [object()])
+    assert handover.prompt_for_new_session("s1") is None
+
+
+@pytest.mark.asyncio
+async def test_create_for_session_summarizes_and_writes(monkeypatch, tmp_path):
+    session = SimpleNamespace(id="s1", project_id="p1", agent_id="a1")
+    monkeypatch.setattr(handover.sessions_db, "get", lambda _sid: session)
+    monkeypatch.setattr(handover.messages_db, "list_for_llm", lambda _sid: [SimpleNamespace(role="user", content="goal")])
+    monkeypatch.setattr(handover.messages_db, "get_latest_summary", lambda _sid: None)
+    monkeypatch.setattr(handover, "ensure_workspace", lambda _pid: tmp_path)
+
+    async def fake_summarize(**kwargs):
+        assert "goal" in kwargs["serialized_history"]
+        return "## Goal\nContinue"
+
+    monkeypatch.setattr(handover, "summarize", fake_summarize)
+    path = await handover.create_for_session("s1", model="test/model")
+    assert path == tmp_path / ".hydrahive" / "HANDOVER.md"
+    assert "Continue" in path.read_text()
+
+
+@pytest.mark.asyncio
+async def test_create_for_projectless_session_is_noop(monkeypatch):
+    monkeypatch.setattr(handover.sessions_db, "get", lambda _sid: SimpleNamespace(project_id=None))
+    assert await handover.create_for_session("s1", model="test/model") is None

--- a/docs/plans/project-handover.md
+++ b/docs/plans/project-handover.md
@@ -1,0 +1,50 @@
+# Plan: Globale Projekt-Handover-Datei
+
+## Ziel
+
+Projektzustand über Compactions und bewusst gestartete neue Chats hinweg automatisch erhalten.
+
+## Dateien
+
+- `core/src/hydrahive/handover.py` — Handover erzeugen, atomar schreiben, lesen und prompten.
+- `core/src/hydrahive/compaction/compactor.py` — nach erfolgreicher Compaction persistieren.
+- `core/src/hydrahive/api/routes/sessions.py` — wartender Handover-Endpunkt.
+- `core/src/hydrahive/runner/runner.py` — Handover nur in leere neue Projekt-Session einlesen.
+- `core/src/hydrahive/buddy/commands.py` — Buddy-Neustart mit Handover und Projektübernahme.
+- `frontend/src/features/chat/api.ts` — Handover-API.
+- `frontend/src/features/chat/ChatPane.tsx` und `commands.ts` — neue Chats warten lassen.
+- `frontend/src/features/buddy/BuddyPage.tsx` — Busy-Anzeige.
+- `core/tests/test_project_handover.py` — Unit-/Integrationsabdeckung.
+
+## Implementierungsreihenfolge
+
+### Task 1: Sicherer Handover-Store
+- [ ] Tests für Projektpfad, Redaction, atomisches Schreiben und Lesen schreiben.
+- [ ] Tests rot ausführen.
+- [ ] Store und Prompt-Rendering implementieren.
+- [ ] Tests grün ausführen.
+- [ ] Commit: `feat(handover): add project checkpoint store`
+
+### Task 2: Compaction und neuer Chat
+- [ ] Tests für Compaction-Persistenz und wartenden API-Call schreiben.
+- [ ] Handover nach erfolgreicher Compaction schreiben.
+- [ ] Session-Endpunkt zum Erzeugen einer vollständigen Übergabe ergänzen.
+- [ ] Buddy-Clear projektgebunden und wartend machen.
+- [ ] Commit: `feat(handover): persist checkpoints across sessions`
+
+### Task 3: Automatisches Einlesen und UI
+- [ ] Test: nur leere neue Projekt-Session bekommt Handover-Prompt.
+- [ ] Runner-Injektion implementieren.
+- [ ] Alle expliziten Neuer-Chat-Pfade awaiten; Busy-Text anzeigen.
+- [ ] Frontend-Build und Backendtests ausführen.
+- [ ] Commit: `feat(chat): await project handover before new session`
+
+## Akzeptanzkriterien
+
+- [ ] Spec-Kriterien erfüllt.
+- [ ] Backendtests, Ruff und Frontend-Build grün.
+- [ ] HH2-Review ohne neue Verletzungen.
+
+## Nicht in diesem Plan
+
+- Automatische Git-Commits oder Handover-Historie.

--- a/docs/specs/project-handover.md
+++ b/docs/specs/project-handover.md
@@ -1,0 +1,36 @@
+# Spec: Globale Projekt-Handover-Datei
+
+## Was
+
+HydraHive pflegt pro Projektworkspace eine kanonische `.hydrahive/HANDOVER.md`. Jede erfolgreiche Compaction aktualisiert sie. Vor einem bewusst gestarteten neuen Chat wird eine aktuelle Übergabe erzeugt; die UI wartet darauf. Der erste Runner-Aufruf einer leeren Projekt-Session liest die Übergabe automatisch als Startkontext.
+
+## Warum
+
+Compaction und neue Chats verlieren sonst wichtigen Arbeitszustand. Das trifft kleine Codex-Kontextfenster besonders, ist aber ein modellunabhängiges Projektproblem.
+
+## Wie
+
+- Projektgebundener, secret-redacteter Markdown-Checkpoint mit Session-, Agent- und Zeit-Metadaten.
+- Atomisches Schreiben über temporäre Datei plus `replace`.
+- Nach erfolgreicher Compaction wird deren strukturierte Summary geschrieben.
+- `POST /api/sessions/{id}/handover` fasst den aktuellen Verlauf zusammen und wartet auf Abschluss.
+- Neue-Chat-Pfade rufen den Endpunkt vor der Session-Erstellung auf.
+- Buddy-Clear erzeugt serverseitig die Übergabe und übernimmt die Projektbindung.
+- Nur eine leere neue Session erhält `HANDOVER.md` als volatilen Startkontext; bestehende Chats werden nicht rückwirkend beeinflusst.
+- Chats ohne Projektbindung schreiben/lesen keine Projekt-Handover-Datei.
+
+## Akzeptanzkriterien
+
+- Jede erfolgreiche projektgebundene Compaction aktualisiert `.hydrahive/HANDOVER.md`.
+- „Neuer Chat“ wartet sichtbar auf die Übergabe.
+- Eine neue Session desselben Projekts erhält die Übergabe beim ersten Run.
+- Kein Handover außerhalb des zugehörigen Projektworkspaces.
+- Secrets werden vor dem Schreiben redigiert.
+- Schreibvorgang ist atomar; Fehler bei automatischem Compaction-Handover brechen die Compaction nicht.
+- Tests decken Pfad, Redaction, leere Session, Compaction und API ab.
+
+## Nicht enthalten
+
+- Automatische Git-Commits, Pushes oder Merges.
+- Handover für projektlose Chats.
+- Ein historisches Handover-Archiv in Version 1.

--- a/frontend/src/features/buddy/BuddyPage.tsx
+++ b/frontend/src/features/buddy/BuddyPage.tsx
@@ -63,11 +63,18 @@ export function BuddyPage() {
 
   useEffect(() => { chatApi.listProjects().then(setProjects).catch(() => {}) }, [])
 
+  const [handoverBusy, setHandoverBusy] = useState(false)
+
   async function newChat() {
-    const r = await buddyApi.clear()
-    setLocalMsgs([])
-    setReasoningEffort(null)
-    setState((s) => (s ? { ...s, session_id: r.session_id } : s))
+    setHandoverBusy(true)
+    try {
+      const r = await buddyApi.clear()
+      setLocalMsgs([])
+      setReasoningEffort(null)
+      setState((s) => (s ? { ...s, session_id: r.session_id } : s))
+    } finally {
+      setHandoverBusy(false)
+    }
   }
 
   function handleBuddyLocalAction(actionId: string) {
@@ -135,7 +142,7 @@ export function BuddyPage() {
                 {state.model && <div className="w-[210px]"><ModelPicker current={state.model} hint="Buddy-Modell wechseln" fullWidth onPick={async (m) => { await buddyApi.setModel(m); setReasoningEffort(null); setState(await buddyApi.state()) }} /></div>}
                 {effortLevels.length > 0 && <ReasoningEffortPill current={reasoningEffort} levels={effortLevels} onSelect={async (effort) => { if (state.session_id) await chatApi.updateSession(state.session_id, { reasoning_effort: effort ?? "" }); setReasoningEffort(effort) }} />}
                 <HelpButton topic="buddy" />
-                <CockpitButton disabled={chat.busy} tone="primary" onClick={newChat}>Neuer Chat</CockpitButton>
+                <CockpitButton disabled={chat.busy || handoverBusy} tone="primary" onClick={newChat}>{handoverBusy ? "Übergabe wird erstellt …" : "Neuer Chat"}</CockpitButton>
               </div>
             </div>
             {state.created && <div className="px-5 pt-3 pb-1 text-center text-[11px] text-[#69d7ff]">{t("just_woken_up")}</div>}

--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -98,6 +98,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
   }, [projectId, activeId, sessions])
 
   async function handleNew(agentId: string, title: string, projectId?: string) {
+    if (activeSession?.project_id) await chatApi.handover(activeSession.id)
     const s = await chatApi.createSession(agentId, title || undefined, projectId)
     setShowNew(false); setSessions((cur) => [s, ...cur]); setActiveId(s.id)
   }
@@ -109,6 +110,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
   }
 
   const [tokenRefresh, setTokenRefresh] = useState(0)
+  const [newSessionBusy, setNewSessionBusy] = useState(false)
   const [showPixelMonitor, setShowPixelMonitor] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
 
@@ -224,9 +226,15 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
   async function createPreferredSession() {
     const agent = activeAgent ?? preferredAgent ?? agents.find((a) => !a.is_buddy) ?? agents[0]
     if (!agent) return
-    const s = await chatApi.createSession(agent.id, undefined, projectId ?? undefined)
-    setSessions((cur) => [s, ...cur])
-    setActiveId(s.id)
+    setNewSessionBusy(true)
+    try {
+      if (activeSession?.project_id) await chatApi.handover(activeSession.id)
+      const s = await chatApi.createSession(agent.id, undefined, projectId ?? undefined)
+      setSessions((cur) => [s, ...cur])
+      setActiveId(s.id)
+    } finally {
+      setNewSessionBusy(false)
+    }
   }
 
   const center = activeSession ? (
@@ -241,6 +249,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
             compacting={compacting} compactNote={compactNote}
             lastTurnTokens={chat.lastTurnTokens} busy={chat.busy}
             systemPrompt={systemPrompt} onCompact={handleCompact}
+            newSessionBusy={newSessionBusy}
             onDelete={() => handleDelete(activeSession.id)} tokenRefresh={tokenRefresh}
             onNewSession={async () => {
               if (!activeAgent) return

--- a/frontend/src/features/chat/_ChatHeader.tsx
+++ b/frontend/src/features/chat/_ChatHeader.tsx
@@ -19,6 +19,7 @@ interface Props {
   onCompact: () => void
   onDelete: () => void
   onNewSession: () => void
+  newSessionBusy?: boolean
   tokenRefresh: number
   cockpitMode?: boolean
   sessions?: Session[]
@@ -28,7 +29,7 @@ interface Props {
 
 export function ChatHeader({
   session, agent, orphaned, compacting, compactNote,
-  lastTurnTokens, busy, systemPrompt, onCompact, onDelete, onNewSession, tokenRefresh,
+  lastTurnTokens, busy, systemPrompt, onCompact, onDelete, onNewSession, newSessionBusy = false, tokenRefresh,
   cockpitMode = false, sessions = [], activeSessionId = null, onSelectSession,
 }: Props) {
   const { t, i18n } = useTranslation("chat")
@@ -110,11 +111,11 @@ export function ChatHeader({
             </button>
             <button
               onClick={onNewSession}
-              disabled={busy}
+              disabled={busy || newSessionBusy}
               title={t("session.new_chat")}
               className="rounded-[4px] border border-transparent bg-gradient-to-br from-[#1fb6ff] to-[#8b5cf6] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-30"
             >
-              <SquarePen size={12} className="mr-1 inline" /> Neuer Chat
+              {newSessionBusy ? <Loader2 size={12} className="mr-1 inline animate-spin" /> : <SquarePen size={12} className="mr-1 inline" />} {newSessionBusy ? "Übergabe wird erstellt …" : "Neuer Chat"}
             </button>
           </div>
         </div>
@@ -165,12 +166,12 @@ export function ChatHeader({
         <HelpButton topic="chat" />
         <button
           onClick={onNewSession}
-          disabled={busy}
+          disabled={busy || newSessionBusy}
           title={t("session.new_chat")}
           className="flex items-center gap-1.5 rounded-[4px] border border-[#2a364b] bg-[#172133] px-3 py-1.5 text-xs text-[#e8eef8] transition-colors hover:border-[#46617f] hover:bg-[#1b2536] disabled:cursor-not-allowed disabled:opacity-30"
         >
-          <SquarePen size={12} />
-          {t("session.new_chat")}
+          {newSessionBusy ? <Loader2 size={12} className="animate-spin" /> : <SquarePen size={12} />}
+          {newSessionBusy ? "Übergabe wird erstellt …" : t("session.new_chat")}
         </button>
         <button
           onClick={onCompact}

--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -14,6 +14,7 @@ export const chatApi = {
   createSession: (agent_id: string, title?: string, project_id?: string) =>
     api.post<Session>("/sessions", { agent_id, title, project_id }),
   deleteSession: (id: string) => api.delete<void>(`/sessions/${id}`),
+  handover: (id: string) => api.post<{ written: boolean; reason?: string }>(`/sessions/${id}/handover`, {}),
   updateSession: (id: string, fields: { title?: string; status?: string; model_override?: string | null; reasoning_effort?: string | null; project_id?: string | null }) =>
     api.patch<Session>(`/sessions/${id}`, fields),
   listMessages: (id: string) => api.get<Message[]>(`/sessions/${id}/messages`),

--- a/frontend/src/features/chat/commands.ts
+++ b/frontend/src/features/chat/commands.ts
@@ -54,6 +54,7 @@ async function modelCmd(arg: string, agent: AgentBrief): Promise<ChatCommandResu
 }
 
 async function clearCmd(session: Session, agent: AgentBrief): Promise<ChatCommandResult> {
+  if (session.project_id) await chatApi.handover(session.id)
   const fresh = await chatApi.createSession(agent.id, undefined, session.project_id ?? undefined)
   return { message: `Neue Session gestartet: ${fresh.title || fresh.id.slice(0, 8)}`, newSessionId: fresh.id }
 }


### PR DESCRIPTION
## Verhalten
- jede erfolgreiche projektgebundene Compaction aktualisiert `.hydrahive/HANDOVER.md`
- „Neuer Chat“ wartet auf eine frische strukturierte Übergabe
- neue leere Session liest das Projekt-Handover automatisch beim ersten Run
- Buddy behält beim neuen Chat die aktive Projektbindung
- projektlose Chats bleiben unverändert

## Sicherheit
- Zielpfad ausschließlich aus serverseitiger Projekt-ID
- Secret-Redaction vor Dateischreibzugriff
- atomisches Schreiben via os.replace
- Endpoint prüft Auth und Session-Owner

## Tests
- 69 fokussierte Backendtests grün
- Ruff grün
- Frontend-Build grün
- Cockpit Offline-Guard grün
- Import- und Diff-Check grün