### PR TITLE
perf(chat): window thread to last 50 messages, load older on scroll

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -18,6 +18,8 @@ import { FileOverlay } from "./workspace/FileOverlay"
 import type { FileKind } from "./workspace/fileType"
 import { ChatHeader } from "./_ChatHeader"
 import { ChatBubbleThread } from "./_ChatBubbleThread"
+import { LoadOlderSentinel } from "./_LoadOlderSentinel"
+import { useMessageWindow } from "./_useMessageWindow"
 import { useHydraRuntime } from "./_assistantRuntime"
 import type { AgentBrief, Message, Session } from "./types"
 import type { ProjectBrief } from "./api"
@@ -60,7 +62,10 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
   const [localMsgs, setLocalMsgs] = useState<Message[]>([])
   const chat = useChat(activeId)
   const allMessages = useMemo(() => [...chat.messages, ...localMsgs], [chat.messages, localMsgs])
-  const runtime = useHydraRuntime(allMessages, chat.busy, chat.send, chat.cancel)
+  // Nur die letzten N Nachrichten rendern; ältere werden beim Hochscrollen
+  // nachgeladen. Hält den DOM klein, damit lange Threads flüssig bleiben.
+  const { windowed, hasMore, loadMore, visibleCount } = useMessageWindow(allMessages, activeId)
+  const runtime = useHydraRuntime(windowed, chat.busy, chat.send, chat.cancel)
 
   const knownAgentIds = new Set(agents.map((a) => a.id))
   const buddyAgentIds = new Set(agents.filter((a) => a.is_buddy).map((a) => a.id))
@@ -260,7 +265,9 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
             activeSessionId={activeId}
             onSelectSession={setActiveId}
           />
