### PR TITLE
feat(media): Videoschnitt V2 — Playback, Playhead & Transport

### DIFF
--- a/docs/specs/videocut-v2.md
+++ b/docs/specs/videocut-v2.md
@@ -1,0 +1,53 @@
+# Videoschnitt V2 — Playback, Playhead & Transport
+
+## Was
+Der Videoschnitt bekommt eine funktionierende Vorschau: Der **Output-Monitor**
+spielt die Timeline ab (clientseitig, kein Server-Render). Ein **Playhead** läuft
+über den Spuren mit und ist per Klick/Scrub verschiebbar. Die **Transport-Buttons**
+(Anfang/Play/Pause/Stopp/Ende) sind funktional, eine **Zeitanzeige** zeigt Position
+und Gesamtlänge.
+
+## Warum
+Zweiter Slice der Videoschnitt-Roadmap (Task d778bcdb). V1 hat Bibliothek → Clip →
+Spur → Persistenz geliefert; V2 macht das Ergebnis erlebbar, ohne auf Export (V6)
+zu warten. Trim/Split kommt in V3.
+
+## Wie
+- **Backend: keine Änderungen.** Reine Frontend-Erweiterung auf den V1-Strukturen.
+- **Master-Clock** (`useCutPlayback`): eine wall-clock-getriebene rAF-Schleife führt
+  `currentTime` in Sekunden. Transport: `play/pause/stop/seek/toStart/toEnd`.
+  `duration` = Ende des spätesten Clips über alle Spuren. Beim Erreichen des Endes
+  stoppt die Wiedergabe.
+- **Output-Monitor** (`OutputMonitor`): zeigt den aktiven visuellen Clip. Priorität
+  **Video 2 über Video 1** (obere Spur gewinnt). Video-Clips → `<video>` (mit Ton),
+  Bild-Clips → `<img>` (Standbild für ihre Dauer). Kein aktiver Clip → „kein Signal".
+- **Audio parallel** (`PlaybackAudio`): je Audio-Spur (Musik/Effekt/Sprache) ein
+  verstecktes `<audio>`-Element, das den aktiven Clip abspielt. `volume` je Clip,
+  `muted` je Spur.
+- **Grobe Sync** (`useMediaSync`): Media-Elemente folgen der Master-Clock. Bei Drift
+  > 0,3 s wird `element.currentTime` nachgezogen; `play()/pause()` folgen dem
+  Play-Status. Clip-Wechsel → Element-Remount via `key={clip.id}`. Für eine Preview
+  ausreichend (kein frame-genauer Server-Sync).
+- **Playhead** (`TrackArea`): vertikale Linie über Ruler + Spuren, Position aus
+  `currentTime`. Der Ruler ist Scrub-Fläche: Pointer-Down/-Move setzt `currentTime`
+  über `onSeek`.
+- **URL-Auflösung**: Asset-Referenz `rel_path` (`atelier/…`) + Atelier-Root →
+  absoluter Pfad → `fileUrl()` (`/api/files?path=…&token=…`). Map `asset_id → {url, kind}`
+  einmal aus `assets` + Root gebaut (`buildAssetMedia`).
+
+## Dateien (alle < 200 Zeilen)
+- `media/videocut/useCutPlayback.ts` — Clock, Transport, aktive-Clip-Helper, Timecode.
+- `media/videocut/playbackSync.ts` — `useMediaSync` (Drift/Play/Pause/Volume).
+- `media/videocut/OutputMonitor.tsx` — visueller Monitor (Video/Bild).
+- `media/videocut/PlaybackAudio.tsx` — versteckte Audio-Elemente je Spur.
+- `media/videocut/api.ts` — `buildAssetMedia` + `ClipMedia` ergänzt.
+- `media/videocut/TrackArea.tsx` — Playhead + Scrub.
+- `media/MediaPostProduction.tsx` — Verdrahtung Transport/Monitore/Zeit.
+
+## Akzeptanzkriterien
+- [ ] Play spielt die Timeline ab; Output-Monitor zeigt Videos und Standbilder zeitrichtig.
+- [ ] Musik-/Sprache-/Effekt-Spuren spielen parallel (grobe Sync).
+- [ ] Playhead läuft mit und ist per Klick/Scrub im Ruler verschiebbar.
+- [ ] Transport: Anfang/Play/Pause/Stopp/Ende funktionieren; Play stoppt am Ende.
+- [ ] Zeitanzeige zeigt Position / Gesamtlänge.
+- [ ] Keine Backend-Änderung, Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,18 +1,21 @@
 import { Film, Pause, Play, SkipBack, SkipForward, Square } from "lucide-react"
