### PR TITLE
fix(codex): drop unsupported max_output_tokens param

### DIFF
--- a/core/src/hydrahive/runner/_codex_provider.py
+++ b/core/src/hydrahive/runner/_codex_provider.py
@@ -51,8 +51,11 @@ def _build_payload(
         "parallel_tool_calls": True,
         "instructions": instructions or _DEFAULT_INSTRUCTIONS,
     }
-    if max_tokens:
-        payload["max_output_tokens"] = max_tokens
+    # Der Codex-OAuth-/Responses-Backend lehnt max_output_tokens ab
+    # ("Unsupported parameter"). Der offizielle Codex-Client sendet es nicht;
+    # das Output-Limit wird serverseitig gesteuert. max_tokens bleibt in der
+    # Signatur für API-Parität, wird für diesen Pfad aber nicht übertragen.
+    _ = max_tokens
     if reasoning_effort:
         from hydrahive.llm.reasoning_effort import effort_levels_for_model
         if reasoning_effort in effort_levels_for_model(f"openai-codex/{model}"):

--- a/core/tests/test_codex_context.py
+++ b/core/tests/test_codex_context.py
@@ -12,11 +12,12 @@ def test_codex_oauth_context_windows_match_official_client():
     assert context_window_for("openai-codex/gpt-5.4-mini") == 272_000
 
 
-def test_codex_payload_sets_output_limit():
+def test_codex_payload_omits_unsupported_output_limit():
+    # Der Codex-OAuth-Endpunkt lehnt max_output_tokens mit HTTP 400 ab.
     payload = _build_payload(
         model="gpt-5.6-sol", system_prompt="", messages=[], tools=[], max_tokens=32_000,
     )
-    assert payload["max_output_tokens"] == 32_000
+    assert "max_output_tokens" not in payload
 
 
 def test_encrypted_reasoning_replayed_for_same_model_only():


### PR DESCRIPTION
## Regression
PR #299 sendete max_output_tokens im Codex-Payload. Der Codex-OAuth-/Responses-Endpunkt antwortet mit HTTP 400 "Unsupported parameter: max_output_tokens".

## Fix
- Parameter wird nicht mehr an Codex übertragen.
- Signatur bleibt für API-Parität erhalten.
- Test prüft nun die Abwesenheit des Feldes.

## Tests
- 4 Codex-Kontext-Tests grün
- Ruff grün