### PR TITLE
feat(cockpit): Verbrauchs-/Guthaben-Box im Projekt-Cockpit

### DIFF
--- a/core/src/hydrahive/api/routes/llm.py
+++ b/core/src/hydrahive/api/routes/llm.py
@@ -13,8 +13,10 @@ from hydrahive.api.middleware.auth import require_admin, require_auth
 from hydrahive.llm import _config
 from hydrahive.llm import client as llm_client
 from hydrahive.llm import registry
+from hydrahive.llm._codex_usage import fetch_usage as fetch_codex_usage
 from hydrahive.llm._minimax_usage import fetch_usage as fetch_minimax_usage
 from hydrahive.llm._oauth_usage import get_oauth_rate_limits
+from hydrahive.llm._openrouter_credits import fetch_credits as fetch_openrouter_credits
 from hydrahive.settings import settings
 
 router = APIRouter(prefix="/api/llm", tags=["llm"])
@@ -96,6 +98,18 @@ async def minimax_usage(_: Annotated[tuple[str, str], Depends(require_auth)]) ->
 def anthropic_rate_limits(_: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
     """Anthropic OAuth Rate-Limits. Für alle User sichtbar — zeigt 5h/7d Utilization."""
     return get_oauth_rate_limits()
+
+
+@router.get("/codex/usage")
+async def codex_usage(_: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    """Codex Plan-Usage (5h/7d) aus der ChatGPT-OAuth. Ausgeblendet wenn kein OAuth aktiv."""
+    return await fetch_codex_usage()
+
+
+@router.get("/openrouter/credits")
+async def openrouter_credits(_: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    """OpenRouter Restguthaben. Ausgeblendet wenn kein Key gesetzt."""
+    return await fetch_openrouter_credits()
 
 
 @router.get("/effort-models")

--- a/core/src/hydrahive/llm/_codex_usage.py
+++ b/core/src/hydrahive/llm/_codex_usage.py
@@ -1,0 +1,126 @@
+"""OpenAI Codex Plan-Usage — `GET /backend-api/wham/usage`.
+
+Nutzt die vorhandene Codex-OAuth (ChatGPT Plus/Pro). Liefert primary (5h) +
+secondary (7d) Fenster mit used_percent + reset — strukturgleich zu Anthropic.
+Das Frontend zeigt daraus 5h/7d-Balken mit Reset-Timer in der Cockpit-Box.
+
+30s In-Module-Cache verhindert Endpoint-Spam beim Cockpit-Polling.
+Bei fehlendem OAuth / Fehler: {available: False, reason: ...} — UI blendet aus.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+_cache: dict[str, Any] = {"data": None, "fetched_at": 0.0}
+_CACHE_TTL = 30.0
+
+_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _set_cache(data: dict) -> dict:
+    global _cache
+    _cache = {"data": data, "fetched_at": time.time()}
+    return data
+
+
+def _normalize_window(raw: Any) -> dict | None:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        used_pct = float(raw.get("used_percent") or 0)
+        reset_in_s = int(raw.get("reset_after_seconds") or 0)
+        window_s = int(raw.get("limit_window_seconds") or 0)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "used_pct": min(round(used_pct, 1), 100.0),
+        "reset_in_s": max(0, reset_in_s),
+        "window_s": window_s,
+    }
+
+
+async def fetch_usage() -> dict:
+    """Cached Codex-Plan-Usage-Abfrage.
+
+    Erfolg: {available: True, plan_type, primary, secondary, credits, fetched_at}
+    Fehler/no-oauth: {available: False, reason: ...}
+    """
+    if _cache["data"] is not None and (time.time() - _cache["fetched_at"]) < _CACHE_TTL:
+        return _cache["data"]
+
+    try:
+        from hydrahive.oauth.openai_codex import resolve_openai_codex_token
+        tok = await resolve_openai_codex_token()
+    except Exception as exc:
+        logger.debug("codex_usage token resolve failed: %s", exc)
+        return _set_cache({"available": False, "reason": "no_oauth", "fetched_at": _iso_now()})
+
+    access = tok.get("access", "")
+    account_id = tok.get("account_id", "")
+    if not access:
+        return _set_cache({"available": False, "reason": "no_oauth", "fetched_at": _iso_now()})
+
+    import httpx
+
+    headers = {"Authorization": f"Bearer {access}"}
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(_USAGE_URL, headers=headers)
+    except Exception as exc:
+        logger.warning("codex_usage HTTP fetch failed: %s", exc)
+        return _set_cache({"available": False, "reason": "network_error", "fetched_at": _iso_now()})
+
+    if resp.status_code in (401, 403):
+        return _set_cache({"available": False, "reason": "unauthorized", "fetched_at": _iso_now()})
+    if resp.status_code >= 400:
+        return _set_cache({"available": False, "reason": f"http_{resp.status_code}", "fetched_at": _iso_now()})
+
+    try:
+        raw = resp.json()
+    except ValueError:
+        return _set_cache({"available": False, "reason": "invalid_json", "fetched_at": _iso_now()})
+
+    if not isinstance(raw, dict):
+        return _set_cache({"available": False, "reason": "invalid_json", "fetched_at": _iso_now()})
+
+    rate = raw.get("rate_limit") or {}
+    primary = _normalize_window(rate.get("primary_window"))
+    secondary = _normalize_window(rate.get("secondary_window"))
+    if primary is None and secondary is None:
+        return _set_cache({"available": False, "reason": "no_data", "fetched_at": _iso_now()})
+
+    credits_raw = raw.get("credits") or {}
+    credits: dict[str, Any] = {}
+    if isinstance(credits_raw, dict):
+        credits = {
+            "has_credits": bool(credits_raw.get("has_credits")),
+            "unlimited": bool(credits_raw.get("unlimited")),
+        }
+        balance = credits_raw.get("balance")
+        if balance is not None:
+            try:
+                credits["balance"] = float(balance)
+            except (TypeError, ValueError):
+                pass
+
+    return _set_cache({
+        "available": True,
+        "fetched_at": _iso_now(),
+        "plan_type": str(raw.get("plan_type") or ""),
+        "primary": primary,
+        "secondary": secondary,
+        "credits": credits,
+    })

--- a/core/src/hydrahive/llm/_openrouter_credits.py
+++ b/core/src/hydrahive/llm/_openrouter_credits.py
@@ -1,0 +1,89 @@
+"""OpenRouter Credit-Guthaben — `GET /api/v1/credits`.
+
+Liefert total_credits + total_usage. Das Frontend zeigt daraus Restguthaben
+($ und Balken) in der Cockpit-Verbrauchsbox.
+
+30s In-Module-Cache verhindert API-Spam beim Cockpit-Polling.
+Bei fehlendem Key / Fehler: {available: False, reason: ...} — die UI blendet
+die Zeile dann komplett aus.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from hydrahive.llm._config import openrouter_key
+
+logger = logging.getLogger(__name__)
+
+
+_cache: dict[str, Any] = {"data": None, "fetched_at": 0.0}
+_CACHE_TTL = 30.0
+
+_CREDITS_URL = "https://openrouter.ai/api/v1/credits"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _set_cache(data: dict) -> dict:
+    global _cache
+    _cache = {"data": data, "fetched_at": time.time()}
+    return data
+
+
+async def fetch_credits() -> dict:
+    """Cached OpenRouter-Guthaben-Abfrage.
+
+    Erfolg: {available: True, total, used, remaining, used_pct, fetched_at}
+    Fehler/no-key: {available: False, reason: ...}
+    """
+    if _cache["data"] is not None and (time.time() - _cache["fetched_at"]) < _CACHE_TTL:
+        return _cache["data"]
+
+    key = openrouter_key()
+    if not key:
+        return _set_cache({"available": False, "reason": "no_api_key", "fetched_at": _iso_now()})
+
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(_CREDITS_URL, headers={"Authorization": f"Bearer {key}"})
+    except Exception as exc:
+        logger.warning("openrouter_credits HTTP fetch failed: %s", exc)
+        return _set_cache({"available": False, "reason": "network_error", "fetched_at": _iso_now()})
+
+    if resp.status_code == 401:
+        return _set_cache({"available": False, "reason": "invalid_api_key", "fetched_at": _iso_now()})
+    if resp.status_code >= 400:
+        return _set_cache({"available": False, "reason": f"http_{resp.status_code}", "fetched_at": _iso_now()})
+
+    try:
+        raw = resp.json()
+    except ValueError:
+        return _set_cache({"available": False, "reason": "invalid_json", "fetched_at": _iso_now()})
+
+    data = raw.get("data") if isinstance(raw, dict) else None
+    if not isinstance(data, dict):
+        return _set_cache({"available": False, "reason": "invalid_json", "fetched_at": _iso_now()})
+
+    try:
+        total = float(data.get("total_credits") or 0)
+        used = float(data.get("total_usage") or 0)
+    except (TypeError, ValueError):
+        return _set_cache({"available": False, "reason": "invalid_json", "fetched_at": _iso_now()})
+
+    remaining = round(total - used, 4)
+    used_pct = round(used / total * 100, 1) if total > 0 else 0.0
+    return _set_cache({
+        "available": True,
+        "fetched_at": _iso_now(),
+        "total": round(total, 4),
+        "used": round(used, 4),
+        "remaining": remaining,
+        "used_pct": min(used_pct, 100.0),
+    })

--- a/core/tests/test_usage_endpoints.py
+++ b/core/tests/test_usage_endpoints.py
@@ -1,0 +1,124 @@
+"""Tests: OpenRouter-Credits + Codex-Usage Normalisierung.
+
+Gemockte HTTP-Responses — kein Netzwerk. Prüft die Parsing-Logik und das
+'available: False'-Verhalten (fehlender Key/OAuth), das die UI zum Ausblenden
+der jeweiligen Zeile nutzt.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from hydrahive.llm import _codex_usage, _openrouter_credits
+
+
+def _fake_response(status_code: int, json_body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=json_body)
+    return resp
+
+
+def _fake_client_ctx(resp: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.get = AsyncMock(return_value=resp)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _reset_caches() -> None:
+    _openrouter_credits._cache = {"data": None, "fetched_at": 0.0}
+    _codex_usage._cache = {"data": None, "fetched_at": 0.0}
+
+
+# ---------- OpenRouter ----------
+
+def test_openrouter_credits_computes_remaining_and_pct():
+    _reset_caches()
+    resp = _fake_response(200, {"data": {"total_credits": 100, "total_usage": 81.32}})
+    with patch.object(_openrouter_credits, "openrouter_key", return_value="sk-or-test"), \
+         patch("httpx.AsyncClient", return_value=_fake_client_ctx(resp)):
+        out = asyncio.run(_openrouter_credits.fetch_credits())
+    assert out["available"] is True
+    assert out["total"] == 100
+    assert out["used"] == 81.32
+    assert out["remaining"] == 18.68
+    assert out["used_pct"] == 81.3
+
+
+def test_openrouter_credits_no_key_is_unavailable():
+    _reset_caches()
+    with patch.object(_openrouter_credits, "openrouter_key", return_value=""):
+        out = asyncio.run(_openrouter_credits.fetch_credits())
+    assert out["available"] is False
+    assert out["reason"] == "no_api_key"
+
+
+def test_openrouter_credits_401_invalid_key():
+    _reset_caches()
+    resp = _fake_response(401, {})
+    with patch.object(_openrouter_credits, "openrouter_key", return_value="sk-bad"), \
+         patch("httpx.AsyncClient", return_value=_fake_client_ctx(resp)):
+        out = asyncio.run(_openrouter_credits.fetch_credits())
+    assert out["available"] is False
+    assert out["reason"] == "invalid_api_key"
+
+
+def test_openrouter_credits_zero_total_no_div_by_zero():
+    _reset_caches()
+    resp = _fake_response(200, {"data": {"total_credits": 0, "total_usage": 0}})
+    with patch.object(_openrouter_credits, "openrouter_key", return_value="sk-or-test"), \
+         patch("httpx.AsyncClient", return_value=_fake_client_ctx(resp)):
+        out = asyncio.run(_openrouter_credits.fetch_credits())
+    assert out["available"] is True
+    assert out["used_pct"] == 0.0
+    assert out["remaining"] == 0
+
+
+# ---------- Codex ----------
+
+_CODEX_OK = {
+    "plan_type": "prolite",
+    "rate_limit": {
+        "primary_window": {"used_percent": 47, "limit_window_seconds": 18000, "reset_after_seconds": 6189},
+        "secondary_window": {"used_percent": 21, "limit_window_seconds": 604800, "reset_after_seconds": 556542},
+    },
+    "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+}
+
+
+def test_codex_usage_normalizes_windows():
+    _reset_caches()
+    resp = _fake_response(200, _CODEX_OK)
+    with patch("hydrahive.oauth.openai_codex.resolve_openai_codex_token",
+               AsyncMock(return_value={"access": "tok", "account_id": "acc"})), \
+         patch("httpx.AsyncClient", return_value=_fake_client_ctx(resp)):
+        out = asyncio.run(_codex_usage.fetch_usage())
+    assert out["available"] is True
+    assert out["plan_type"] == "prolite"
+    assert out["primary"]["used_pct"] == 47.0
+    assert out["primary"]["reset_in_s"] == 6189
+    assert out["secondary"]["used_pct"] == 21.0
+    assert out["credits"]["has_credits"] is False
+
+
+def test_codex_usage_no_oauth_is_unavailable():
+    _reset_caches()
+    with patch("hydrahive.oauth.openai_codex.resolve_openai_codex_token",
+               AsyncMock(return_value={"access": "", "account_id": ""})):
+        out = asyncio.run(_codex_usage.fetch_usage())
+    assert out["available"] is False
+    assert out["reason"] == "no_oauth"
+
+
+def test_codex_usage_403_unauthorized():
+    _reset_caches()
+    resp = _fake_response(403, {})
+    with patch("hydrahive.oauth.openai_codex.resolve_openai_codex_token",
+               AsyncMock(return_value={"access": "tok", "account_id": "acc"})), \
+         patch("httpx.AsyncClient", return_value=_fake_client_ctx(resp)):
+        out = asyncio.run(_codex_usage.fetch_usage())
+    assert out["available"] is False
+    assert out["reason"] == "unauthorized"

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -20,6 +20,7 @@ import { ProjectMountsOverlay } from "./project/ProjectMountsOverlay"
 import { ProjectInsightsOverlay, type ProjectInsightView } from "./project/ProjectInsightsOverlay"
 import { ProjectAgentsPanel } from "./project/ProjectAgentsPanel"
 import { ProjectAiSettingsPanel } from "./project/ProjectAiSettingsPanel"
+import { CockpitUsagePanel } from "./project/CockpitUsagePanel"
 import { ProjectGitSummary } from "./project/ProjectGitSummary"
 import { ProjectGitOverlay } from "./project/ProjectGitOverlay"
 import { ProjectIntegrationsOverlay } from "./project/ProjectIntegrationsOverlay"
@@ -81,8 +82,8 @@ export function ProjectCockpitPage() {
   const selectedAgentId = activeProjectId ? (selectedAgentByProject[activeProjectId] ?? projectAgentId) : projectAgentId
   const selectedAgent = agents.find((agent) => agent.id === selectedAgentId) ?? null
   const selectedAgentModel = selectedAgent?.llm_model ?? ""
-  type LeftPanelId = "project" | "agents" | "git" | "ai"
-  const leftPanelDefaults: Record<LeftPanelId, boolean> = { project: false, agents: false, git: true, ai: true }
+  type LeftPanelId = "project" | "agents" | "git" | "ai" | "usage"
+  const leftPanelDefaults: Record<LeftPanelId, boolean> = { project: false, agents: false, git: true, ai: true, usage: false }
   const leftPanelCollapsed = { ...leftPanelDefaults, ...((prefs.preferences.cockpit_layout?.project_left_collapsed ?? {}) as Partial<Record<LeftPanelId, boolean>>) }
   const setLeftPanelCollapsed = (panel: LeftPanelId, collapsed: boolean) => {
     void prefs.patch({
@@ -181,6 +182,16 @@ export function ProjectCockpitPage() {
               agents={agents}
               onAgentChanged={(updated) => setAgents((cur) => cur.map((agent) => agent.id === updated.id ? { ...agent, ...updated } : agent))}
             />
+          </CollapsibleCockpitPanel>
+
+          <CollapsibleCockpitPanel
+            title="Verbrauch"
+            eyebrow="Guthaben"
+            summary="Modell-Kontingente"
+            collapsed={leftPanelCollapsed.usage}
+            onToggle={() => setLeftPanelCollapsed("usage", !leftPanelCollapsed.usage)}
+          >
+            <CockpitUsagePanel />
           </CollapsibleCockpitPanel>
         </aside>
 

--- a/frontend/src/features/cockpit/project/CockpitUsagePanel.tsx
+++ b/frontend/src/features/cockpit/project/CockpitUsagePanel.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react"
+import { api } from "@/shared/api-client"
+import {
+  llmApi,
+  type AnthropicRateLimits,
+  type CodexUsage,
+  type OpenRouterCredits,
+} from "@/features/llm/api"
+
+const REFRESH_MS = 60_000
+
+interface MinimaxModel {
+  label: string
+  category: string
+  weekly_total: number
+  weekly_used: number
+  weekly_pct: number
+  interval_reset_in_s: number
+}
+interface MinimaxUsage {
+  available: boolean
+  reason?: string
+  models?: MinimaxModel[]
+}
+
+function fmtResetIn(s: number): string {
+  if (s <= 0) return "—"
+  const d = Math.floor(s / 86400)
+  if (d > 0) return `${d}d ${Math.floor((s % 86400) / 3600)}h`
+  const h = Math.floor(s / 3600)
+  if (h > 0) return `${h}h ${Math.floor((s % 3600) / 60)}m`
+  return `${Math.max(1, Math.floor(s / 60))}m`
+}
+
+function barTone(pct: number): string {
+  if (pct >= 90) return "bg-rose-400"
+  if (pct >= 70) return "bg-amber-400"
+  return "bg-emerald-400"
+}
+
+/** Eine kompakte Balken-Zeile: Label · %-Balken · Reset/Zahl rechts. */
+function UsageBar({ label, pct, right }: { label: string; pct: number; right?: string }) {
+  const clamped = Math.max(0, Math.min(100, pct))
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-9 shrink-0 text-[10px] font-semibold uppercase tracking-wide text-[#8d9ab0]">{label}</span>
+      <div className="relative h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-white/[6%]">
+        <div className={`absolute inset-y-0 left-0 rounded-full ${barTone(clamped)}`} style={{ width: `${clamped}%` }} />
+      </div>
+      <span className="w-7 shrink-0 text-right text-[10px] tabular-nums text-[#c3ccdd]">{Math.round(clamped)}%</span>
+      {right !== undefined ? (
+        <span className="w-14 shrink-0 text-right text-[9px] tabular-nums text-[#7a869c]">{right}</span>
+      ) : null}
+    </div>
+  )
+}
+
+function ProviderBlock({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[9px] font-black uppercase tracking-[0.12em] text-[#5f6d84]">{name}</p>
+      {children}
+    </div>
+  )
+}
+
+export function CockpitUsagePanel() {
+  const [anthropic, setAnthropic] = useState<AnthropicRateLimits | null>(null)
+  const [codex, setCodex] = useState<CodexUsage | null>(null)
+  const [minimax, setMinimax] = useState<MinimaxUsage | null>(null)
+  const [openrouter, setOpenrouter] = useState<OpenRouterCredits | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    async function load() {
+      const [a, c, m, o] = await Promise.allSettled([
+        llmApi.getAnthropicRateLimits(),
+        llmApi.getCodexUsage(),
+        api.get<MinimaxUsage>("/llm/minimax/usage"),
+        llmApi.getOpenRouterCredits(),
+      ])
+      if (!alive) return
+      if (a.status === "fulfilled") setAnthropic(a.value)
+      if (c.status === "fulfilled") setCodex(c.value)
+      if (m.status === "fulfilled") setMinimax(m.value)
+      if (o.status === "fulfilled") setOpenrouter(o.value)
+    }
+    void load()
+    const id = setInterval(() => void load(), REFRESH_MS)
+    return () => { alive = false; clearInterval(id) }
+  }, [])
+
+  // Anthropic nur wenn echte Utilization-Daten vorliegen.
+  const aUtil5h = anthropic?.["5h_utilization"] ?? 0
+  const aUtil7d = anthropic?.["7d_utilization"] ?? 0
+  const showAnthropic = Boolean(anthropic?.updated_at) && (aUtil5h > 0 || aUtil7d > 0)
+
+  const showCodex = Boolean(codex?.available) && Boolean(codex?.primary || codex?.secondary)
+  const showOpenrouter = Boolean(openrouter?.available)
+  const minimaxModels = (minimax?.available ? minimax.models ?? [] : []).filter((m) => m.weekly_total > 0)
+  const showMinimax = minimaxModels.length > 0
+
+  const anyActive = showAnthropic || showCodex || showOpenrouter || showMinimax
+
+  return (
+    <div className="space-y-3">
+      {!anyActive ? (
+        <p className="text-xs text-[#7a869c]">Keine aktive Modellquelle mit Verbrauchsdaten.</p>
+      ) : null}
+
+      {showAnthropic ? (
+        <ProviderBlock name="Anthropic">
+          {aUtil5h > 0 ? <UsageBar label="5h" pct={aUtil5h * 100} right={fmtResetIn(secondsUntil(anthropic?.["5h_reset"]))} /> : null}
+          {aUtil7d > 0 ? <UsageBar label="7d" pct={aUtil7d * 100} right={fmtResetIn(secondsUntil(anthropic?.["7d_reset"]))} /> : null}
+        </ProviderBlock>
+      ) : null}
+
+      {showCodex ? (
+        <ProviderBlock name={`Codex${codex?.plan_type ? ` · ${codex.plan_type}` : ""}`}>
+          {codex?.primary ? <UsageBar label="5h" pct={codex.primary.used_pct} right={fmtResetIn(codex.primary.reset_in_s)} /> : null}
+          {codex?.secondary ? <UsageBar label="7d" pct={codex.secondary.used_pct} right={fmtResetIn(codex.secondary.reset_in_s)} /> : null}
+        </ProviderBlock>
+      ) : null}
+
+      {showOpenrouter ? (
+        <ProviderBlock name="OpenRouter">
+          <UsageBar
+            label="Rest"
+            pct={openrouter?.used_pct ?? 0}
+            right={`$${(openrouter?.remaining ?? 0).toFixed(2)}`}
+          />
+        </ProviderBlock>
+      ) : null}
+
+      {showMinimax ? (
+        <ProviderBlock name="MiniMax">
+          {minimaxModels.map((m) => (
+            <UsageBar key={m.label} label={m.category.slice(0, 4)} pct={m.weekly_pct} right={fmtResetIn(m.interval_reset_in_s)} />
+          ))}
+        </ProviderBlock>
+      ) : null}
+    </div>
+  )
+}
+
+/** ISO-Reset-Zeitpunkt → Sekunden ab jetzt (Anthropic liefert absolute Zeit). */
+function secondsUntil(iso?: string): number {
+  if (!iso) return 0
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return 0
+  return Math.max(0, Math.floor((t - Date.now()) / 1000))
+}

--- a/frontend/src/features/llm/api.ts
+++ b/frontend/src/features/llm/api.ts
@@ -40,6 +40,32 @@ export interface AnthropicRateLimits {
   overage_reset?: string
 }
 
+export interface CodexUsageWindow {
+  used_pct: number
+  reset_in_s: number
+  window_s: number
+}
+
+export interface CodexUsage {
+  available: boolean
+  reason?: string
+  fetched_at?: string
+  plan_type?: string
+  primary?: CodexUsageWindow | null
+  secondary?: CodexUsageWindow | null
+  credits?: { has_credits?: boolean; unlimited?: boolean; balance?: number }
+}
+
+export interface OpenRouterCredits {
+  available: boolean
+  reason?: string
+  fetched_at?: string
+  total?: number
+  used?: number
+  remaining?: number
+  used_pct?: number
+}
+
 export const llmApi = {
   getConfig: () => api.get<LlmConfig>("/llm"),
   updateConfig: (cfg: LlmConfig) => api.put<LlmConfig>("/llm", cfg),
@@ -53,6 +79,8 @@ export const llmApi = {
   oauthRevoke: (provider: string) =>
     api.delete<{ ok: boolean }>(`/llm/oauth/${provider}`),
   getAnthropicRateLimits: () => api.get<AnthropicRateLimits>("/llm/anthropic/rate-limits"),
+  getCodexUsage: () => api.get<CodexUsage>("/llm/codex/usage"),
+  getOpenRouterCredits: () => api.get<OpenRouterCredits>("/llm/openrouter/credits"),
 }
 
 export interface CatalogModel {


### PR DESCRIPTION
## Was
Neue einklappbare **Verbrauchs-Box** in der linken Spalte des Projekt-Cockpits (unter 'KI Einstellungen'). Zeigt die Kontingente des jeweils aktiven Modells kompakt mit dünnen Balken + Reset-Timer. **Jede Zeile erscheint nur, wenn ihre Quelle aktiv bzw. der Token gesetzt ist** — kein Rauschen für ungenutzte Provider.

| Quelle | Anzeige | Endpoint |
|--------|---------|----------|
| **Anthropic** | 5h + 7d Utilization + Reset | bestehend |
| **Codex** | 5h + 7d Plan-Usage + Reset (+ plan_type) | **neu** `GET /llm/codex/usage` |
| **OpenRouter** | Restguthaben: Balken **und** $-Zahl | **neu** `GET /llm/openrouter/credits` |
| **MiniMax** | weekly-Kontingent + Reset | bestehend |

## Codex-Detail
Nutzt `https://chatgpt.com/backend-api/wham/usage` über die **bereits vorhandene ChatGPT-OAuth** (`resolve_openai_codex_token`). Liefert `primary_window` (5h) + `secondary_window` (7d) mit `used_percent` + `reset_after_seconds` — strukturgleich zu Anthropic. Live gegen echten Account verifiziert.

## Backend
- Zwei neue Fetch-Module (`_openrouter_credits.py`, `_codex_usage.py`) analog zu `_minimax_usage.py`: 30s-Cache, `available:false` + reason bei fehlendem Key/OAuth/Fehler.
- Zwei neue authentifizierte GET-Routes in `llm.py`.

## Frontend
- `CockpitUsagePanel`: pollt alle 60s, lädt alle 4 Quellen parallel (`Promise.allSettled`), blendet inaktive aus. Dünne 1.5px-Balken, platzoptimiert für die 270px-Spalte.
- Als 5. `CollapsibleCockpitPanel` eingehängt, Collapse-State pro User persistent.

## Tests / Checks
- 7 neue Unit-Tests (gemocktes httpx) — remaining/pct-Berechnung, no-key/no-oauth/401/403-Ausblenden, Fenster-Normalisierung. Grün.
- 48 bestehende LLM-Tests grün, ruff grün, ESLint grün, Typecheck grün, Frontend-Build grün.
- hh-review: alle Dateien <200 Zeilen, kein print(), keine hardcoded paths, keine zirkulären Imports.