### PR TITLE
feat(media): Videoschnitt V1 — Clip-Bibliothek + Spuren

### DIFF
--- a/docs/specs/videocut-v1.md
+++ b/docs/specs/videocut-v1.md
@@ -1,0 +1,42 @@
+# Videoschnitt V1 — Clip-Bibliothek + Clips auf Spur legen
+
+## Was
+Erster funktionaler Slice des Videoschnitts im Media-Cockpit (Menüpunkt „Videoschnitt").
+Clip-Bibliothek aus vorhandenen Atelier-Beständen, Clips per Klick auf Spuren legen,
+dateibasierte Persistenz. Kein Playback (V2), kein Trim/Split (V3).
+
+## Warum
+Stückweiser Aufbau des Schnittpults (Roadmap-Task d40a4c59). V1 liefert das Fundament:
+Datenfluss Bibliothek → Asset-Referenz → Timeline-Clip → Persistenz.
+
+## Wie
+- **Backend: keine Änderungen.** Wiederverwendet wird die vorhandene Timeline-API
+  (`GET/PUT /api/projects/{pid}/media-projects/{slug}/timeline`, media_workspace.py)
+  und die Asset-Referenz-API (media_assets.py).
+- **Media-Projekt „schnitt"**: beim ersten Öffnen automatisch angelegt (list → create falls fehlt).
+- **Spur-Mapping** (UI → Timeline-Track-Kind): Video 1→video, Video 2→video,
+  Musik→music, Effekt→audio, Sprache→voice. 5 Default-Tracks mit festen IDs
+  (vid1/vid2/music/fx/voice) beim ersten Speichern.
+- **Bibliothek** speist sich aus Atelier-APIs des aktiven Projekts:
+  - Bilder: `atelier/projects/{pid}/gallery` (GalleryItem.rel)
+  - Videos: `atelier/projects/{pid}/videos` (VideoJob completed, video_rel, duration)
+  - Musik: `atelier/projects/{pid}/audio/library` (AudioLibraryItem.rel)
+- **Hinzufügen**: Item-Klick → Ziel-Spur (Video→vid1/vid2 wählbar, Audio→music/fx/voice
+  wählbar, Bild→vid1/vid2 als Standbild 5s) → Asset-Referenz anlegen falls für
+  rel_path noch keine existiert (rel_path = `atelier/<rel>`, source_project_id = aktives
+  Projekt) → Clip ans Spur-Ende (start = Summe vorhandener Clips) → PUT timeline.
+- **Dauer**: Video aus VideoJob.duration; Audio clientseitig via Audio-Element-Metadata
+  (Fallback 30s); Bild 5s fest (editierbar ab V7).
+- **Darstellung**: Clips als farbige Blöcke (proportional, feste px/s-Skala) mit Label,
+  Dauer, Entfernen (X). Ruler zeigt dynamische Sekunden-Marken.
+- **Dateien** (alle <200 Zeilen): `media/videocut/api.ts` (ensure+laden),
+  `media/videocut/useCutTimeline.ts` (State+Ops), `media/videocut/ClipLibrary.tsx`,
+  `media/videocut/TrackArea.tsx`, `MediaPostProduction.tsx` (Verdrahtung, Monitore bleiben Dummy).
+
+## Akzeptanzkriterien
+- [ ] Öffnen des Videoschnitts legt bei Bedarf still das Media-Projekt „schnitt" an
+- [ ] Bibliothek zeigt Bilder/Videos/Musik des aktiven Projekts mit Thumbnail/Icon
+- [ ] Klick legt Clip auf die gewählte Spur, Block erscheint proportional
+- [ ] Timeline überlebt Reload (PUT/GET über vorhandene API)
+- [ ] Clip entfernen funktioniert und persistiert
+- [ ] Keine Backend-Änderung, Build/Typecheck/ESLint grün

--- a/frontend/src/features/cockpit/MediaCockpitPage.tsx
+++ b/frontend/src/features/cockpit/MediaCockpitPage.tsx
@@ -95,7 +95,7 @@ export function MediaCockpitPage() {
           </header>
           <div className="min-h-0 overflow-y-auto p-4">
             {isEditor
-              ? <MediaPostProduction />
+              ? <MediaPostProduction projectId={projectId} />
               : <ControlledAtelierPage projectId={projectId} step={view as AtelierStep} onStepChange={setView} hideHeader />}
           </div>
         </main>

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,23 +1,11 @@
-import { Film, Mic, Music, Pause, Play, Plus, SkipBack, SkipForward, Sparkles, Square, Video } from "lucide-react"
+import { Film, Pause, Play, SkipBack, SkipForward, Square } from "lucide-react"
 import type { ComponentType } from "react"
+import { ClipLibrary } from "./videocut/ClipLibrary"
+import { TrackArea } from "./videocut/TrackArea"
+import { useCutTimeline } from "./videocut/useCutTimeline"
 
-/** Dummy-Nachbearbeitung: 3 virtuelle Monitore (2× Input, 1× Output) + Mehrspur-Leiste.
- *  Reine Platzhalter-UI, keine Funktion — dient als Gerüst für den stückweisen Ausbau. */
-
-interface TrackDef {
-  id: string
-  label: string
-  icon: ComponentType<{ size?: number | string; className?: string }>
-  tone: string // Rand-/Akzentfarbe der Spur
-}
-
-const TRACKS: TrackDef[] = [
-  { id: "vid1", label: "Video 1", icon: Video, tone: "#5aa9ff" },
-  { id: "vid2", label: "Video 2", icon: Video, tone: "#7c9cff" },
-  { id: "music", label: "Musik", icon: Music, tone: "#4ade80" },
-  { id: "fx", label: "Effekt", icon: Sparkles, tone: "#c084fc" },
-  { id: "voice", label: "Sprache", icon: Mic, tone: "#ffb86b" },
-]
+/** Videoschnitt (V1): Clip-Bibliothek + Spuren mit Persistenz.
+ *  Monitore + Transport sind noch Platzhalter (V2). */
 
 function Monitor({ title, kind }: { title: string; kind: "input" | "output" }) {
   const accent = kind === "output" ? "#ffb86b" : "#5aa9ff"
@@ -28,7 +16,6 @@ function Monitor({ title, kind }: { title: string; kind: "input" | "output" }) {
         <span className="font-mono text-[10px] text-[#68758a]">00:00:00</span>
       </div>
       <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
-        {/* Platzhalter-Raster */}
         <div className="absolute inset-0 opacity-[0.06]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "24px 24px" }} />
         <div className="absolute inset-0 grid place-items-center">
           <div className="flex flex-col items-center gap-1 text-[#3f4b60]">
@@ -43,27 +30,24 @@ function Monitor({ title, kind }: { title: string; kind: "input" | "output" }) {
 
 function TransportButton({ icon: Icon, label, primary }: { icon: ComponentType<{ size?: number | string }>; label: string; primary?: boolean }) {
   return (
-    <button
-      type="button"
-      title={label}
-      aria-label={label}
-      disabled
+    <button type="button" title={label} aria-label={label} disabled
       className={["grid h-8 w-8 place-items-center rounded-[4px] border transition-colors",
-        primary ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] bg-[#111827] text-[#8d9ab0]"].join(" ")}
-    >
+        primary ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] bg-[#111827] text-[#8d9ab0]"].join(" ")}>
       <Icon size={15} />
     </button>
   )
 }
 
-export function MediaPostProduction() {
-  return (
-    <div>
-      <div className="mb-3 flex justify-end">
-        <span className="rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-[#68758a]">Dummy · in Arbeit</span>
-      </div>
+interface Props {
+  projectId: string
+}
 
-      <div>
+export function MediaPostProduction({ projectId }: Props) {
+  const { timeline, assets, loading, saving, error, addClip, removeClip } = useCutTimeline(projectId)
+
+  return (
+    <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_260px]">
+      <div className="min-w-0">
         {/* 3 Monitore: Input 1, Input 2, Output */}
         <div className="grid gap-3 lg:grid-cols-3">
           <Monitor title="Input · Vid 1" kind="input" />
@@ -71,7 +55,7 @@ export function MediaPostProduction() {
           <Monitor title="Output" kind="output" />
         </div>
 
-        {/* Transport + Dropdown */}
+        {/* Transport (V2) + Status */}
         <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#2a364b] pt-3">
           <TransportButton icon={SkipBack} label="Zum Anfang" />
           <TransportButton icon={Play} label="Abspielen" primary />
@@ -79,46 +63,28 @@ export function MediaPostProduction() {
           <TransportButton icon={Square} label="Stopp" />
           <TransportButton icon={SkipForward} label="Zum Ende" />
           <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">00:00:00 / 00:00:00</span>
-
-          <div className="ml-auto flex items-center gap-2">
-            <label className="font-mono text-[10px] uppercase tracking-[0.12em] text-[#68758a]">Auflösung</label>
-            <select disabled className="rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-2 py-1.5 text-xs text-[#e8eef8]">
-              <option>1080p · 25 fps</option>
-              <option>720p · 25 fps</option>
-              <option>4K · 25 fps</option>
-            </select>
-            <button type="button" disabled className="inline-flex items-center gap-1.5 rounded-[4px] border border-[#2a364b] bg-[#111827] px-2.5 py-1.5 text-xs font-semibold text-[#8d9ab0]">
-              <Plus size={13} /> Clip
-            </button>
-          </div>
+          <span className="ml-auto text-[10px] uppercase tracking-[0.12em] text-[#68758a]">
+            {loading ? "Lade…" : saving ? "Speichere…" : "Gespeichert"}
+          </span>
         </div>
 
-        {/* Zeitleiste (Ruler) */}
-        <div className="mt-3 grid grid-cols-[84px_1fr] gap-2">
-          <div />
-          <div className="flex justify-between rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-1 font-mono text-[9px] text-[#68758a]">
-            {["0s", "5s", "10s", "15s", "20s", "25s", "30s"].map((t) => <span key={t}>{t}</span>)}
-          </div>
-        </div>
+        {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
 
-        {/* Spuren: vid1, vid2, musik, effekt, sprache */}
-        <div className="mt-2 space-y-1.5">
-          {TRACKS.map((track) => {
-            const Icon = track.icon
-            return (
-              <div key={track.id} className="grid grid-cols-[84px_1fr] gap-2">
-                <div className="flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-1.5" style={{ borderLeft: `3px solid ${track.tone}` }}>
-                  <Icon size={13} className="shrink-0" />
-                  <span className="truncate text-[11px] font-semibold text-[#c3ccdd]">{track.label}</span>
-                </div>
-                <div className="relative h-9 overflow-hidden rounded-[3px] border border-[#223048] bg-[#0d1420]">
-                  <div className="absolute inset-0 opacity-[0.04]" style={{ backgroundImage: "linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "48px 100%" }} />
-                </div>
-              </div>
-            )
-          })}
+        {/* Spuren mit echten Clips */}
+        <div className="mt-3">
+          {timeline ? (
+            <TrackArea timeline={timeline} assets={assets} onRemoveClip={removeClip} />
+          ) : (
+            <p className="text-xs text-[#7a869c]">{loading ? "Timeline wird geladen…" : "Keine Timeline verfügbar."}</p>
+          )}
         </div>
       </div>
+
+      {/* Clip-Bibliothek rechts */}
+      <aside className="min-h-0 rounded-[4px] border border-[#2a364b] bg-[#111827] p-2 xl:max-h-[calc(100vh-220px)]">
+        <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Bibliothek</p>
+        <ClipLibrary projectId={projectId} onAdd={(item, trackId, url) => void addClip(item, trackId, url)} disabled={!timeline || saving} />
+      </aside>
     </div>
   )
 }

--- a/frontend/src/features/cockpit/media/videocut/ClipLibrary.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ClipLibrary.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react"
+import { Image as ImageIcon, Music, Video } from "lucide-react"
+import { atelierApi } from "@/modules/atelier/api"
+import { libraryFileUrl, loadLibrary, type LibraryItem } from "./api"
+
+interface Props {
+  projectId: string
+  /** Item + Ziel-Spur-ID (vom User gewählt). */
+  onAdd: (item: LibraryItem, trackId: string, previewUrl: string | null) => void
+  disabled: boolean
+}
+
+const KIND_TABS = [
+  { id: "video" as const, label: "Videos", icon: Video },
+  { id: "image" as const, label: "Bilder", icon: ImageIcon },
+  { id: "audio" as const, label: "Audio", icon: Music },
+]
+
+/** Ziel-Spuren je Medientyp. */
+const TARGETS: Record<LibraryItem["kind"], { id: string; label: string }[]> = {
+  video: [{ id: "vid1", label: "Video 1" }, { id: "vid2", label: "Video 2" }],
+  image: [{ id: "vid1", label: "Video 1" }, { id: "vid2", label: "Video 2" }],
+  audio: [{ id: "music", label: "Musik" }, { id: "fx", label: "Effekt" }, { id: "voice", label: "Sprache" }],
+}
+
+export function ClipLibrary({ projectId, onAdd, disabled }: Props) {
+  const [items, setItems] = useState<LibraryItem[] | null>(null)
+  const [kind, setKind] = useState<LibraryItem["kind"]>("video")
+  const [pending, setPending] = useState<LibraryItem | null>(null)
+
+  useEffect(() => {
+    if (!projectId) return
+    let alive = true
+    ;(async () => {
+      let root: string | null = null
+      try { root = (await atelierApi.meta(projectId)).root } catch { /* ohne root keine previews */ }
+      const list = await loadLibrary(projectId, root)
+      if (alive) setItems(list)
+    })()
+    return () => { alive = false }
+  }, [projectId])
+
+  const loading = items === null
+
+  const allItems = items ?? []
+  const visible = allItems.filter((item) => item.kind === kind)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex gap-1">
+        {KIND_TABS.map((tab) => {
+          const Icon = tab.icon
+          const count = allItems.filter((i) => i.kind === tab.id).length
+          return (
+            <button key={tab.id} onClick={() => { setKind(tab.id); setPending(null) }}
+              className={["inline-flex items-center gap-1.5 rounded-[3px] px-2 py-1 text-[11px] font-semibold",
+                kind === tab.id ? "bg-cyan-400/15 text-cyan-100" : "bg-white/[5%] text-zinc-500 hover:text-zinc-300"].join(" ")}>
+              <Icon size={12} /> {tab.label} <span className="opacity-60">{count}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {loading ? <p className="mt-2 text-xs text-[#7a869c]">Lade Bibliothek…</p> : null}
+      {!loading && visible.length === 0 ? <p className="mt-2 text-xs text-[#7a869c]">Keine Einträge — im Atelier generieren.</p> : null}
+
+      <div className="mt-2 grid min-h-0 flex-1 auto-rows-min grid-cols-2 gap-1.5 overflow-y-auto pr-1 sm:grid-cols-3">
+        {visible.map((item) => (
+          <div key={item.key} className="rounded-[3px] border border-[#223048] bg-[#111827] p-1">
+            <div className="relative aspect-video overflow-hidden rounded-[2px] bg-black">
+              {item.kind === "image" && item.absPath ? (
+                <img src={libraryFileUrl(item.absPath)} alt="" className="h-full w-full object-cover" loading="lazy" />
+              ) : item.kind === "video" && item.absPath ? (
+                <video src={libraryFileUrl(item.absPath)} className="h-full w-full object-cover" preload="metadata" muted />
+              ) : (
+                <div className="grid h-full place-items-center text-[#3f4b60]"><Music size={18} /></div>
+              )}
+            </div>
+            <p className="mt-1 truncate text-[10px] text-[#c3ccdd]" title={item.label}>{item.label}</p>
+            {pending?.key === item.key ? (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {TARGETS[item.kind].map((target) => (
+                  <button key={target.id} disabled={disabled}
+                    onClick={() => { onAdd(item, target.id, item.absPath ? libraryFileUrl(item.absPath) : null); setPending(null) }}
+                    className="rounded-[2px] bg-cyan-400/15 px-1.5 py-0.5 text-[9px] font-bold uppercase text-cyan-100 hover:bg-cyan-400/25">
+                    → {target.label}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <button disabled={disabled} onClick={() => setPending(item)}
+                className="mt-1 w-full rounded-[2px] bg-white/[5%] px-1.5 py-0.5 text-[9px] font-bold uppercase text-zinc-400 hover:text-zinc-200">
+                + zur Spur
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -1,0 +1,93 @@
+import { Mic, Music, Sparkles, Video, X } from "lucide-react"
+import type { ComponentType } from "react"
+import type { MediaAssetReference } from "../../mediaProjectsApi"
+import type { MediaTimeline } from "../../mediaWorkspaceApi"
+import { CUT_TRACKS } from "./useCutTimeline"
+
+interface Props {
+  timeline: MediaTimeline
+  assets: MediaAssetReference[]
+  onRemoveClip: (trackId: string, clipId: string) => void
+}
+
+const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string; className?: string }>; tone: string }> = {
+  vid1: { icon: Video, tone: "#5aa9ff" },
+  vid2: { icon: Video, tone: "#7c9cff" },
+  music: { icon: Music, tone: "#4ade80" },
+  fx: { icon: Sparkles, tone: "#c084fc" },
+  voice: { icon: Mic, tone: "#ffb86b" },
+}
+
+const PX_PER_SECOND = 6
+const MIN_RULER_SECONDS = 30
+
+function fmtDur(s: number): string {
+  if (s >= 60) return `${Math.floor(s / 60)}:${String(Math.round(s % 60)).padStart(2, "0")}`
+  return `${Math.round(s * 10) / 10}s`
+}
+
+export function TrackArea({ timeline, assets, onRemoveClip }: Props) {
+  const assetLabel = new Map(assets.map((a) => [a.id, a.label]))
+  const totalLen = Math.max(
+    MIN_RULER_SECONDS,
+    ...timeline.tracks.flatMap((t) => t.clips.map((c) => c.start + c.duration)),
+  )
+  const rulerSteps = Math.ceil(totalLen / 5)
+  const innerWidth = totalLen * PX_PER_SECOND
+
+  return (
+    <div className="overflow-x-auto">
+      <div style={{ minWidth: `${innerWidth + 96}px` }}>
+        {/* Ruler */}
+        <div className="grid grid-cols-[84px_1fr] gap-2">
+          <div />
+          <div className="relative h-5 rounded-[3px] border border-[#2a364b] bg-[#111827]" style={{ width: `${innerWidth}px` }}>
+            {Array.from({ length: rulerSteps + 1 }, (_, i) => (
+              <span key={i} className="absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * PX_PER_SECOND + 2}px` }}>
+                {i * 5}s
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Spuren */}
+        <div className="mt-2 space-y-1.5">
+          {CUT_TRACKS.map((def) => {
+            const track = timeline.tracks.find((t) => t.id === def.id)
+            const meta = TRACK_META[def.id]
+            const Icon = meta.icon
+            return (
+              <div key={def.id} className="grid grid-cols-[84px_1fr] gap-2">
+                <div className="flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-1.5" style={{ borderLeft: `3px solid ${meta.tone}` }}>
+                  <Icon size={13} className="shrink-0" />
+                  <span className="truncate text-[11px] font-semibold text-[#c3ccdd]">{def.name}</span>
+                </div>
+                <div className="relative h-10 rounded-[3px] border border-[#223048] bg-[#0d1420]" style={{ width: `${innerWidth}px` }}>
+                  <div className="absolute inset-0 opacity-[0.04]" style={{ backgroundImage: "linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: `${5 * PX_PER_SECOND}px 100%` }} />
+                  {(track?.clips ?? []).map((clip) => (
+                    <div key={clip.id}
+                      className="group absolute inset-y-1 overflow-hidden rounded-[3px] border px-1.5 py-0.5"
+                      style={{
+                        left: `${clip.start * PX_PER_SECOND}px`,
+                        width: `${Math.max(clip.duration * PX_PER_SECOND, 34)}px`,
+                        borderColor: meta.tone,
+                        background: `${meta.tone}22`,
+                      }}
+                      title={`${assetLabel.get(clip.asset_id) ?? clip.asset_id} · ${fmtDur(clip.duration)}`}>
+                      <p className="truncate text-[9px] font-semibold leading-3 text-[#e8eef8]">{assetLabel.get(clip.asset_id) ?? clip.asset_id}</p>
+                      <p className="font-mono text-[8px] text-[#8d9ab0]">{fmtDur(clip.duration)}</p>
+                      <button onClick={() => onRemoveClip(def.id, clip.id)} aria-label="Clip entfernen"
+                        className="absolute right-0.5 top-0.5 hidden rounded-[2px] bg-black/60 p-0.5 text-zinc-300 hover:text-white group-hover:block">
+                        <X size={9} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/api.ts
+++ b/frontend/src/features/cockpit/media/videocut/api.ts
@@ -1,0 +1,122 @@
+import { atelierApi, fileUrl } from "@/modules/atelier/api"
+import type { AudioLibraryItem, GalleryItem, VideoJob } from "@/modules/atelier/types"
+import { mediaAssetsApi, mediaProjectsApi, type MediaAssetReference } from "../../mediaProjectsApi"
+import { mediaWorkspaceApi, type MediaTimeline } from "../../mediaWorkspaceApi"
+
+/** Media-Projekt-Slug für den Videoschnitt — wird still angelegt. */
+export const CUT_SLUG = "schnitt"
+
+/** Bibliothekseintrag, normalisiert über alle Atelier-Quellen. */
+export interface LibraryItem {
+  key: string
+  kind: "video" | "image" | "audio"
+  label: string
+  /** rel_path im Projekt-Workspace (atelier/...) für Asset-Referenzen. */
+  relPath: string
+  /** Absoluter Pfad für Thumbnails/Preview via /api/files. */
+  absPath: string | null
+  /** Bekannte Dauer in Sekunden (Videos aus Job-Meta), sonst null. */
+  duration: number | null
+}
+
+export function libraryFileUrl(absPath: string): string {
+  return fileUrl(absPath)
+}
+
+/** Stellt sicher, dass das Schnitt-Media-Projekt existiert. */
+export async function ensureCutProject(projectId: string): Promise<void> {
+  const existing = await mediaProjectsApi.list(projectId)
+  if (existing.some((item) => item.slug === CUT_SLUG)) return
+  await mediaProjectsApi.create(projectId, {
+    slug: CUT_SLUG,
+    name: "Videoschnitt",
+    description: "Automatisch angelegt für die Nachbearbeitung im Media-Cockpit.",
+  })
+}
+
+/** Lädt alle Bibliotheksquellen des Projekts parallel. Fehler je Quelle → leere Liste. */
+export async function loadLibrary(projectId: string, atelierRoot: string | null): Promise<LibraryItem[]> {
+  const [gallery, videos, audio] = await Promise.allSettled([
+    atelierApi.gallery(projectId),
+    atelierApi.listVideos(projectId),
+    atelierApi.audioLibrary(projectId),
+  ])
+  const items: LibraryItem[] = []
+
+  if (videos.status === "fulfilled") {
+    for (const job of videos.value as VideoJob[]) {
+      if (job.status !== "completed" || !job.video_rel) continue
+      items.push({
+        key: `video:${job.video_rel}`,
+        kind: "video",
+        label: job.prompt?.slice(0, 60) || job.video_rel.split("/").pop() || job.job_id,
+        relPath: `atelier/${job.video_rel}`,
+        absPath: atelierRoot ? `${atelierRoot}/${job.video_rel}` : null,
+        duration: job.duration > 0 ? job.duration : null,
+      })
+    }
+  }
+  if (gallery.status === "fulfilled") {
+    for (const img of gallery.value as GalleryItem[]) {
+      items.push({
+        key: `image:${img.rel}`,
+        kind: "image",
+        label: img.name,
+        relPath: `atelier/${img.rel}`,
+        absPath: img.path || null,
+        duration: null,
+      })
+    }
+  }
+  if (audio.status === "fulfilled") {
+    for (const track of audio.value as AudioLibraryItem[]) {
+      items.push({
+        key: `audio:${track.rel}`,
+        kind: "audio",
+        label: track.name,
+        relPath: `atelier/${track.rel}`,
+        absPath: atelierRoot ? `${atelierRoot}/${track.rel}` : null,
+        duration: null,
+      })
+    }
+  }
+  return items
+}
+
+/** Findet oder erstellt die Asset-Referenz für einen Bibliothekseintrag. */
+export async function ensureAssetRef(
+  projectId: string,
+  item: LibraryItem,
+  existing: MediaAssetReference[],
+): Promise<MediaAssetReference> {
+  const found = existing.find((a) => a.rel_path === item.relPath && a.source_project_id === projectId)
+  if (found) return found
+  const kind = item.kind === "video" ? "video" : item.kind === "image" ? "image" : "audio"
+  const id = `${kind}-${hashString(item.relPath)}`
+  return mediaAssetsApi.create(projectId, CUT_SLUG, {
+    id,
+    kind,
+    label: item.label.slice(0, 100),
+    source_project_id: projectId,
+    rel_path: item.relPath,
+  })
+}
+
+export async function loadTimelineAndAssets(projectId: string): Promise<{ timeline: MediaTimeline; assets: MediaAssetReference[] }> {
+  const [timeline, assets] = await Promise.all([
+    mediaWorkspaceApi.getTimeline(projectId, CUT_SLUG),
+    mediaAssetsApi.list(projectId, CUT_SLUG),
+  ])
+  return { timeline, assets }
+}
+
+export function saveTimeline(projectId: string, timeline: MediaTimeline): Promise<MediaTimeline> {
+  return mediaWorkspaceApi.saveTimeline(projectId, CUT_SLUG, timeline)
+}
+
+/** Kurzer stabiler Hash für Asset-IDs (djb2). */
+function hashString(value: string): string {
+  let hash = 5381
+  for (let i = 0; i < value.length; i++) hash = ((hash << 5) + hash + value.charCodeAt(i)) >>> 0
+  return hash.toString(36)
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import type { MediaAssetReference } from "../../mediaProjectsApi"
+import type { MediaTimeline, MediaTimelineTrack } from "../../mediaWorkspaceApi"
+import { ensureAssetRef, ensureCutProject, loadTimelineAndAssets, saveTimeline, type LibraryItem } from "./api"
+
+/** Feste UI-Spuren des Schnittpults → Timeline-Track-Kinds. */
+export const CUT_TRACKS = [
+  { id: "vid1", name: "Video 1", kind: "video" as const },
+  { id: "vid2", name: "Video 2", kind: "video" as const },
+  { id: "music", name: "Musik", kind: "music" as const },
+  { id: "fx", name: "Effekt", kind: "audio" as const },
+  { id: "voice", name: "Sprache", kind: "voice" as const },
+]
+
+export const IMAGE_DEFAULT_DURATION = 5
+const AUDIO_FALLBACK_DURATION = 30
+
+function withDefaultTracks(timeline: MediaTimeline): MediaTimeline {
+  const existing = new Map(timeline.tracks.map((t) => [t.id, t]))
+  const tracks: MediaTimelineTrack[] = CUT_TRACKS.map((def) =>
+    existing.get(def.id) ?? { id: def.id, name: def.name, kind: def.kind, muted: false, clips: [] },
+  )
+  return { ...timeline, tracks }
+}
+
+function trackEnd(track: MediaTimelineTrack): number {
+  return track.clips.reduce((max, clip) => Math.max(max, clip.start + clip.duration), 0)
+}
+
+/** Dauer einer Audio-/Videodatei clientseitig über Element-Metadata ermitteln. */
+function probeDuration(url: string, kind: "audio" | "video"): Promise<number | null> {
+  return new Promise((resolve) => {
+    const el = document.createElement(kind)
+    const done = (value: number | null) => { el.src = ""; resolve(value) }
+    el.preload = "metadata"
+    el.onloadedmetadata = () => done(Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null)
+    el.onerror = () => done(null)
+    setTimeout(() => done(null), 8000)
+    el.src = url
+  })
+}
+
+export function useCutTimeline(projectId: string) {
+  const [timeline, setTimeline] = useState<MediaTimeline | null>(null)
+  const [assets, setAssets] = useState<MediaAssetReference[]>([])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const initialized = useRef<string | null>(null)
+  const loading = timeline === null && error === null
+
+  useEffect(() => {
+    if (!projectId || initialized.current === projectId) return
+    initialized.current = projectId
+    ;(async () => {
+      try {
+        await ensureCutProject(projectId)
+        const { timeline: tl, assets: refs } = await loadTimelineAndAssets(projectId)
+        setTimeline(withDefaultTracks(tl))
+        setAssets(refs)
+      } catch {
+        setError("Schnitt-Projekt konnte nicht geladen werden.")
+      }
+    })()
+  }, [projectId])
+
+  const persist = useCallback(async (next: MediaTimeline) => {
+    setTimeline(next)
+    setSaving(true)
+    setError(null)
+    try {
+      await saveTimeline(projectId, next)
+    } catch {
+      setError("Timeline konnte nicht gespeichert werden.")
+    } finally {
+      setSaving(false)
+    }
+  }, [projectId])
+
+  /** Legt einen Bibliothekseintrag ans Ende der Ziel-Spur. */
+  const addClip = useCallback(async (item: LibraryItem, trackId: string, previewUrl: string | null) => {
+    if (!timeline) return
+    setError(null)
+    try {
+      const ref = await ensureAssetRef(projectId, item, assets)
+      if (!assets.some((a) => a.id === ref.id)) setAssets((cur) => [...cur, ref])
+
+      let duration = item.duration
+      if (duration == null && previewUrl && (item.kind === "audio" || item.kind === "video")) {
+        duration = await probeDuration(previewUrl, item.kind === "audio" ? "audio" : "video")
+      }
+      if (duration == null) duration = item.kind === "image" ? IMAGE_DEFAULT_DURATION : AUDIO_FALLBACK_DURATION
+
+      const next: MediaTimeline = {
+        ...timeline,
+        tracks: timeline.tracks.map((track) => {
+          if (track.id !== trackId) return track
+          const clip = {
+            id: `clip-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+            asset_id: ref.id,
+            start: trackEnd(track),
+            duration,
+            source_in: 0,
+            volume: 1,
+          }
+          return { ...track, clips: [...track.clips, clip] }
+        }),
+      }
+      await persist(next)
+    } catch {
+      setError("Clip konnte nicht hinzugefügt werden.")
+    }
+  }, [timeline, assets, projectId, persist])
+
+  const removeClip = useCallback((trackId: string, clipId: string) => {
+    if (!timeline) return
+    const next: MediaTimeline = {
+      ...timeline,
+      tracks: timeline.tracks.map((track) =>
+        track.id === trackId ? { ...track, clips: track.clips.filter((c) => c.id !== clipId) } : track,
+      ),
+    }
+    void persist(next)
+  }, [timeline, persist])
+
+  return { timeline, assets, loading, saving, error, addClip, removeClip }
+}


### PR DESCRIPTION
## V1 der Videoschnitt-Roadmap
Erster funktionaler Slice: Bibliothek → Clip auf Spur → Persistenz. Spec: `docs/specs/videocut-v1.md`.

## Was funktioniert jetzt
- **Media-Projekt 'schnitt'** wird beim ersten Öffnen des Videoschnitts still angelegt (Entscheidung: Option A, kein Dropdown)
- **Clip-Bibliothek** (rechte Spalte): Videos, Bilder und Audio des aktiven Projekts aus den Atelier-APIs (`gallery`, `listVideos`, `audioLibrary`) mit Thumbnails und Tab-Filter
- **'+ zur Spur'**: Ziel-Spur wählen (Video→Vid1/Vid2, Audio→Musik/Effekt/Sprache, Bild→Standbild 5s) → Clip landet am Spur-Ende
- **Spuren**: 5 feste Spuren auf das vorhandene Timeline-Modell gemappt; Clips als farbcodierte proportionale Blöcke (6px/s) mit Label/Dauer/Entfernen; Ruler dynamisch, horizontal scrollbar
- **Persistenz**: vorhandene Timeline-API (`GET/PUT .../timeline`) — **keine Backend-Änderung**
- Dauer-Ermittlung: Video aus Job-Meta, Audio per Element-Metadata-Probe (Fallback 30s), Bild 5s

## Wiederverwendung statt Neubau
- Timeline-Backend (media_workspace.py inkl. Pydantic-Validierung + ffmpeg-Export für V6) existierte noch vom zurückgebauten Slice — nur das Frontend ist neu
- Payload gegen das Pydantic-Modell verifiziert (5 Tracks, Clip-Felder)

## Checks
Typecheck grün, ESLint der neuen Dateien grün (1 Bestandsfehler in MediaIdeaOverlay.tsx unberührt), Build grün. Alle Dateien <200 Zeilen.

## Nicht enthalten (bewusst)
Playback/Playhead (V2), Trim/Split (V3), Monitore bleiben Dummy.