-          <ChatBubbleThread />
+          <ChatBubbleThread
+            topSlot={<LoadOlderSentinel hasMore={hasMore} onLoadMore={loadMore} visibleCount={visibleCount} />}
+          />
           {showPixelMonitor && (
             <AgentPixelMonitor
               agentTools={pixelData.agentTools}

--- a/frontend/src/features/chat/_ChatBubbleThread.tsx
+++ b/frontend/src/features/chat/_ChatBubbleThread.tsx
@@ -185,10 +185,11 @@ function ChatSystemMessage() {
   return <CompactionBlock message={original} />
 }
 
-export function ChatBubbleThread() {
+export function ChatBubbleThread({ topSlot }: { topSlot?: ReactNode } = {}) {
   return (
     <ThreadPrimitive.Root className="flex-1 overflow-hidden flex flex-col">
       <ThreadPrimitive.Viewport className="flex-1 overflow-y-auto space-y-[9px] p-[14px]">
+        {topSlot}
         <ThreadPrimitive.Messages
           components={{
             UserMessage: ChatUserMessage,

--- a/frontend/src/features/chat/_LoadOlderSentinel.tsx
+++ b/frontend/src/features/chat/_LoadOlderSentinel.tsx
@@ -1,0 +1,24 @@
+import { Loader2 } from "lucide-react"
+import { useLoadOlder } from "./_useLoadOlder"
+
+interface Props {
+  hasMore: boolean
+  onLoadMore: () => void
+  /** Sichtbare Nachrichtenanzahl — treibt Scroll-Korrektur nach dem Nachladen. */
+  visibleCount: number
+}
+
+/**
+ * Unsichtbarer Anker oben im Thread. Scrollt er in den sichtbaren Bereich,
+ * werden ältere Nachrichten nachgeladen (siehe useLoadOlder).
+ */
+export function LoadOlderSentinel({ hasMore, onLoadMore, visibleCount }: Props) {
+  const sentinelRef = useLoadOlder(hasMore, onLoadMore, visibleCount)
+  if (!hasMore) return null
+  return (
+    <div ref={sentinelRef} className="flex items-center justify-center py-3 text-xs text-[#8d9ab0]">
+      <Loader2 size={12} className="mr-2 animate-spin" />
+      Ältere Nachrichten werden geladen …
+    </div>
+  )
+}

--- a/frontend/src/features/chat/_useLoadOlder.ts
+++ b/frontend/src/features/chat/_useLoadOlder.ts
@@ -1,0 +1,65 @@
+import { useEffect, useLayoutEffect, useRef } from "react"
+
+/** Nächsten scrollbaren Vorfahren finden (assistant-ui Viewport). */
+function getScrollParent(node: HTMLElement | null): HTMLElement | null {
+  let el = node?.parentElement ?? null
+  while (el) {
+    const overflowY = getComputedStyle(el).overflowY
+    if (overflowY === "auto" || overflowY === "scroll") return el
+    el = el.parentElement
+  }
+  return null
+}
+
+/**
+ * Lädt ältere Nachrichten nach, sobald ein Sentinel oben in den sichtbaren
+ * Bereich scrollt (IntersectionObserver). Nach dem Nachladen wird die
+ * Scroll-Position erhalten, damit der Thread nicht nach oben springt und der
+ * Observer nicht sofort erneut feuert.
+ *
+ * `dep` ist die sichtbare Nachrichtenanzahl — ändert sie sich, korrigieren wir
+ * die Scroll-Position um die neu oben eingefügte Höhe.
+ */
+export function useLoadOlder(
+  hasMore: boolean,
+  onLoadMore: () => void,
+  dep: number,
+) {
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const scrollParentRef = useRef<HTMLElement | null>(null)
+  const prevScrollHeight = useRef(0)
+  const loadMoreRef = useRef(onLoadMore)
+  loadMoreRef.current = onLoadMore
+
+  useEffect(() => {
+    scrollParentRef.current = getScrollParent(sentinelRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (!hasMore) return
+    const el = sentinelRef.current
+    const root = scrollParentRef.current
+    if (!el || !root) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          prevScrollHeight.current = root.scrollHeight
+          loadMoreRef.current()
+        }
+      },
+      { root, threshold: 0 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [hasMore, dep])
+
+  useLayoutEffect(() => {
+    const root = scrollParentRef.current
+    if (!root || !prevScrollHeight.current) return
+    const diff = root.scrollHeight - prevScrollHeight.current
+    if (diff > 0) root.scrollTop += diff
+    prevScrollHeight.current = 0
+  }, [dep])
+
+  return sentinelRef
+}

--- a/frontend/src/features/chat/_useMessageWindow.ts
+++ b/frontend/src/features/chat/_useMessageWindow.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react"
+import type { Message } from "./types"
+
+const INITIAL_WINDOW = 50
+const LOAD_STEP = 50
+
+/**
+ * Rendert nur die letzten N Nachrichten eines Threads statt aller. Ältere
+ * werden beim Hochscrollen in Schritten nachgeladen. Das hält den DOM klein,
+ * damit Re-Renders (Tippen, Streaming) auch in langen Sessions flüssig bleiben.
+ *
+ * `resetKey` (z.B. die Session-ID) setzt das Fenster zurück, sobald der Thread
+ * wechselt — sonst würde eine kurze neue Session das Limit einer alten erben.
+ */
+export function useMessageWindow(messages: Message[], resetKey: string | null) {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_WINDOW)
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_WINDOW)
+  }, [resetKey])
+
+  const total = messages.length
+  const hasMore = total > visibleCount
+
+  const windowed = useMemo(() => {
+    if (!hasMore) return messages
+    return messages.slice(total - visibleCount)
+  }, [messages, hasMore, total, visibleCount])
+
+  function loadMore() {
+    setVisibleCount((c) => Math.min(c + LOAD_STEP, total))
+  }
+
+  return { windowed, hasMore, loadMore, visibleCount, total }
+}


### PR DESCRIPTION
## Problem
Der Chat wird mit wachsendem Verlauf immer traeger. Symptom: nur am Anfang neuer Fenster fluessig, danach staut sich das Tippen. Ursache ist nicht die Render-Geschwindigkeit pro Nachricht, sondern die Anzahl: der komplette Thread wird ins DOM gerendert. Bei hunderten Nachrichten gleicht React bei jedem Render (auch tastendruck-getriggert) alle Bubbles mit Markdown, Tool-Karten und Syntax-Highlighting ab.

## Fix
Windowing: es werden nur die letzten 50 Nachrichten gerendert. Beim Hochscrollen werden aeltere in 50er-Schritten nachgeladen (IntersectionObserver-Sentinel oben im Viewport). Nach dem Nachladen wird die Scroll-Position erhalten, damit der Thread nicht springt. Bei Session-Wechsel setzt das Fenster zurueck.

## Umsetzung
- _useMessageWindow.ts: haelt visibleCount, slict die letzten N, Reset per Session-ID
- _useLoadOlder.ts: IntersectionObserver + Scroll-Positions-Erhalt
- _LoadOlderSentinel.tsx: unsichtbarer Anker oben im Thread
- ChatBubbleThread bekommt optionalen topSlot
- ChatPane reicht das gefensterte Array an die Runtime

Kein Backend-Eingriff — rein clientseitig. Ergaenzt Markdown-Memoisierung (#302) und rAF-Coalescing (#304): weniger DOM plus guenstigere Renders.

## Tests
- Typecheck gruen
- Frontend-Build gruen
- Cockpit Offline-Guard gruen