### PR TITLE
feat(media): Videoschnitt V3a — A/B-Roll Justage-Fundament

### DIFF
--- a/docs/specs/videocut-v3a.md
+++ b/docs/specs/videocut-v3a.md
@@ -1,0 +1,53 @@
+# Videoschnitt V3a — Justage-Fundament (A/B-Roll)
+
+## Was
+Der Videoschnitt wird zum echten A/B-Roll-Pult. Die beiden **Input-Monitore**
+werden an die Video-Spuren gekoppelt: Input 1 zeigt vid1, Input 2 zeigt vid2 —
+jeweils das Frame an der Position eines neuen, ziehbaren **roten Cut-Cursors**.
+Clips lassen sich frei **horizontal verschieben** (Überlappung ausdrücklich erlaubt).
+
+## Warum
+Voraussetzung für Schnittpunkte (V3b) und Übergänge (V3c). Der rote Cursor +
+die gekoppelten Monitore sind das Justier-Werkzeug: Beim Ziehen sieht man
+gleichzeitig, welches vid1- und welches vid2-Frame an dieser Stelle liegt, und
+findet so den perfekten Schnittmoment — ohne vid1 bis zum Ende oder vid2 vom
+Anfang nehmen zu müssen.
+
+## Warum nicht Trim/Split zuerst
+Clips kürzen/teilen bringt nichts, solange man sie nicht verschieben und keine
+Schnittpunkte setzen kann. Deshalb rückt das alte V3 (Trim/Split) hinter V3a–c.
+
+## Wie
+- **Backend: keine Änderungen.** Verschieben ändert nur `clip.start` (bestehendes
+  Feld). Kein Kollisions-/Overlap-Schutz — Überlappung ist gewollt.
+- **`useDragX`**: kleiner Pointer-Drag-Primitiv (window-Listener), rechnet
+  Pixel-Delta → Sekunden-Delta. Für Clip-Drag und Cut-Cursor-Drag genutzt.
+- **`moveClip(trackId, clipId, newStart)`** in `useCutTimeline`: setzt `start`
+  (>= 0), persistiert. Während des Drags wird lokal (ohne PUT) gerendert, erst
+  beim Loslassen gespeichert.
+- **Clip-Drag** in `TrackArea`: Pointer-Down auf Clip-Body → horizontal ziehen.
+  **Snapping** (Schwelle 0,4 s) an Clip-Kanten (Start/Ende aller vid1/vid2-Clips),
+  an 0 und an den Cut-Cursor. Entfernen-Button (X) bleibt klickbar.
+- **Roter Cut-Cursor** in `TrackArea`: vertikaler roter Balken über den Spuren mit
+  Griff oben, ziehbar. Position = `cursorTime` (Parent-State). Live-Update beim
+  Ziehen, kein Persist (reiner Ansicht-Cursor).
+- **`InputMonitor`** (neu): zeigt für eine Spur (vid1/vid2) das eingefrorene Frame
+  am `cursorTime` — Video via `<video>` auf `currentTime = localTime + source_in`
+  gesetzt und pausiert; Bild via `<img>`; sonst „kein Signal".
+- **Output-Monitor**: bleibt vorerst Playback wie V2 (vid2>vid1). Echte
+  Ergebnis-Assemblierung entlang der Schnittpunkte kommt in V3b.
+
+## Dateien (alle < 200 Zeilen)
+- `media/videocut/useDragX.ts` — Pointer-Drag-Primitiv (neu)
+- `media/videocut/InputMonitor.tsx` — track-gekoppelter Frozen-Frame-Monitor (neu)
+- `media/videocut/useCutTimeline.ts` — `moveClip` ergänzt
+- `media/videocut/TrackArea.tsx` — Clip-Drag + roter Cut-Cursor ergänzt
+- `media/MediaPostProduction.tsx` — `cursorTime`-State, Input-Monitore koppeln
+
+## Akzeptanzkriterien
+- [ ] Input 1 zeigt vid1-Frame, Input 2 zeigt vid2-Frame am Cut-Cursor.
+- [ ] Roter Cut-Cursor ist ziehbar; beide Inputs aktualisieren live.
+- [ ] Clips lassen sich horizontal verschieben, dürfen überlappen, Position persistiert.
+- [ ] Snapping an Clip-Kanten / 0 / Cursor.
+- [ ] Clip-Entfernen funktioniert weiterhin.
+- [ ] Keine Backend-Änderung, Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,35 +1,16 @@
-import { Film, Pause, Play, SkipBack, SkipForward, Square } from "lucide-react"
+import { Pause, Play, SkipBack, SkipForward, Square } from "lucide-react"
 import { useEffect, useState, type ComponentType } from "react"
 import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
