### PR TITLE
feat(cockpit): Statusfilter im Projekt-Tasks-Widget

### DIFF
--- a/frontend/src/features/cockpit/project/ProjectTasksPanel.tsx
+++ b/frontend/src/features/cockpit/project/ProjectTasksPanel.tsx
@@ -32,6 +32,18 @@ interface Props {
   projectId: string | null
 }
 
+type TaskFilter = "all" | "open" | "in_progress" | "done"
+
+const FILTERS: { key: TaskFilter; label: string }[] = [
+  { key: "all", label: "Alle" },
+  { key: "open", label: "Offen" },
+  { key: "in_progress", label: "Doing" },
+  { key: "done", label: "Erledigt" },
+]
+
+// Offene Arbeit zuerst, Erledigtes/Abgebrochenes ans Ende.
+const STATUS_ORDER: Record<TaskStatus, number> = { in_progress: 0, open: 1, done: 2, cancelled: 3 }
+
 export function ProjectTasksPanel({ projectId }: Props) {
   const [tasks, setTasks] = useState<Task[]>([])
   const [loading, setLoading] = useState(false)
@@ -39,8 +51,25 @@ export function ProjectTasksPanel({ projectId }: Props) {
   const [createOpen, setCreateOpen] = useState(false)
   const [title, setTitle] = useState("")
   const [priority, setPriority] = useState<TaskPriority>("medium")
+  const [filter, setFilter] = useState<TaskFilter>("all")
   const [error, setError] = useState<string | null>(null)
   const titleInputRef = useRef<HTMLInputElement>(null)
+
+  const counts = tasks.reduce(
+    (acc, task) => {
+      acc.all += 1
+      if (task.status === "open") acc.open += 1
+      else if (task.status === "in_progress") acc.in_progress += 1
+      else if (task.status === "done") acc.done += 1
+      return acc
+    },
+    { all: 0, open: 0, in_progress: 0, done: 0 } as Record<TaskFilter, number>,
+  )
+
+  const visibleTasks = tasks
+    .filter((task) => (filter === "all" ? true : task.status === filter))
+    .slice()
+    .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
 
   async function reload() {
     if (!projectId) {
@@ -122,11 +151,30 @@ export function ProjectTasksPanel({ projectId }: Props) {
           <CockpitButton tone="primary" disabled={!projectId || creating || !title.trim()} onClick={() => void createTask()}>Task +</CockpitButton>
         </div>
       </div>}
+      {projectId && tasks.length > 0 ? (
+        <div className="mb-2 flex flex-wrap gap-1">
+          {FILTERS.map((item) => (
+            <button
+              key={item.key}
+              onClick={() => setFilter(item.key)}
+              className={[
+                "rounded-[3px] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em]",
+                filter === item.key
+                  ? "bg-cyan-400/15 text-cyan-100"
+                  : "bg-white/[5%] text-zinc-500 hover:text-zinc-300",
+              ].join(" ")}
+            >
+              {item.label} <span className="opacity-60">{counts[item.key]}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
       {error ? <p className="mb-2 text-xs text-rose-300">{error}</p> : null}
       {loading ? <p className="text-sm text-zinc-600">Lade Tasks…</p> : null}
       {!loading && tasks.length === 0 ? <p className="text-sm text-zinc-600">Keine Tasks für dieses Projekt.</p> : null}
+      {!loading && tasks.length > 0 && visibleTasks.length === 0 ? <p className="text-sm text-zinc-600">Keine Tasks mit diesem Status.</p> : null}
       <div className="min-h-0 flex-1 space-y-1.5 overflow-y-auto pr-1">
-        {tasks.slice(0, 20).map((task) => (
+        {visibleTasks.slice(0, 30).map((task) => (
           <div key={task.id} className="rounded-[4px] border border-[#223048] bg-[#111827] p-2">
             <div className="flex items-start justify-between gap-2">
               <p className="min-w-0 text-sm font-semibold text-[#e8eef8]">{task.title}</p>


### PR DESCRIPTION
## Problem
Im Projekt-Cockpit zeigte das Tasks-Widget (unten rechts) nur die ersten 20 Tasks in roher API-Reihenfolge. Dadurch verdrängten erledigte Tasks die offenen/laufenden — man sah oft nur 'Erledigt' und hatte keine Möglichkeit, gezielt offene oder in Bearbeitung befindliche Tasks anzuzeigen.

## Lösung
- **Filterleiste** über der Liste: **Alle / Offen / Doing / Erledigt** mit Live-Zählern je Status
- **Sortierung**: laufende (`in_progress`) und offene Tasks zuerst, Erledigtes/Abgebrochenes ans Ende
- Limit von 20 → 30 erhöht
- Hinweis 'Keine Tasks mit diesem Status', wenn ein Filter leer ist

## Test
- Typecheck grün (`tsc --noEmit`)
- Frontend-Build grün (7.67s)
- Rein additive Frontend-Änderung, keine API-/Backend-Änderung