-import type { ComponentType } from "react"
+import { useEffect, useState, type ComponentType } from "react"
+import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
+import { OutputMonitor } from "./videocut/OutputMonitor"
+import { PlaybackAudio } from "./videocut/PlaybackAudio"
 import { TrackArea } from "./videocut/TrackArea"
+import { timecode, useCutPlayback } from "./videocut/useCutPlayback"
 import { useCutTimeline } from "./videocut/useCutTimeline"
 
-/** Videoschnitt (V1): Clip-Bibliothek + Spuren mit Persistenz.
- *  Monitore + Transport sind noch Platzhalter (V2). */
+/** Videoschnitt (V2): Playback im Output-Monitor, Playhead + Transport.
+ *  Die beiden Input-Monitore bleiben Platzhalter (Feintrim ab V3/V4). */
 
-function Monitor({ title, kind }: { title: string; kind: "input" | "output" }) {
-  const accent = kind === "output" ? "#ffb86b" : "#5aa9ff"
+function InputMonitor({ title }: { title: string }) {
   return (
     <div className="flex min-w-0 flex-col">
       <div className="flex items-center justify-between px-1 pb-1">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em]" style={{ color: accent }}>{title}</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#5aa9ff]">{title}</span>
         <span className="font-mono text-[10px] text-[#68758a]">00:00:00</span>
       </div>
       <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
@@ -28,11 +31,17 @@ function Monitor({ title, kind }: { title: string; kind: "input" | "output" }) {
   )
 }
 
-function TransportButton({ icon: Icon, label, primary }: { icon: ComponentType<{ size?: number | string }>; label: string; primary?: boolean }) {
+function TransportButton({ icon: Icon, label, onClick, primary, disabled }: {
+  icon: ComponentType<{ size?: number | string }>
+  label: string
+  onClick: () => void
+  primary?: boolean
+  disabled?: boolean
+}) {
   return (
-    <button type="button" title={label} aria-label={label} disabled
-      className={["grid h-8 w-8 place-items-center rounded-[4px] border transition-colors",
-        primary ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b]" : "border-[#2a364b] bg-[#111827] text-[#8d9ab0]"].join(" ")}>
+    <button type="button" title={label} aria-label={label} onClick={onClick} disabled={disabled}
+      className={["grid h-8 w-8 place-items-center rounded-[4px] border transition-colors disabled:opacity-40",
+        primary ? "border-[#ffb86b]/50 bg-[#ffb86b]/10 text-[#ffb86b] hover:bg-[#ffb86b]/20" : "border-[#2a364b] bg-[#111827] text-[#8d9ab0] hover:text-[#c3ccdd]"].join(" ")}>
       <Icon size={15} />
     </button>
   )
@@ -44,25 +53,46 @@ interface Props {
 
 export function MediaPostProduction({ projectId }: Props) {
   const { timeline, assets, loading, saving, error, addClip, removeClip } = useCutTimeline(projectId)
+  const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
+
+  // Atelier-Root → asset_id-Medien-Map für das Playback.
+  const [media, setMedia] = useState<Map<string, ClipMedia>>(new Map())
+  useEffect(() => {
+    if (!projectId) return
+    let alive = true
+    void loadAtelierRoot(projectId).then((root) => {
+      if (alive) setMedia(buildAssetMedia(assets, root))
+    })
+    return () => { alive = false }
+  }, [projectId, assets])
+
+  const canPlay = duration > 0
 
   return (
     <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_260px]">
       <div className="min-w-0">
-        {/* 3 Monitore: Input 1, Input 2, Output */}
+        {/* 3 Monitore: Input 1, Input 2, Output (live) */}
         <div className="grid gap-3 lg:grid-cols-3">
-          <Monitor title="Input · Vid 1" kind="input" />
-          <Monitor title="Input · Vid 2" kind="input" />
-          <Monitor title="Output" kind="output" />
+          <InputMonitor title="Input · Vid 1" />
+          <InputMonitor title="Input · Vid 2" />
+          {timeline ? (
+            <OutputMonitor timeline={timeline} media={media} currentTime={currentTime} playing={playing} />
+          ) : (
+            <InputMonitor title="Output" />
+          )}
         </div>
 
-        {/* Transport (V2) + Status */}
+        {/* Transport + Zeitanzeige */}
         <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#2a364b] pt-3">
-          <TransportButton icon={SkipBack} label="Zum Anfang" />
-          <TransportButton icon={Play} label="Abspielen" primary />
-          <TransportButton icon={Pause} label="Pause" />
-          <TransportButton icon={Square} label="Stopp" />
-          <TransportButton icon={SkipForward} label="Zum Ende" />
-          <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">00:00:00 / 00:00:00</span>
+          <TransportButton icon={SkipBack} label="Zum Anfang" onClick={toStart} disabled={!canPlay} />
+          {playing ? (
+            <TransportButton icon={Pause} label="Pause" onClick={pause} primary disabled={!canPlay} />
+          ) : (
+            <TransportButton icon={Play} label="Abspielen" onClick={play} primary disabled={!canPlay} />
+          )}
+          <TransportButton icon={Square} label="Stopp" onClick={stop} disabled={!canPlay} />
+          <TransportButton icon={SkipForward} label="Zum Ende" onClick={toEnd} disabled={!canPlay} />
+          <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">{timecode(currentTime)} / {timecode(duration)}</span>
           <span className="ml-auto text-[10px] uppercase tracking-[0.12em] text-[#68758a]">
             {loading ? "Lade…" : saving ? "Speichere…" : "Gespeichert"}
           </span>
@@ -70,10 +100,10 @@ export function MediaPostProduction({ projectId }: Props) {
 
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
 
-        {/* Spuren mit echten Clips */}
+        {/* Spuren mit Clips + Playhead */}
         <div className="mt-3">
           {timeline ? (
-            <TrackArea timeline={timeline} assets={assets} onRemoveClip={removeClip} />
+            <TrackArea timeline={timeline} assets={assets} onRemoveClip={removeClip} currentTime={currentTime} onSeek={seek} />
           ) : (
             <p className="text-xs text-[#7a869c]">{loading ? "Timeline wird geladen…" : "Keine Timeline verfügbar."}</p>
           )}
@@ -85,6 +115,9 @@ export function MediaPostProduction({ projectId }: Props) {
         <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Bibliothek</p>
         <ClipLibrary projectId={projectId} onAdd={(item, trackId, url) => void addClip(item, trackId, url)} disabled={!timeline || saving} />
       </aside>
+
+      {/* Parallele Audio-Wiedergabe (versteckt) */}
+      {timeline ? <PlaybackAudio timeline={timeline} media={media} currentTime={currentTime} playing={playing} /> : null}
     </div>
   )
 }

--- a/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
+++ b/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
@@ -1,0 +1,68 @@
+import { Film } from "lucide-react"
+import { useRef } from "react"
+import type { MediaTimeline } from "../../mediaWorkspaceApi"
+import type { ClipMedia } from "./api"
+import { useMediaSync } from "./playbackSync"
+import { clipAt, timecode, type ActiveClip } from "./useCutPlayback"
+
+interface Props {
+  timeline: MediaTimeline
+  media: Map<string, ClipMedia>
+  currentTime: number
+  playing: boolean
+}
+
+/** Sichtbarer Clip an Position t: obere Video-Spur (vid2) hat Vorrang vor vid1. */
+function activeVisual(timeline: MediaTimeline, t: number): ActiveClip | null {
+  for (const id of ["vid2", "vid1"]) {
+    const track = timeline.tracks.find((tr) => tr.id === id)
+    if (!track) continue
+    const hit = clipAt(track, t)
+    if (hit) return hit
+  }
+  return null
+}
+
+/** <video>-Element, folgt der Master-Clock. key={clip.id} sorgt für Remount bei Clip-Wechsel. */
+function VideoSurface({ url, localTime, playing, muted }: { url: string; localTime: number; playing: boolean; muted: boolean }) {
+  const ref = useRef<HTMLVideoElement>(null)
+  useMediaSync(ref, { localTime, playing, active: true, muted })
+  return <video ref={ref} src={url} className="h-full w-full object-contain" playsInline preload="auto" muted={muted} />
+}
+
+export function OutputMonitor({ timeline, media, currentTime, playing }: Props) {
+  const active = activeVisual(timeline, currentTime)
+  const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="flex items-center justify-between px-1 pb-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#ffb86b]">Output</span>
+        <span className="font-mono text-[10px] text-[#68758a]">{timecode(currentTime)}</span>
+      </div>
+      <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
+        {clipMedia && clipMedia.kind === "video" ? (
+          <VideoSurface
+            key={active!.clip.id}
+            url={clipMedia.url}
+            localTime={active!.localTime}
+            playing={playing}
+            muted={active!.track.muted}
+          />
+        ) : clipMedia && clipMedia.kind === "image" ? (
+          <img key={active!.clip.id} src={clipMedia.url} alt="" className="h-full w-full object-contain" />
+        ) : (
+          <>
+            <div className="absolute inset-0 opacity-[0.06]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "24px 24px" }} />
+            <div className="absolute inset-0 grid place-items-center">
+              <div className="flex flex-col items-center gap-1 text-[#3f4b60]">
+                <Film size={26} />
+                <span className="text-[10px] uppercase tracking-[0.14em]">kein Signal</span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/PlaybackAudio.tsx
+++ b/frontend/src/features/cockpit/media/videocut/PlaybackAudio.tsx
@@ -1,0 +1,52 @@
+import { useRef } from "react"
+import type { MediaTimeline } from "../../mediaWorkspaceApi"
+import type { ClipMedia } from "./api"
+import { useMediaSync } from "./playbackSync"
+import { clipAt } from "./useCutPlayback"
+
+/** Audio-Spuren des Schnittpults, die parallel zum Output klingen. */
+const AUDIO_TRACK_IDS = ["music", "fx", "voice"] as const
+
+interface Props {
+  timeline: MediaTimeline
+  media: Map<string, ClipMedia>
+  currentTime: number
+  playing: boolean
+}
+
+/** Ein verstecktes <audio> je Spur; folgt der Master-Clock am aktiven Clip. */
+function AudioTrackPlayer({ trackId, timeline, media, currentTime, playing }: {
+  trackId: string
+  timeline: MediaTimeline
+  media: Map<string, ClipMedia>
+  currentTime: number
+  playing: boolean
+}) {
+  const ref = useRef<HTMLAudioElement>(null)
+  const track = timeline.tracks.find((t) => t.id === trackId)
+  const active = track ? clipAt(track, currentTime) : null
+  const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
+
+  useMediaSync(ref, {
+    localTime: active?.localTime ?? 0,
+    playing,
+    active: Boolean(clipMedia),
+    volume: active?.clip.volume ?? 1,
+    muted: track?.muted ?? false,
+  })
+
+  // key sorgt für Remount (neue Quelle) bei Clip-Wechsel.
+  if (!clipMedia) return null
+  return <audio key={active!.clip.id} ref={ref} src={clipMedia.url} preload="auto" />
+}
+
+/** Rendert die parallelen Audio-Spuren (Musik/Effekt/Sprache) als versteckte Elemente. */
+export function PlaybackAudio({ timeline, media, currentTime, playing }: Props) {
+  return (
+    <div className="sr-only" aria-hidden>
+      {AUDIO_TRACK_IDS.map((id) => (
+        <AudioTrackPlayer key={id} trackId={id} timeline={timeline} media={media} currentTime={currentTime} playing={playing} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -1,5 +1,5 @@
 import { Mic, Music, Sparkles, Video, X } from "lucide-react"
-import type { ComponentType } from "react"
+import { useCallback, useRef, type ComponentType, type PointerEvent } from "react"
 import type { MediaAssetReference } from "../../mediaProjectsApi"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import { CUT_TRACKS } from "./useCutTimeline"
@@ -8,6 +8,10 @@ interface Props {
   timeline: MediaTimeline
   assets: MediaAssetReference[]
   onRemoveClip: (trackId: string, clipId: string) => void
+  /** Aktuelle Playhead-Position in Sekunden. */
+  currentTime: number
+  /** Springt zu Sekunde t (Klick/Scrub im Ruler). */
+  onSeek: (t: number) => void
 }
 
 const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string; className?: string }>; tone: string }> = {
@@ -26,7 +30,7 @@ function fmtDur(s: number): string {
   return `${Math.round(s * 10) / 10}s`
 }
 
-export function TrackArea({ timeline, assets, onRemoveClip }: Props) {
+export function TrackArea({ timeline, assets, onRemoveClip, currentTime, onSeek }: Props) {
   const assetLabel = new Map(assets.map((a) => [a.id, a.label]))
   const totalLen = Math.max(
     MIN_RULER_SECONDS,
@@ -34,24 +38,58 @@ export function TrackArea({ timeline, assets, onRemoveClip }: Props) {
   )
   const rulerSteps = Math.ceil(totalLen / 5)
   const innerWidth = totalLen * PX_PER_SECOND
+  const playheadLeft = Math.min(currentTime, totalLen) * PX_PER_SECOND
+
+  const scrubbing = useRef(false)
+  const laneRef = useRef<HTMLDivElement>(null)
+
+  const seekFromEvent = useCallback((e: PointerEvent) => {
+    const el = laneRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const x = Math.max(0, Math.min(e.clientX - rect.left, innerWidth))
+    onSeek(x / PX_PER_SECOND)
+  }, [innerWidth, onSeek])
+
+  const onPointerDown = useCallback((e: PointerEvent) => {
+    scrubbing.current = true
+    e.currentTarget.setPointerCapture(e.pointerId)
+    seekFromEvent(e)
+  }, [seekFromEvent])
+
+  const onPointerMove = useCallback((e: PointerEvent) => {
+    if (scrubbing.current) seekFromEvent(e)
+  }, [seekFromEvent])
+
+  const onPointerUp = useCallback((e: PointerEvent) => {
+    scrubbing.current = false
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* nicht gecaptured */ }
+  }, [])
 
   return (
     <div className="overflow-x-auto">
       <div style={{ minWidth: `${innerWidth + 96}px` }}>
-        {/* Ruler */}
+        {/* Ruler — Scrub-Fläche */}
         <div className="grid grid-cols-[84px_1fr] gap-2">
           <div />
-          <div className="relative h-5 rounded-[3px] border border-[#2a364b] bg-[#111827]" style={{ width: `${innerWidth}px` }}>
+          <div
+            ref={laneRef}
+            className="relative h-5 cursor-pointer rounded-[3px] border border-[#2a364b] bg-[#111827] touch-none"
+            style={{ width: `${innerWidth}px` }}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+          >
             {Array.from({ length: rulerSteps + 1 }, (_, i) => (
-              <span key={i} className="absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * PX_PER_SECOND + 2}px` }}>
+              <span key={i} className="pointer-events-none absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * PX_PER_SECOND + 2}px` }}>
                 {i * 5}s
               </span>
             ))}
           </div>
         </div>
 
-        {/* Spuren */}
-        <div className="mt-2 space-y-1.5">
+        {/* Spuren + Playhead-Overlay */}
+        <div className="relative mt-2 space-y-1.5">
           {CUT_TRACKS.map((def) => {
             const track = timeline.tracks.find((t) => t.id === def.id)
             const meta = TRACK_META[def.id]
@@ -86,6 +124,14 @@ export function TrackArea({ timeline, assets, onRemoveClip }: Props) {
               </div>
             )
           })}
+
+          {/* Playhead-Linie über allen Spuren (nur im Spurbereich, nicht über den Labels) */}
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 w-px bg-[#ffb86b]"
+            style={{ left: `calc(84px + 0.5rem + ${playheadLeft}px)` }}
+          >
+            <div className="absolute -top-0.5 -left-[3px] h-1.5 w-1.5 rounded-full bg-[#ffb86b]" />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/features/cockpit/media/videocut/api.ts
+++ b/frontend/src/features/cockpit/media/videocut/api.ts
@@ -23,6 +23,38 @@ export function libraryFileUrl(absPath: string): string {
   return fileUrl(absPath)
 }
 
+/** Auflösbares Medium eines Timeline-Clips (für Playback). */
+export interface ClipMedia {
+  url: string
+  kind: "video" | "image" | "audio"
+}
+
+/** Baut asset_id → abspielbare URL/Art aus Asset-Referenzen + Atelier-Root.
+ *  rel_path liegt als `atelier/<rel>` vor; der absolute Pfad ergibt sich aus
+ *  dem Atelier-Root des Projekts, ausgeliefert über /api/files. */
+export function buildAssetMedia(
+  assets: MediaAssetReference[],
+  atelierRoot: string | null,
+): Map<string, ClipMedia> {
+  const map = new Map<string, ClipMedia>()
+  if (!atelierRoot) return map
+  for (const asset of assets) {
+    const rel = asset.rel_path.startsWith("atelier/") ? asset.rel_path.slice("atelier/".length) : asset.rel_path
+    const kind = asset.kind === "video" ? "video" : asset.kind === "image" ? "image" : "audio"
+    map.set(asset.id, { url: fileUrl(`${atelierRoot}/${rel}`), kind })
+  }
+  return map
+}
+
+/** Atelier-Root des Projekts (für absolute Pfade). Fehler → null. */
+export async function loadAtelierRoot(projectId: string): Promise<string | null> {
+  try {
+    return (await atelierApi.meta(projectId)).root
+  } catch {
+    return null
+  }
+}
+
 /** Stellt sicher, dass das Schnitt-Media-Projekt existiert. */
 export async function ensureCutProject(projectId: string): Promise<void> {
   const existing = await mediaProjectsApi.list(projectId)

--- a/frontend/src/features/cockpit/media/videocut/playbackSync.ts
+++ b/frontend/src/features/cockpit/media/videocut/playbackSync.ts
@@ -1,0 +1,59 @@
+import { useEffect, type RefObject } from "react"
+
+/** Ab welchem Drift (Sekunden) currentTime des Elements nachgezogen wird.
+ *  Grobe Sync reicht für die Preview — häufiges Nachziehen würde ruckeln. */
+const DRIFT_THRESHOLD = 0.3
+
+interface SyncOptions {
+  /** Lokale Soll-Position im Medium (Sekunden ab Clip-Start). */
+  localTime: number
+  /** Läuft die Master-Clock? */
+  playing: boolean
+  /** Ist dieses Element gerade aktiv (aktiver Clip vorhanden)? */
+  active: boolean
+  /** Lautstärke 0..1. */
+  volume?: number
+  /** Spur stummgeschaltet. */
+  muted?: boolean
+}
+
+/** Hält ein <video>/<audio>-Element grob an der Master-Clock.
+ *  - Drift > Schwelle → currentTime nachziehen
+ *  - playing/active steuern play()/pause()
+ *  play() kann rejecten (Autoplay-Policy) — bewusst verschluckt. */
+export function useMediaSync(
+  ref: RefObject<HTMLMediaElement | null>,
+  { localTime, playing, active, volume = 1, muted = false }: SyncOptions,
+): void {
+  // Lautstärke/Mute getrennt anwenden (kein Re-Sync nötig).
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.volume = Math.max(0, Math.min(1, volume))
+    el.muted = muted
+  }, [ref, volume, muted])
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    if (!active) {
+      if (!el.paused) el.pause()
+      return
+    }
+
+    if (Math.abs(el.currentTime - localTime) > DRIFT_THRESHOLD) {
+      try {
+        el.currentTime = localTime
+      } catch {
+        /* Metadata evtl. noch nicht geladen — nächster Tick korrigiert. */
+      }
+    }
+
+    if (playing && el.paused) {
+      void el.play().catch(() => {})
+    } else if (!playing && !el.paused) {
+      el.pause()
+    }
+  }, [ref, localTime, playing, active])
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutPlayback.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutPlayback.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { MediaTimeline, MediaTimelineClip, MediaTimelineTrack } from "../../mediaWorkspaceApi"
+
+/** Aktiver Clip einer Spur samt lokaler Position (Sekunden ab Clip-Start). */
+export interface ActiveClip {
+  track: MediaTimelineTrack
+  clip: MediaTimelineClip
+  localTime: number
+}
+
+/** Gesamtlänge der Timeline = Ende des spätesten Clips. */
+export function timelineDuration(timeline: MediaTimeline | null): number {
+  if (!timeline) return 0
+  let end = 0
+  for (const track of timeline.tracks) {
+    for (const clip of track.clips) end = Math.max(end, clip.start + clip.duration)
+  }
+  return end
+}
+
+/** Aktiven Clip einer Spur an Position t finden (letzter, der t abdeckt). */
+export function clipAt(track: MediaTimelineTrack, t: number): ActiveClip | null {
+  let hit: MediaTimelineClip | null = null
+  for (const clip of track.clips) {
+    if (t >= clip.start && t < clip.start + clip.duration) hit = clip
+  }
+  return hit ? { track, clip: hit, localTime: t - hit.start } : null
+}
+
+/** Timecode HH:MM:SS aus Sekunden. */
+export function timecode(sec: number): string {
+  const s = Math.max(0, Math.floor(sec))
+  const hh = String(Math.floor(s / 3600)).padStart(2, "0")
+  const mm = String(Math.floor((s % 3600) / 60)).padStart(2, "0")
+  const ss = String(s % 60).padStart(2, "0")
+  return `${hh}:${mm}:${ss}`
+}
+
+/** Master-Clock des Schnittpults. Führt currentTime per wall-clock-rAF und
+ *  liefert Transport-Steuerung. Media-Elemente folgen dieser Clock (grobe Sync). */
+export function useCutPlayback(timeline: MediaTimeline | null) {
+  const duration = useMemo(() => timelineDuration(timeline), [timeline])
+  const [currentTime, setCurrentTime] = useState(0)
+  const [playing, setPlaying] = useState(false)
+
+  const rafRef = useRef<number | null>(null)
+  // Ankerpunkt: wall-clock-Zeitstempel + Timeline-Position beim Play-Start.
+  const anchorRef = useRef<{ wall: number; time: number } | null>(null)
+  const durationRef = useRef(duration)
+  useEffect(() => {
+    durationRef.current = duration
+  }, [duration])
+
+  const stopLoop = useCallback(() => {
+    if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    rafRef.current = null
+    anchorRef.current = null
+  }, [])
+
+  // rAF-Schleife während der Wiedergabe.
+  useEffect(() => {
+    if (!playing) {
+      stopLoop()
+      return
+    }
+    const tick = () => {
+      const anchor = anchorRef.current
+      if (!anchor) return
+      const elapsed = (performance.now() - anchor.wall) / 1000
+      const next = anchor.time + elapsed
+      if (next >= durationRef.current) {
+        setCurrentTime(durationRef.current)
+        setPlaying(false)
+        return
+      }
+      setCurrentTime(next)
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return stopLoop
+  }, [playing, stopLoop])
+
+  const play = useCallback(() => {
+    if (durationRef.current <= 0) return
+    setPlaying((wasPlaying) => {
+      if (wasPlaying) return true
+      // Am Ende erneut → von vorn.
+      const startAt = currentTime >= durationRef.current ? 0 : currentTime
+      anchorRef.current = { wall: performance.now(), time: startAt }
+      if (startAt !== currentTime) setCurrentTime(startAt)
+      return true
+    })
+  }, [currentTime])
+
+  const pause = useCallback(() => setPlaying(false), [])
+
+  const stop = useCallback(() => {
+    setPlaying(false)
+    setCurrentTime(0)
+  }, [])
+
+  const seek = useCallback((t: number) => {
+    const clamped = Math.max(0, Math.min(t, durationRef.current))
+    setCurrentTime(clamped)
+    // Bei laufender Wiedergabe Anker neu setzen, damit die Clock weiterläuft.
+    if (anchorRef.current) anchorRef.current = { wall: performance.now(), time: clamped }
+  }, [])
+
+  const toStart = useCallback(() => seek(0), [seek])
+  const toEnd = useCallback(() => {
+    setPlaying(false)
+    setCurrentTime(durationRef.current)
+  }, [])
+
+  const togglePlay = useCallback(() => {
+    if (playing) pause()
+    else play()
+  }, [playing, play, pause])
+
+  return { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd, togglePlay }
+}


### PR DESCRIPTION
## V2 der Videoschnitt-Roadmap (Task d778bcdb)

Zweiter Slice: die Timeline wird erlebbar. Reine Frontend-Erweiterung auf den V1-Strukturen, **keine Backend-Änderung**.

### Was neu ist
- **Output-Monitor** spielt die Timeline clientseitig ab: aktiver visueller Clip (Video 2 hat Vorrang vor Video 1), Video-Clips mit Ton, Standbilder für ihre Dauer.
- **Parallele Audio-Spuren** (Musik/Effekt/Sprache) über versteckte `<audio>`-Elemente, `volume` je Clip, `muted` je Spur.
- **Master-Clock** (`useCutPlayback`): wall-clock-getriebene rAF-Schleife führt `currentTime`; Media-Elemente folgen mit Drift-Korrektur (>0,3s) — grobe Sync, für Preview ausreichend.
- **Playhead** läuft über den Spuren mit, **Ruler ist Scrub-Fläche** (Klick + Drag → Springen).
- **Transport** funktional: Anfang/Play/Pause/Stopp/Ende; Play stoppt am Ende. **Zeitanzeige** Position / Gesamtlänge.

### Dateien (alle <200 Zeilen, co-located in `media/videocut/`)
- `useCutPlayback.ts` — Clock, Transport, aktive-Clip-Helper, Timecode
- `playbackSync.ts` — `useMediaSync` (Drift/Play/Pause/Volume)
- `OutputMonitor.tsx` — visueller Monitor
- `PlaybackAudio.tsx` — parallele Audio-Elemente
- `TrackArea.tsx` — Playhead + Scrub (erweitert)
- `api.ts` — `buildAssetMedia` + `loadAtelierRoot` (erweitert)
- `MediaPostProduction.tsx` — Verdrahtung (erweitert)

### Verifikation
- ✅ tsc -b grün
- ✅ eslint grün
- ✅ npm run build grün (8.36s)

Spec: `docs/specs/videocut-v2.md`. Nächste: V3 Trim/Split (ff6723e8).