### PR TITLE
fix(media): Videoschnitt als eigener Menüpunkt

### DIFF
--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ComponentType } from "react"
-import { Film, Images, Sparkles, Users, Video } from "lucide-react"
+import { Film, Images, Scissors, Sparkles, Users, Video } from "lucide-react"
 import { projectsApi } from "@/features/projects/api"
 import type { Project } from "@/features/projects/types"
 import { AtelierPage } from "@/modules/atelier/AtelierPage"
@@ -12,6 +12,8 @@ type AtelierStep = "characters" | "generate" | "gallery" | "clips" | "film"
 type ControlledAtelierProps = { projectId?: string; step?: AtelierStep; onStepChange?: (step: AtelierStep) => void; hideHeader?: boolean }
 const ControlledAtelierPage = AtelierPage as ComponentType<ControlledAtelierProps>
 
+type MediaView = AtelierStep | "editor"
+
 const steps = [
   { id: "characters", number: "01", title: "Charaktere", text: "Figuren auswählen und verwalten", icon: Users },
   { id: "generate", number: "02", title: "Bild erzeugen", text: "Keyframes und Motive erstellen", icon: Sparkles },
@@ -23,7 +25,7 @@ const steps = [
 export function MediaCockpitPage() {
   const [projects, setProjects] = useState<Project[]>([])
   const [projectId, setProjectId] = useState("")
-  const [step, setStep] = useState<AtelierStep>("generate")
+  const [view, setView] = useState<MediaView>("generate")
 
   useEffect(() => {
     projectsApi.list().then((items) => {
@@ -33,14 +35,15 @@ export function MediaCockpitPage() {
   }, [])
 
   const project = useMemo(() => projects.find((item) => item.id === projectId), [projects, projectId])
-  const activeIndex = steps.findIndex((item) => item.id === step)
+  const isEditor = view === "editor"
+  const activeIndex = steps.findIndex((item) => item.id === view)
+  const activeStep = steps[activeIndex]
 
   return (
     <CockpitShell title="Media-Cockpit" eyebrow="Media" description="Geführter Produktionsablauf" hideHeader className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]">
       <CockpitTopbar active="media" context={project?.name ?? "Projekt laden…"} action={{ label: "Atelier", path: "/atelier" }} />
-      <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="grid min-h-[600px] gap-[10px] p-[10px] lg:grid-cols-[280px_minmax(0,1fr)]">
-        <aside className="panel overflow-y-auto rounded-[4px] border border-[#2a364b] bg-[#151c2b] p-3">
+      <div className="grid min-h-0 flex-1 gap-[10px] overflow-hidden p-[10px] lg:grid-cols-[280px_minmax(0,1fr)]">
+        <aside className="panel min-h-0 overflow-y-auto rounded-[4px] border border-[#2a364b] bg-[#151c2b] p-3">
           <CockpitSectionLabel>Projekt</CockpitSectionLabel>
           <select value={projectId} onChange={(event) => setProjectId(event.target.value)} className="mt-2 w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8]">
             {projects.length === 0 && <option value="">Projekte laden…</option>}
@@ -49,33 +52,53 @@ export function MediaCockpitPage() {
 
           <div className="mt-5 flex items-center justify-between gap-2">
             <CockpitSectionLabel>Produktion</CockpitSectionLabel>
-            <span className="font-mono text-[10px] text-[#8d9ab0]">{activeIndex + 1} / {steps.length}</span>
+            <span className="font-mono text-[10px] text-[#8d9ab0]">{activeIndex >= 0 ? activeIndex + 1 : "–"} / {steps.length}</span>
           </div>
           <nav className="mt-2 space-y-2" aria-label="Produktionsschritte">
             {steps.map((item, index) => {
               const Icon = item.icon
-              const active = item.id === step
+              const active = item.id === view
               return (
-                <button key={item.id} onClick={() => setStep(item.id)} className={["grid w-full grid-cols-[32px_1fr] gap-2 rounded-[4px] border p-2 text-left transition-colors", active ? "border-[#ffb86b]/55 bg-[#30243a]" : "border-[#2a364b] bg-[#111827] hover:border-[#46617f]"].join(" ")}>
+                <button key={item.id} onClick={() => setView(item.id)} className={["grid w-full grid-cols-[32px_1fr] gap-2 rounded-[4px] border p-2 text-left transition-colors", active ? "border-[#ffb86b]/55 bg-[#30243a]" : "border-[#2a364b] bg-[#111827] hover:border-[#46617f]"].join(" ")}>
                   <span className={["grid h-8 w-8 place-items-center rounded-[3px] border", active ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] bg-[#0d1420] text-[#8d9ab0]"].join(" ")}><Icon size={15} /></span>
-                  <span className="min-w-0"><span className="flex items-center justify-between gap-2"><strong className="text-sm text-[#e8eef8]">{item.title}</strong><span className="font-mono text-[10px] text-[#68758a]">{item.number}</span></span><span className="block text-xs leading-4 text-[#8d9ab0]">{item.text}</span>{index < activeIndex && <span className="mt-1 block text-[10px] uppercase tracking-[0.12em] text-[#4ade80]">durchlaufen</span>}</span>
+                  <span className="min-w-0"><span className="flex items-center justify-between gap-2"><strong className="text-sm text-[#e8eef8]">{item.title}</strong><span className="font-mono text-[10px] text-[#68758a]">{item.number}</span></span><span className="block text-xs leading-4 text-[#8d9ab0]">{item.text}</span>{activeIndex >= 0 && index < activeIndex && <span className="mt-1 block text-[10px] uppercase tracking-[0.12em] text-[#4ade80]">durchlaufen</span>}</span>
                 </button>
               )
             })}
           </nav>
+
+          {/* Trenner + eigener Menüpunkt Nachbearbeitung */}
+          <div className="mt-5 border-t border-[#2a364b] pt-4">
+            <CockpitSectionLabel>Nachbearbeitung</CockpitSectionLabel>
+            <button onClick={() => setView("editor")} className={["mt-2 grid w-full grid-cols-[32px_1fr] gap-2 rounded-[4px] border p-2 text-left transition-colors", isEditor ? "border-[#ffb86b]/55 bg-[#30243a]" : "border-[#2a364b] bg-[#111827] hover:border-[#46617f]"].join(" ")}>
+              <span className={["grid h-8 w-8 place-items-center rounded-[3px] border", isEditor ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] bg-[#0d1420] text-[#8d9ab0]"].join(" ")}><Scissors size={15} /></span>
+              <span className="min-w-0"><strong className="text-sm text-[#e8eef8]">Videoschnitt</strong><span className="block text-xs leading-4 text-[#8d9ab0]">Clips schneiden und vertonen</span></span>
+            </button>
+          </div>
         </aside>
 
         <main className="panel grid min-h-0 grid-rows-[auto_1fr] overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#151c2b]">
           <header className="border-b border-[#2a364b] bg-[#111827] px-4 py-3">
-            <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#ffb86b]">Schritt {String(activeIndex + 1).padStart(2, "0")}</span>
-            <h1 className="mt-1 text-lg font-semibold text-[#e8eef8]">{steps[activeIndex]?.title}</h1>
-            <p className="mt-1 text-xs text-[#8d9ab0]">{steps[activeIndex]?.text}</p>
+            {isEditor ? (
+              <>
+                <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#ffb86b]">Nachbearbeitung</span>
+                <h1 className="mt-1 text-lg font-semibold text-[#e8eef8]">Videoschnitt</h1>
+                <p className="mt-1 text-xs text-[#8d9ab0]">Clips auf Spuren schneiden, vertonen und exportieren</p>
+              </>
+            ) : (
+              <>
+                <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#ffb86b]">Schritt {String(activeIndex + 1).padStart(2, "0")}</span>
+                <h1 className="mt-1 text-lg font-semibold text-[#e8eef8]">{activeStep?.title}</h1>
+                <p className="mt-1 text-xs text-[#8d9ab0]">{activeStep?.text}</p>
+              </>
+            )}
           </header>
-          <div className="min-h-0 overflow-hidden p-4"><ControlledAtelierPage projectId={projectId} step={step} onStepChange={setStep} hideHeader /></div>
+          <div className="min-h-0 overflow-y-auto p-4">
+            {isEditor
+              ? <MediaPostProduction />
+              : <ControlledAtelierPage projectId={projectId} step={view as AtelierStep} onStepChange={setView} hideHeader />}
+          </div>
         </main>
-      </div>
-
-      <MediaPostProduction />
       </div>
     </CockpitShell>
   )

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,4 +1,4 @@
-import { Film, Mic, Music, Pause, Play, Plus, Scissors, SkipBack, SkipForward, Sparkles, Square, Video } from "lucide-react"
+import { Film, Mic, Music, Pause, Play, Plus, SkipBack, SkipForward, Sparkles, Square, Video } from "lucide-react"
 import type { ComponentType } from "react"
 
 /** Dummy-Nachbearbeitung: 3 virtuelle Monitore (2× Input, 1× Output) + Mehrspur-Leiste.
@@ -58,18 +58,12 @@ function TransportButton({ icon: Icon, label, primary }: { icon: ComponentType<{
 
 export function MediaPostProduction() {
   return (
-    <section className="mt-[10px] border-t border-[#2a364b] px-[10px] pb-[10px] pt-4">
-      {/* Trenner Nachbearbeitung */}
-      <div className="mb-3 flex items-center gap-3">
-        <span className="grid h-7 w-7 place-items-center rounded-[4px] border border-[#2a364b] bg-[#111827] text-[#ffb86b]"><Scissors size={14} /></span>
-        <div>
-          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#ffb86b]">Nachbearbeitung</p>
-          <h2 className="text-base font-semibold text-[#e8eef8]">Videoschnitt</h2>
-        </div>
-        <span className="ml-auto rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[#68758a]">Dummy · in Arbeit</span>
+    <div>
+      <div className="mb-3 flex justify-end">
+        <span className="rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[#68758a]">Dummy · in Arbeit</span>
       </div>
 
-      <div className="rounded-[4px] border border-[#2a364b] bg-[#151c2b] p-3">
+      <div>
         {/* 3 Monitore: Input 1, Input 2, Output */}
         <div className="grid gap-3 lg:grid-cols-3">
           <Monitor title="Input · Vid 1" kind="input" />
@@ -125,6 +119,6 @@ export function MediaPostProduction() {
           })}
         </div>
       </div>
-    </section>
+    </div>
   )
 }


### PR DESCRIPTION
## Korrektur zu #309
Der Videoschnitt hing als Sektion unten am Flow — gewünscht war ein **eigener Menüpunkt links**, der rechts aufgeht wie die anderen Schritte.

## Jetzt
- **Linke Leiste:** 5 Produktionsschritte, dann **Trenner** mit Label 'Nachbearbeitung', darunter Menüpunkt **Videoschnitt** (Scheren-Icon)
- **Hauptbereich:** Klick auf Videoschnitt öffnet den Editor mit eigenem Header ('Nachbearbeitung / Videoschnitt') — gleiche Mechanik wie Charaktere/Galerie/etc.
- Layout zurück auf feste Höhe (kein Seiten-Scroll mehr)
- Dummy-Inhalt unverändert: 3 Monitore (Input Vid1/Vid2/Output), Transport, Dropdown, 5 Spuren

Typecheck, ESLint, Build grün.