+import { InputMonitor } from "./videocut/InputMonitor"
 import { OutputMonitor } from "./videocut/OutputMonitor"
 import { PlaybackAudio } from "./videocut/PlaybackAudio"
 import { TrackArea } from "./videocut/TrackArea"
 import { timecode, useCutPlayback } from "./videocut/useCutPlayback"
 import { useCutTimeline } from "./videocut/useCutTimeline"
 
-/** Videoschnitt (V2): Playback im Output-Monitor, Playhead + Transport.
- *  Die beiden Input-Monitore bleiben Platzhalter (Feintrim ab V3/V4). */
-
-function InputMonitor({ title }: { title: string }) {
-  return (
-    <div className="flex min-w-0 flex-col">
-      <div className="flex items-center justify-between px-1 pb-1">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#5aa9ff]">{title}</span>
-        <span className="font-mono text-[10px] text-[#68758a]">00:00:00</span>
-      </div>
-      <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
-        <div className="absolute inset-0 opacity-[0.06]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "24px 24px" }} />
-        <div className="absolute inset-0 grid place-items-center">
-          <div className="flex flex-col items-center gap-1 text-[#3f4b60]">
-            <Film size={26} />
-            <span className="text-[10px] uppercase tracking-[0.14em]">kein Signal</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
+/** Videoschnitt (V3a): A/B-Roll-Justage. Input 1 zeigt vid1, Input 2 zeigt vid2
+ *  am roten Cut-Cursor; Clips frei verschiebbar (Überlappung erlaubt). */
 
 function TransportButton({ icon: Icon, label, onClick, primary, disabled }: {
   icon: ComponentType<{ size?: number | string }>
@@ -52,10 +33,13 @@ interface Props {
 }
 
 export function MediaPostProduction({ projectId }: Props) {
-  const { timeline, assets, loading, saving, error, addClip, removeClip } = useCutTimeline(projectId)
+  const { timeline, assets, loading, saving, error, addClip, removeClip, previewClipStart, moveClip } = useCutTimeline(projectId)
   const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
 
-  // Atelier-Root → asset_id-Medien-Map für das Playback.
+  // Roter Cut-Cursor (Justage-Position der Input-Monitore).
+  const [cursorTime, setCursorTime] = useState(0)
+
+  // Atelier-Root → asset_id-Medien-Map für Playback + Frozen-Frames.
   const [media, setMedia] = useState<Map<string, ClipMedia>>(new Map())
   useEffect(() => {
     if (!projectId) return
@@ -71,14 +55,16 @@ export function MediaPostProduction({ projectId }: Props) {
   return (
     <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_260px]">
       <div className="min-w-0">
-        {/* 3 Monitore: Input 1, Input 2, Output (live) */}
+        {/* 3 Monitore: Input 1 (vid1), Input 2 (vid2), Output (Ergebnis) */}
         <div className="grid gap-3 lg:grid-cols-3">
-          <InputMonitor title="Input · Vid 1" />
-          <InputMonitor title="Input · Vid 2" />
           {timeline ? (
-            <OutputMonitor timeline={timeline} media={media} currentTime={currentTime} playing={playing} />
+            <>
+              <InputMonitor title="Input · Vid 1" trackId="vid1" timeline={timeline} media={media} cursorTime={cursorTime} accent="#5aa9ff" />
+              <InputMonitor title="Input · Vid 2" trackId="vid2" timeline={timeline} media={media} cursorTime={cursorTime} accent="#7c9cff" />
+              <OutputMonitor timeline={timeline} media={media} currentTime={currentTime} playing={playing} />
+            </>
           ) : (
-            <InputMonitor title="Output" />
+            <p className="col-span-3 text-xs text-[#7a869c]">Monitore werden geladen…</p>
           )}
         </div>
 
@@ -93,6 +79,7 @@ export function MediaPostProduction({ projectId }: Props) {
           <TransportButton icon={Square} label="Stopp" onClick={stop} disabled={!canPlay} />
           <TransportButton icon={SkipForward} label="Zum Ende" onClick={toEnd} disabled={!canPlay} />
           <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">{timecode(currentTime)} / {timecode(duration)}</span>
+          <span className="ml-3 font-mono text-[11px] text-rose-300">Cut {timecode(cursorTime)}</span>
           <span className="ml-auto text-[10px] uppercase tracking-[0.12em] text-[#68758a]">
             {loading ? "Lade…" : saving ? "Speichere…" : "Gespeichert"}
           </span>
@@ -100,10 +87,20 @@ export function MediaPostProduction({ projectId }: Props) {
 
         {error ? <p className="mt-2 text-xs text-rose-300">{error}</p> : null}
 
-        {/* Spuren mit Clips + Playhead */}
+        {/* Spuren mit verschiebbaren Clips + roter Cut-Cursor + Playhead */}
         <div className="mt-3">
           {timeline ? (
-            <TrackArea timeline={timeline} assets={assets} onRemoveClip={removeClip} currentTime={currentTime} onSeek={seek} />
+            <TrackArea
+              timeline={timeline}
+              assets={assets}
+              onRemoveClip={removeClip}
+              currentTime={currentTime}
+              onSeek={seek}
+              cursorTime={cursorTime}
+              onCursorChange={setCursorTime}
+              onClipPreview={previewClipStart}
+              onClipCommit={moveClip}
+            />
           ) : (
             <p className="text-xs text-[#7a869c]">{loading ? "Timeline wird geladen…" : "Keine Timeline verfügbar."}</p>
           )}

--- a/frontend/src/features/cockpit/media/videocut/ClipBlock.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ClipBlock.tsx
@@ -1,0 +1,70 @@
+import { X } from "lucide-react"
+import { useCallback, type PointerEvent } from "react"
+import type { MediaTimelineClip } from "../../mediaWorkspaceApi"
+import { useDragX } from "./useDragX"
+
+const SNAP_THRESHOLD = 0.4
+
+interface Props {
+  clip: MediaTimelineClip
+  label: string
+  tone: string
+  pxPerSecond: number
+  /** Snap-Ziele in Sekunden (fremde Clip-Kanten, 0, Cursor). */
+  snapTargets: number[]
+  onPreview: (start: number) => void
+  onCommit: (start: number) => void
+  onRemove: () => void
+}
+
+function fmtDur(s: number): string {
+  if (s >= 60) return `${Math.floor(s / 60)}:${String(Math.round(s % 60)).padStart(2, "0")}`
+  return `${Math.round(s * 10) / 10}s`
+}
+
+/** Ein horizontal verschiebbarer Clip. Snapping an fremde Kanten/0/Cursor —
+ *  sowohl Start- als auch Endkante rastet ein. Überlappung ist erlaubt. */
+export function ClipBlock({ clip, label, tone, pxPerSecond, snapTargets, onPreview, onCommit, onRemove }: Props) {
+  const snap = useCallback((value: number): number => {
+    let best = value
+    let bestDelta = SNAP_THRESHOLD
+    for (const t of snapTargets) {
+      const dStart = Math.abs(t - value)
+      if (dStart < bestDelta) { bestDelta = dStart; best = t }
+      const dEnd = Math.abs(t - (value + clip.duration))
+      if (dEnd < bestDelta) { bestDelta = dEnd; best = t - clip.duration }
+    }
+    return Math.max(0, best)
+  }, [snapTargets, clip.duration])
+
+  const { start, dragging } = useDragX({ pxPerSecond, onMove: onPreview, onCommit, snap })
+
+  const onPointerDown = useCallback((e: PointerEvent) => {
+    if (e.button !== 0) return
+    start(e, clip.start)
+  }, [start, clip.start])
+
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      className={["group absolute inset-y-1 select-none touch-none overflow-hidden rounded-[3px] border px-1.5 py-0.5",
+        dragging ? "cursor-grabbing ring-1 ring-white/40" : "cursor-grab"].join(" ")}
+      style={{
+        left: `${clip.start * pxPerSecond}px`,
+        width: `${Math.max(clip.duration * pxPerSecond, 34)}px`,
+        borderColor: tone,
+        background: `${tone}22`,
+      }}
+      title={`${label} · ${fmtDur(clip.duration)}`}>
+      <p className="truncate text-[9px] font-semibold leading-3 text-[#e8eef8]">{label}</p>
+      <p className="font-mono text-[8px] text-[#8d9ab0]">{fmtDur(clip.duration)}</p>
+      <button
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={onRemove}
+        aria-label="Clip entfernen"
+        className="absolute right-0.5 top-0.5 hidden rounded-[2px] bg-black/60 p-0.5 text-zinc-300 hover:text-white group-hover:block">
+        <X size={9} />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/InputMonitor.tsx
+++ b/frontend/src/features/cockpit/media/videocut/InputMonitor.tsx
@@ -1,0 +1,64 @@
+import { Film } from "lucide-react"
+import { useEffect, useRef } from "react"
+import type { MediaTimeline } from "../../mediaWorkspaceApi"
+import type { ClipMedia } from "./api"
+import { clipAt, timecode } from "./useCutPlayback"
+
+interface Props {
+  title: string
+  /** Video-Spur, an die dieser Monitor gekoppelt ist (vid1 / vid2). */
+  trackId: string
+  timeline: MediaTimeline
+  media: Map<string, ClipMedia>
+  /** Position des roten Cut-Cursors in Sekunden. */
+  cursorTime: number
+  accent: string
+}
+
+/** Setzt ein pausiertes <video> auf ein einzelnes Frame (localTime + source_in). */
+function FrozenFrame({ url, seekTo }: { url: string; seekTo: number }) {
+  const ref = useRef<HTMLVideoElement>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const apply = () => {
+      try { el.currentTime = seekTo } catch { /* metadata noch nicht bereit */ }
+    }
+    if (el.readyState >= 1) apply()
+    else el.addEventListener("loadedmetadata", apply, { once: true })
+  }, [seekTo, url])
+  return <video ref={ref} src={url} className="h-full w-full object-contain" preload="metadata" muted playsInline />
+}
+
+/** Input-Monitor: zeigt das Frame der gekoppelten Video-Spur am Cut-Cursor. */
+export function InputMonitor({ title, trackId, timeline, media, cursorTime, accent }: Props) {
+  const track = timeline.tracks.find((t) => t.id === trackId)
+  const active = track ? clipAt(track, cursorTime) : null
+  const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="flex items-center justify-between px-1 pb-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em]" style={{ color: accent }}>{title}</span>
+        <span className="font-mono text-[10px] text-[#68758a]">{timecode(cursorTime)}</span>
+      </div>
+      <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
+        {clipMedia && clipMedia.kind === "video" ? (
+          <FrozenFrame key={active!.clip.id} url={clipMedia.url} seekTo={active!.localTime + active!.clip.source_in} />
+        ) : clipMedia && clipMedia.kind === "image" ? (
+          <img key={active!.clip.id} src={clipMedia.url} alt="" className="h-full w-full object-contain" />
+        ) : (
+          <>
+            <div className="absolute inset-0 opacity-[0.06]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "24px 24px" }} />
+            <div className="absolute inset-0 grid place-items-center">
+              <div className="flex flex-col items-center gap-1 text-[#3f4b60]">
+                <Film size={26} />
+                <span className="text-[10px] uppercase tracking-[0.14em]">kein Signal</span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -1,17 +1,25 @@
-import { Mic, Music, Sparkles, Video, X } from "lucide-react"
-import { useCallback, useRef, type ComponentType, type PointerEvent } from "react"
+import { Mic, Music, Sparkles, Video } from "lucide-react"
+import { useCallback, useMemo, type ComponentType, type PointerEvent } from "react"
 import type { MediaAssetReference } from "../../mediaProjectsApi"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
+import { ClipBlock } from "./ClipBlock"
+import { useDragX } from "./useDragX"
 import { CUT_TRACKS } from "./useCutTimeline"
 
 interface Props {
   timeline: MediaTimeline
   assets: MediaAssetReference[]
   onRemoveClip: (trackId: string, clipId: string) => void
-  /** Aktuelle Playhead-Position in Sekunden. */
+  /** Playhead-Position (Wiedergabe) in Sekunden. */
   currentTime: number
   /** Springt zu Sekunde t (Klick/Scrub im Ruler). */
   onSeek: (t: number) => void
+  /** Roter Cut-Cursor (Justage) in Sekunden. */
+  cursorTime: number
+  onCursorChange: (t: number) => void
+  /** Clip-Verschieben: live (preview) + persistiert (commit). */
+  onClipPreview: (trackId: string, clipId: string, start: number) => void
+  onClipCommit: (trackId: string, clipId: string, start: number) => void
 }
 
 const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string; className?: string }>; tone: string }> = {
@@ -24,14 +32,14 @@ const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string;
 
 const PX_PER_SECOND = 6
 const MIN_RULER_SECONDS = 30
+const LABEL_COL = 84
+const GAP = 8
 
-function fmtDur(s: number): string {
-  if (s >= 60) return `${Math.floor(s / 60)}:${String(Math.round(s % 60)).padStart(2, "0")}`
-  return `${Math.round(s * 10) / 10}s`
-}
-
-export function TrackArea({ timeline, assets, onRemoveClip, currentTime, onSeek }: Props) {
-  const assetLabel = new Map(assets.map((a) => [a.id, a.label]))
+export function TrackArea({
+  timeline, assets, onRemoveClip, currentTime, onSeek,
+  cursorTime, onCursorChange, onClipPreview, onClipCommit,
+}: Props) {
+  const assetLabel = useMemo(() => new Map(assets.map((a) => [a.id, a.label])), [assets])
   const totalLen = Math.max(
     MIN_RULER_SECONDS,
     ...timeline.tracks.flatMap((t) => t.clips.map((c) => c.start + c.duration)),
@@ -39,46 +47,40 @@ export function TrackArea({ timeline, assets, onRemoveClip, currentTime, onSeek 
   const rulerSteps = Math.ceil(totalLen / 5)
   const innerWidth = totalLen * PX_PER_SECOND
   const playheadLeft = Math.min(currentTime, totalLen) * PX_PER_SECOND
+  const cursorLeft = Math.min(cursorTime, totalLen) * PX_PER_SECOND
 
-  const scrubbing = useRef(false)
-  const laneRef = useRef<HTMLDivElement>(null)
+  // Alle Clip-Kanten (Start/Ende) über beide Video-Spuren als Snap-Ziele.
+  const clipEdges = useMemo(() => {
+    const edges: number[] = [0]
+    for (const id of ["vid1", "vid2"]) {
+      const track = timeline.tracks.find((t) => t.id === id)
+      for (const c of track?.clips ?? []) { edges.push(c.start, c.start + c.duration) }
+    }
+    return edges
+  }, [timeline])
 
-  const seekFromEvent = useCallback((e: PointerEvent) => {
-    const el = laneRef.current
-    if (!el) return
-    const rect = el.getBoundingClientRect()
+  const cursorDrag = useDragX({ pxPerSecond: PX_PER_SECOND, onMove: onCursorChange })
+  const onCursorPointerDown = useCallback((e: PointerEvent) => {
+    e.stopPropagation()
+    cursorDrag.start(e, cursorTime)
+  }, [cursorDrag, cursorTime])
+
+  const seekFromRuler = useCallback((e: PointerEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
     const x = Math.max(0, Math.min(e.clientX - rect.left, innerWidth))
     onSeek(x / PX_PER_SECOND)
   }, [innerWidth, onSeek])
 
-  const onPointerDown = useCallback((e: PointerEvent) => {
-    scrubbing.current = true
-    e.currentTarget.setPointerCapture(e.pointerId)
-    seekFromEvent(e)
-  }, [seekFromEvent])
-
-  const onPointerMove = useCallback((e: PointerEvent) => {
-    if (scrubbing.current) seekFromEvent(e)
-  }, [seekFromEvent])
-
-  const onPointerUp = useCallback((e: PointerEvent) => {
-    scrubbing.current = false
-    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* nicht gecaptured */ }
-  }, [])
-
   return (
     <div className="overflow-x-auto">
-      <div style={{ minWidth: `${innerWidth + 96}px` }}>
-        {/* Ruler — Scrub-Fläche */}
-        <div className="grid grid-cols-[84px_1fr] gap-2">
+      <div style={{ minWidth: `${innerWidth + LABEL_COL + GAP}px` }}>
+        {/* Ruler — Scrub-Fläche (Playhead) */}
+        <div className="grid gap-2" style={{ gridTemplateColumns: `${LABEL_COL}px 1fr` }}>
           <div />
           <div
-            ref={laneRef}
-            className="relative h-5 cursor-pointer rounded-[3px] border border-[#2a364b] bg-[#111827] touch-none"
+            className="relative h-5 cursor-pointer touch-none rounded-[3px] border border-[#2a364b] bg-[#111827]"
             style={{ width: `${innerWidth}px` }}
-            onPointerDown={onPointerDown}
-            onPointerMove={onPointerMove}
-            onPointerUp={onPointerUp}
+            onPointerDown={seekFromRuler}
           >
             {Array.from({ length: rulerSteps + 1 }, (_, i) => (
               <span key={i} className="pointer-events-none absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * PX_PER_SECOND + 2}px` }}>
@@ -88,14 +90,14 @@ export function TrackArea({ timeline, assets, onRemoveClip, currentTime, onSeek 
           </div>
         </div>
 
-        {/* Spuren + Playhead-Overlay */}
+        {/* Spuren + Overlays (Playhead + roter Cut-Cursor) */}
         <div className="relative mt-2 space-y-1.5">
           {CUT_TRACKS.map((def) => {
             const track = timeline.tracks.find((t) => t.id === def.id)
             const meta = TRACK_META[def.id]
             const Icon = meta.icon
             return (
-              <div key={def.id} className="grid grid-cols-[84px_1fr] gap-2">
+              <div key={def.id} className="grid gap-2" style={{ gridTemplateColumns: `${LABEL_COL}px 1fr` }}>
                 <div className="flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-1.5" style={{ borderLeft: `3px solid ${meta.tone}` }}>
                   <Icon size={13} className="shrink-0" />
                   <span className="truncate text-[11px] font-semibold text-[#c3ccdd]">{def.name}</span>
@@ -103,34 +105,42 @@ export function TrackArea({ timeline, assets, onRemoveClip, currentTime, onSeek 
                 <div className="relative h-10 rounded-[3px] border border-[#223048] bg-[#0d1420]" style={{ width: `${innerWidth}px` }}>
                   <div className="absolute inset-0 opacity-[0.04]" style={{ backgroundImage: "linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: `${5 * PX_PER_SECOND}px 100%` }} />
                   {(track?.clips ?? []).map((clip) => (
-                    <div key={clip.id}
-                      className="group absolute inset-y-1 overflow-hidden rounded-[3px] border px-1.5 py-0.5"
-                      style={{
-                        left: `${clip.start * PX_PER_SECOND}px`,
-                        width: `${Math.max(clip.duration * PX_PER_SECOND, 34)}px`,
-                        borderColor: meta.tone,
-                        background: `${meta.tone}22`,
-                      }}
-                      title={`${assetLabel.get(clip.asset_id) ?? clip.asset_id} · ${fmtDur(clip.duration)}`}>
-                      <p className="truncate text-[9px] font-semibold leading-3 text-[#e8eef8]">{assetLabel.get(clip.asset_id) ?? clip.asset_id}</p>
-                      <p className="font-mono text-[8px] text-[#8d9ab0]">{fmtDur(clip.duration)}</p>
-                      <button onClick={() => onRemoveClip(def.id, clip.id)} aria-label="Clip entfernen"
-                        className="absolute right-0.5 top-0.5 hidden rounded-[2px] bg-black/60 p-0.5 text-zinc-300 hover:text-white group-hover:block">
-                        <X size={9} />
-                      </button>
-                    </div>
+                    <ClipBlock
+                      key={clip.id}
+                      clip={clip}
+                      label={assetLabel.get(clip.asset_id) ?? clip.asset_id}
+                      tone={meta.tone}
+                      pxPerSecond={PX_PER_SECOND}
+                      snapTargets={def.kind === "video" ? [...clipEdges, cursorTime] : [0, cursorTime]}
+                      onPreview={(start) => onClipPreview(def.id, clip.id, start)}
+                      onCommit={(start) => onClipCommit(def.id, clip.id, start)}
+                      onRemove={() => onRemoveClip(def.id, clip.id)}
+                    />
                   ))}
                 </div>
               </div>
             )
           })}
 
-          {/* Playhead-Linie über allen Spuren (nur im Spurbereich, nicht über den Labels) */}
+          {/* Playhead-Linie (Wiedergabe) */}
           <div
             className="pointer-events-none absolute inset-y-0 z-10 w-px bg-[#ffb86b]"
-            style={{ left: `calc(84px + 0.5rem + ${playheadLeft}px)` }}
+            style={{ left: `calc(${LABEL_COL}px + ${GAP}px + ${playheadLeft}px)` }}
           >
             <div className="absolute -top-0.5 -left-[3px] h-1.5 w-1.5 rounded-full bg-[#ffb86b]" />
+          </div>
+
+          {/* Roter Cut-Cursor (Justage) — ziehbar */}
+          <div
+            className="absolute inset-y-0 z-20 w-[2px] touch-none bg-rose-500"
+            style={{ left: `calc(${LABEL_COL}px + ${GAP}px + ${cursorLeft}px)` }}
+          >
+            <div
+              onPointerDown={onCursorPointerDown}
+              className={["absolute -top-1 -left-[6px] h-3 w-3.5 cursor-ew-resize rounded-[2px] bg-rose-500 shadow",
+                cursorDrag.dragging ? "ring-2 ring-rose-300" : ""].join(" ")}
+              title="Cut-Cursor ziehen"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
@@ -122,5 +122,34 @@ export function useCutTimeline(projectId: string) {
     void persist(next)
   }, [timeline, persist])
 
-  return { timeline, assets, loading, saving, error, addClip, removeClip }
+  /** Setzt clip.start lokal (ohne PUT) — für flüssiges Ziehen. */
+  const previewClipStart = useCallback((trackId: string, clipId: string, start: number) => {
+    setTimeline((cur) => {
+      if (!cur) return cur
+      return {
+        ...cur,
+        tracks: cur.tracks.map((track) =>
+          track.id !== trackId
+            ? track
+            : { ...track, clips: track.clips.map((c) => (c.id === clipId ? { ...c, start: Math.max(0, start) } : c)) },
+        ),
+      }
+    })
+  }, [])
+
+  /** Persistiert die neue Clip-Position (beim Loslassen). */
+  const moveClip = useCallback((trackId: string, clipId: string, start: number) => {
+    if (!timeline) return
+    const next: MediaTimeline = {
+      ...timeline,
+      tracks: timeline.tracks.map((track) =>
+        track.id !== trackId
+          ? track
+          : { ...track, clips: track.clips.map((c) => (c.id === clipId ? { ...c, start: Math.max(0, start) } : c)) },
+      ),
+    }
+    void persist(next)
+  }, [timeline, persist])
+
+  return { timeline, assets, loading, saving, error, addClip, removeClip, previewClipStart, moveClip }
 }

--- a/frontend/src/features/cockpit/media/videocut/useDragX.ts
+++ b/frontend/src/features/cockpit/media/videocut/useDragX.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+interface DragState {
+  startX: number
+  startValue: number
+}
+
+interface UseDragXOptions {
+  /** Pixel pro Sekunde der Timeline-Skala. */
+  pxPerSecond: number
+  /** Wird bei jeder Bewegung mit dem neuen (gesnappten) Wert in Sekunden gerufen. */
+  onMove: (value: number) => void
+  /** Beim Loslassen mit dem finalen Wert — z.B. zum Persistieren. */
+  onCommit?: (value: number) => void
+  /** Optionales Snapping: bekommt Rohwert, gibt gesnappten Wert zurück. */
+  snap?: (value: number) => number
+}
+
+/** Horizontales Pointer-Dragging auf einer Zeitachse.
+ *  Rechnet Pixel-Delta → Sekunden, wendet optionales Snapping an und meldet
+ *  Werte über onMove/onCommit. Window-Listener → Drag läuft auch außerhalb des
+ *  Elements weiter. Gibt einen Pointer-Down-Handler + `dragging`-Flag zurück. */
+export function useDragX({ pxPerSecond, onMove, onCommit, snap }: UseDragXOptions) {
+  const [dragging, setDragging] = useState(false)
+  const stateRef = useRef<DragState | null>(null)
+  // Callbacks in Refs halten → Listener müssen nicht neu gebunden werden.
+  const cb = useRef({ onMove, onCommit, snap })
+  useEffect(() => {
+    cb.current = { onMove, onCommit, snap }
+  })
+
+  const start = useCallback((e: { clientX: number }, currentValue: number) => {
+    stateRef.current = { startX: e.clientX, startValue: currentValue }
+    setDragging(true)
+  }, [])
+
+  useEffect(() => {
+    if (!dragging) return
+    const compute = (clientX: number): number => {
+      const s = stateRef.current
+      if (!s) return 0
+      const raw = s.startValue + (clientX - s.startX) / pxPerSecond
+      const clamped = Math.max(0, raw)
+      return cb.current.snap ? cb.current.snap(clamped) : clamped
+    }
+    const onPointerMove = (ev: PointerEvent) => cb.current.onMove(compute(ev.clientX))
+    const onPointerUp = (ev: PointerEvent) => {
+      const value = compute(ev.clientX)
+      setDragging(false)
+      stateRef.current = null
+      cb.current.onCommit?.(value)
+    }
+    window.addEventListener("pointermove", onPointerMove)
+    window.addEventListener("pointerup", onPointerUp)
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove)
+      window.removeEventListener("pointerup", onPointerUp)
+    }
+  }, [dragging, pxPerSecond])
+
+  return { start, dragging }
+}


### PR DESCRIPTION
## V3a — Justage-Fundament (A/B-Roll)

Nach deinem Feedback: der Videoschnitt wird zum echten A/B-Roll-Pult. **Keine Backend-Änderung.**

### Was neu ist
- **Input-Monitore gekoppelt:** Input 1 zeigt vid1, Input 2 zeigt vid2 — jeweils das **eingefrorene Frame** am roten Cut-Cursor (pausiertes `<video>` auf `localTime+source_in`, bzw. `<img>` für Standbilder).
- **Roter Cut-Cursor:** vertikaler ziehbarer Balken über beide Video-Spuren. Beim Ziehen aktualisieren **beide Input-Monitore live** → man sieht beide Seiten gleichzeitig und findet den perfekten Schnittmoment.
- **Clips frei verschiebbar:** horizontales Drag, **Überlappung ausdrücklich erlaubt** (kein Aneinanderklatschen mehr). Snapping an Clip-Kanten / 0 / Cursor (Schwelle 0,4 s). Live-Preview beim Ziehen, Persist beim Loslassen (`clip.start`).

### Warum diese Reihenfolge
Trim/Split (altes V3) bringt nichts, solange man Clips nicht verschieben und keine Schnittpunkte setzen kann. Deshalb rückt Trim/Split hinter V3a–c.

### Dateien (alle <200 Zeilen)
- `useDragX.ts` — Pointer-Drag-Primitiv (Pixel→Sekunden + Snapping)
- `InputMonitor.tsx` — track-gekoppelter Frozen-Frame-Monitor
- `ClipBlock.tsx` — verschiebbarer Clip mit Snapping
- `TrackArea.tsx` — roter Cut-Cursor + Clip-Drag (umgebaut)
- `useCutTimeline.ts` — `previewClipStart` + `moveClip`
- `MediaPostProduction.tsx` — cursorTime-State, Input-Monitore koppeln

### Verifikation
- ✅ tsc -b grün
- ✅ eslint grün
- ✅ npm run build grün (8.07s)

### Als Nächstes
- **V3b:** Button "Schnittpunkt hinzufügen" → Output assembliert entlang der Schnittpunkte (toggle vid1/vid2 mit Fallback). Braucht 1 Backend-Feld (cut_points).
- **V3c:** Übergangseffekte je Schnittpunkt (Crossfade/Wipe/…).

Spec: `docs/specs/videocut-v3a.md`.