### PR TITLE
fix(llm): expose xhigh/max effort for Claude 4.6+ models

### DIFF
--- a/core/src/hydrahive/llm/reasoning_effort.py
+++ b/core/src/hydrahive/llm/reasoning_effort.py
@@ -15,6 +15,14 @@ def effort_levels_for_model(model: str) -> tuple[str, ...]:
         return _WITH_MAX
     if model.startswith("openai-codex/"):
         return _STANDARD
-    if bare.startswith(("claude-", "MiniMax-M2")):
+    if bare.startswith("claude-"):
+        # Claude 4.6+ nutzt output_config.effort (low..max inkl. xhigh/max);
+        # ältere Claude-Modelle nutzen den Legacy-Budget-Pfad (low/medium/high).
+        # _anthropic.py ist die einzige Wahrheitsquelle — hier nur ableiten.
+        from hydrahive.llm._anthropic import EFFORT_LEVELS, _uses_effort_param
+        if _uses_effort_param(model):
+            return EFFORT_LEVELS
+        return ("low", "medium", "high")
+    if bare.startswith("MiniMax-M2"):
         return ("low", "medium", "high")
     return ()

--- a/core/tests/test_reasoning_effort.py
+++ b/core/tests/test_reasoning_effort.py
@@ -18,6 +18,7 @@ from hydrahive.llm._anthropic import (
     EFFORT_TO_BUDGET,
     apply_effort,
 )
+from hydrahive.llm.reasoning_effort import effort_levels_for_model
 
 # Repräsentative Modelle pro Pfad
 _NEW = "claude-opus-4-8"        # adaptive + output_config.effort
@@ -182,6 +183,40 @@ def test_opus_4_8_in_effort_param_models():
 
 def test_sonnet_4_6_in_effort_param_models():
     assert any("claude-sonnet-4-6".startswith(p) for p in EFFORT_PARAM_MODELS)
+
+
+# ---------------------------------------------------------------------------
+# UI-Dropdown-Stufen (effort_levels_for_model) müssen zum apply_effort-Pfad passen
+# ---------------------------------------------------------------------------
+
+def test_ui_levels_claude_4_8_enthalten_xhigh_und_max():
+    levels = effort_levels_for_model("claude-opus-4-8")
+    assert levels == ("low", "medium", "high", "xhigh", "max")
+
+
+def test_ui_levels_claude_4_8_mit_provider_prefix():
+    levels = effort_levels_for_model("anthropic/claude-opus-4-8")
+    assert "xhigh" in levels and "max" in levels
+
+
+def test_ui_levels_sonnet_5_enthalten_xhigh():
+    assert "xhigh" in effort_levels_for_model("claude-sonnet-5")
+
+
+def test_ui_levels_legacy_claude_nur_low_medium_high():
+    assert effort_levels_for_model("claude-opus-4-5") == ("low", "medium", "high")
+
+
+def test_ui_levels_minimax_nur_low_medium_high():
+    assert effort_levels_for_model("MiniMax-M2.7") == ("low", "medium", "high")
+
+
+def test_ui_levels_decken_sich_mit_apply_effort():
+    """Jede angebotene UI-Stufe muss von apply_effort tatsächlich akzeptiert werden."""
+    for level in effort_levels_for_model("claude-opus-4-8"):
+        kwargs = {"max_tokens": 8192}
+        apply_effort(kwargs, "claude-opus-4-8", level)
+        assert kwargs.get("output_config", {}).get("effort") == level
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Das Reasoning-Tiefe-Dropdown zeigte für Claude 4.6+ (u.a. Opus 4.8, Sonnet 5) nur low/medium/high. xhigh und max fehlten, obwohl der Anthropic-Payload sie über output_config.effort unterstützt.

## Ursache
effort_levels_for_model gab pauschal fuer alle claude-Modelle low/medium/high zurueck, ohne den 4.6+-Pfad aus _anthropic.py zu beruecksichtigen.

## Fix
effort_levels_for_model leitet die Stufen jetzt aus _anthropic._uses_effort_param + EFFORT_LEVELS ab. _anthropic.py bleibt einzige Wahrheitsquelle. Claude 4.6+: low/medium/high/xhigh/max. Legacy-Claude und MiniMax: low/medium/high.

## Frontend
Keine Aenderung noetig: Dropdown zieht die Stufen dynamisch ueber /llm/effort-levels.

## Tests
- 31 Reasoning-Effort-Tests gruen (inkl. neuer UI-Level-Konsistenzpruefungen)
- Ruff gruen