### PR TITLE
feat(media): Videoschnitt V3b — Schnittpunkte & Output-Assemblierung

### DIFF
--- a/core/src/hydrahive/api/routes/media_workspace.py
+++ b/core/src/hydrahive/api/routes/media_workspace.py
@@ -67,17 +67,30 @@ class Track(BaseModel):
     clips: list[Clip] = Field(default_factory=list, max_length=2000)
 
 
+class CutPoint(BaseModel):
+    """A/B-Roll-Schnittpunkt: schaltet den Output zwischen den Video-Spuren um."""
+
+    id: str = Field(..., min_length=1, max_length=100)
+    time: float = Field(ge=0, le=86_400)
+
+
 class Timeline(BaseModel):
     fps: int = Field(default=25, ge=1, le=120)
     width: int = Field(default=1920, ge=16, le=7680)
     height: int = Field(default=1080, ge=16, le=4320)
     tracks: list[Track] = Field(default_factory=list, max_length=100)
+    cut_points: list[CutPoint] = Field(default_factory=list, max_length=2000)
 
     @model_validator(mode="after")
     def unique_ids(self):
         track_ids = [track.id for track in self.tracks]
         clip_ids = [clip.id for track in self.tracks for clip in track.clips]
-        if len(track_ids) != len(set(track_ids)) or len(clip_ids) != len(set(clip_ids)):
+        cut_ids = [cp.id for cp in self.cut_points]
+        if (
+            len(track_ids) != len(set(track_ids))
+            or len(clip_ids) != len(set(clip_ids))
+            or len(cut_ids) != len(set(cut_ids))
+        ):
             raise ValueError("IDs müssen eindeutig sein")
         return self
 

--- a/core/src/hydrahive/media_workspace.py
+++ b/core/src/hydrahive/media_workspace.py
@@ -58,10 +58,10 @@ def save_agent_context(project_id: str, media_slug: str, data: dict) -> dict:
 
 
 def timeline(project_id: str, media_slug: str) -> dict:
-    default = {"version": 1, "fps": 25, "width": 1920, "height": 1080, "tracks": [], "updated_at": None}
+    default = {"version": 1, "fps": 25, "width": 1920, "height": 1080, "tracks": [], "cut_points": [], "updated_at": None}
     return _read(_root(project_id, media_slug) / "timeline" / "timeline.json", default)
 
 
 def save_timeline(project_id: str, media_slug: str, data: dict) -> dict:
-    value = {"version": 1, "fps": data.get("fps", 25), "width": data.get("width", 1920), "height": data.get("height", 1080), "tracks": data.get("tracks", []), "updated_at": _now()}
+    value = {"version": 1, "fps": data.get("fps", 25), "width": data.get("width", 1920), "height": data.get("height", 1080), "tracks": data.get("tracks", []), "cut_points": data.get("cut_points", []), "updated_at": _now()}
     return _atomic(_root(project_id, media_slug) / "timeline" / "timeline.json", value)

--- a/core/tests/test_media_workspace_api.py
+++ b/core/tests/test_media_workspace_api.py
@@ -31,3 +31,20 @@ def test_timeline_rejects_duplicate_clip_ids(client, auth_headers):
     clip = {"id": "same", "asset_id": "a", "start": 0, "duration": 1}
     payload = {"tracks": [{"id": "one", "kind": "video", "clips": [clip]}, {"id": "two", "kind": "audio", "clips": [clip]}]}
     assert client.put(f"{base}/timeline", headers=auth_headers, json=payload).status_code == 422
+
+
+def test_timeline_cut_points_persist(client, auth_headers):
+    base = _base(client, auth_headers)
+    timeline = {
+        "tracks": [{"id": "vid1", "kind": "video", "clips": [{"id": "clip-1", "asset_id": "frame", "start": 0, "duration": 5}]}],
+        "cut_points": [{"id": "cut-1", "time": 2.5}, {"id": "cut-2", "time": 4}],
+    }
+    assert client.put(f"{base}/timeline", headers=auth_headers, json=timeline).status_code == 200
+    fetched = client.get(f"{base}/timeline", headers=auth_headers).json()
+    assert [cp["time"] for cp in fetched["cut_points"]] == [2.5, 4]
+
+
+def test_timeline_rejects_duplicate_cut_point_ids(client, auth_headers):
+    base = _base(client, auth_headers)
+    payload = {"cut_points": [{"id": "same", "time": 1}, {"id": "same", "time": 2}]}
+    assert client.put(f"{base}/timeline", headers=auth_headers, json=payload).status_code == 422

--- a/docs/specs/videocut-v3b.md
+++ b/docs/specs/videocut-v3b.md
@@ -1,0 +1,50 @@
+# Videoschnitt V3b — Schnittpunkte & Output-Assemblierung
+
+## Was
+Der rote Cut-Cursor kann per Button **„Schnittpunkt hinzufügen"** an seiner
+Position einen **Schnittpunkt** fixieren. Schnittpunkte sind eigene, wieder
+verschieb- und löschbare Marker auf der Zeitachse. Bei **Play** assembliert der
+**Output-Monitor** das Endprodukt entlang der Schnittpunkte: er schaltet an
+jedem Schnittpunkt zwischen vid1 und vid2 um.
+
+## Warum
+Kern des A/B-Roll-Schnitts. Erst der Schnittpunkt entscheidet, wo der Output von
+Vid 1 auf Vid 2 (und zurück) umschaltet — dadurch muss man vid1 nicht bis zum
+Ende und vid2 nicht vom Anfang nehmen. Baut auf V3a (Justage) auf, bereitet
+Übergangseffekte (V3c) vor.
+
+## Umschalt-Logik (Toggle mit Fallback)
+- Output startet auf **vid1**.
+- Jeder Schnittpunkt links von Position `t` **toggelt** die aktive Spur
+  (0 Schnittpunkte davor → vid1, 1 → vid2, 2 → vid1, …).
+- Hat die aktive Spur an `t` **keinen Clip** (Lücke), fällt der Output auf die
+  andere Spur zurück (statt Schwarzbild). Hat auch die keine → „kein Signal".
+
+## Wie
+### Backend (kleine, additive Änderung)
+- **`CutPoint`**-Model: `{ id: str, time: float }` (`time` in Sekunden, 0..86400).
+- **`Timeline.cut_points: list[CutPoint]`** (default `[]`, `max_length` begrenzt).
+  Pydantic-Validierung wie gehabt; `cut_points`-IDs müssen eindeutig sein.
+- **`media_workspace.timeline()`**-Default + **`save_timeline()`**-Whitelist um
+  `cut_points` erweitern (sonst wird das Feld beim Speichern verworfen).
+
+### Frontend
+- **Types/api**: `MediaCutPoint` + `cut_points` in `MediaTimeline`.
+- **`assembleOutput.activeVideoAt(timeline, t)`**: reine Funktion → aktive
+  `ActiveClip` nach obiger Logik (oder null).
+- **`useCutTimeline`**: `addCutPoint(time)`, `moveCutPoint(id, time)` (+preview),
+  `removeCutPoint(id)` — alle persistieren.
+- **`OutputMonitor`**: nutzt `activeVideoAt` statt der V2-Regel „vid2>vid1".
+- **`CutPointMarker`** (neu): weiße vertikale Linie mit Griff, ziehbar
+  (Snapping an Clip-Kanten/0), Löschen per X. Über allen Spuren.
+- **`TrackArea`**: rendert Schnittpunkt-Marker; reicht Add/Move/Remove durch.
+- **`MediaPostProduction`**: Button „Schnittpunkt hinzufügen" (fügt am
+  `cursorTime` hinzu), Zähler.
+
+## Akzeptanzkriterien
+- [ ] Button setzt am roten Cursor einen Schnittpunkt; Marker erscheint, persistiert.
+- [ ] Schnittpunkte sind verschiebbar (persistiert) und löschbar.
+- [ ] Bei Play schaltet der Output an jedem Schnittpunkt zwischen vid1/vid2 um.
+- [ ] Lücke in aktiver Spur → Fallback auf andere Spur.
+- [ ] `cut_points` überleben Reload (Backend round-trip).
+- [ ] Backend-Test grün, Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,4 +1,4 @@
-import { Pause, Play, SkipBack, SkipForward, Square } from "lucide-react"
+import { Pause, Play, Scissors, SkipBack, SkipForward, Square } from "lucide-react"
 import { useEffect, useState, type ComponentType } from "react"
 import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
@@ -33,7 +33,11 @@ interface Props {
 }
 
 export function MediaPostProduction({ projectId }: Props) {
-  const { timeline, assets, loading, saving, error, addClip, removeClip, previewClipStart, moveClip } = useCutTimeline(projectId)
+  const {
+    timeline, assets, loading, saving, error,
+    addClip, removeClip, previewClipStart, moveClip,
+    addCutPoint, previewCutPoint, moveCutPoint, removeCutPoint,
+  } = useCutTimeline(projectId)
   const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
 
   // Roter Cut-Cursor (Justage-Position der Input-Monitore).
@@ -79,7 +83,22 @@ export function MediaPostProduction({ projectId }: Props) {
           <TransportButton icon={Square} label="Stopp" onClick={stop} disabled={!canPlay} />
           <TransportButton icon={SkipForward} label="Zum Ende" onClick={toEnd} disabled={!canPlay} />
           <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">{timecode(currentTime)} / {timecode(duration)}</span>
-          <span className="ml-3 font-mono text-[11px] text-rose-300">Cut {timecode(cursorTime)}</span>
+
+          {/* Schnittpunkt am roten Cursor setzen */}
+          <button
+            type="button"
+            onClick={() => addCutPoint(cursorTime)}
+            disabled={!timeline || saving}
+            title="Schnittpunkt am Cut-Cursor hinzufügen"
+            className="ml-3 inline-flex items-center gap-1.5 rounded-[4px] border border-rose-500/50 bg-rose-500/10 px-2 py-1 text-[11px] font-semibold text-rose-200 transition-colors hover:bg-rose-500/20 disabled:opacity-40"
+          >
+            <Scissors size={13} /> Schnittpunkt
+          </button>
+          <span className="font-mono text-[11px] text-rose-300">{timecode(cursorTime)}</span>
+          {timeline && (timeline.cut_points?.length ?? 0) > 0 ? (
+            <span className="text-[10px] uppercase tracking-[0.12em] text-[#68758a]">· {timeline.cut_points!.length} Schnitte</span>
+          ) : null}
+
           <span className="ml-auto text-[10px] uppercase tracking-[0.12em] text-[#68758a]">
             {loading ? "Lade…" : saving ? "Speichere…" : "Gespeichert"}
           </span>
@@ -100,6 +119,9 @@ export function MediaPostProduction({ projectId }: Props) {
               onCursorChange={setCursorTime}
               onClipPreview={previewClipStart}
               onClipCommit={moveClip}
+              onCutPreview={previewCutPoint}
+              onCutCommit={moveCutPoint}
+              onCutRemove={removeCutPoint}
             />
           ) : (
             <p className="text-xs text-[#7a869c]">{loading ? "Timeline wird geladen…" : "Keine Timeline verfügbar."}</p>

--- a/frontend/src/features/cockpit/media/videocut/CutPointMarker.tsx
+++ b/frontend/src/features/cockpit/media/videocut/CutPointMarker.tsx
@@ -1,0 +1,64 @@
+import { X } from "lucide-react"
+import { useCallback, type PointerEvent } from "react"
+import type { MediaCutPoint } from "../../mediaWorkspaceApi"
+import { useDragX } from "./useDragX"
+
+const SNAP_THRESHOLD = 0.4
+
+interface Props {
+  cut: MediaCutPoint
+  pxPerSecond: number
+  /** Absoluter Left-Offset der Spurspalte (Label-Breite + Gap). */
+  laneOffsetCss: string
+  /** Snap-Ziele in Sekunden (Clip-Kanten, 0). */
+  snapTargets: number[]
+  onPreview: (time: number) => void
+  onCommit: (time: number) => void
+  onRemove: () => void
+}
+
+/** Weißer, vertikal über alle Spuren gehender Schnittpunkt-Marker. Ziehbar
+ *  (mit Snapping an Clip-Kanten), löschbar. Der Griff sitzt unten am Marker. */
+export function CutPointMarker({ cut, pxPerSecond, laneOffsetCss, snapTargets, onPreview, onCommit, onRemove }: Props) {
+  const snap = useCallback((value: number): number => {
+    let best = value
+    let bestDelta = SNAP_THRESHOLD
+    for (const t of snapTargets) {
+      const d = Math.abs(t - value)
+      if (d < bestDelta) { bestDelta = d; best = t }
+    }
+    return Math.max(0, best)
+  }, [snapTargets])
+
+  const { start, dragging } = useDragX({ pxPerSecond, onMove: onPreview, onCommit, snap })
+
+  const onPointerDown = useCallback((e: PointerEvent) => {
+    if (e.button !== 0) return
+    e.stopPropagation()
+    start(e, cut.time)
+  }, [start, cut.time])
+
+  return (
+    <div
+      className="group/cut absolute inset-y-0 z-30 w-[2px] bg-white"
+      style={{ left: `calc(${laneOffsetCss} + ${cut.time * pxPerSecond}px)` }}
+    >
+      {/* Griff oben: ziehen */}
+      <div
+        onPointerDown={onPointerDown}
+        title="Schnittpunkt ziehen"
+        className={["absolute -top-1 -left-[5px] h-3 w-3 cursor-ew-resize touch-none rounded-[2px] border border-white bg-[#0d1420]",
+          dragging ? "ring-2 ring-white/70" : ""].join(" ")}
+      />
+      {/* Löschen unten */}
+      <button
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={onRemove}
+        aria-label="Schnittpunkt löschen"
+        className="absolute -bottom-1 -left-[6px] hidden rounded-[2px] bg-black/70 p-0.5 text-zinc-300 hover:text-white group-hover/cut:block"
+      >
+        <X size={9} />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
+++ b/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
@@ -2,25 +2,15 @@ import { Film } from "lucide-react"
 import { useRef } from "react"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import type { ClipMedia } from "./api"
+import { activeVideoAt } from "./assembleOutput"
 import { useMediaSync } from "./playbackSync"
-import { clipAt, timecode, type ActiveClip } from "./useCutPlayback"
+import { timecode } from "./useCutPlayback"
 
 interface Props {
   timeline: MediaTimeline
   media: Map<string, ClipMedia>
   currentTime: number
   playing: boolean
-}
-
-/** Sichtbarer Clip an Position t: obere Video-Spur (vid2) hat Vorrang vor vid1. */
-function activeVisual(timeline: MediaTimeline, t: number): ActiveClip | null {
-  for (const id of ["vid2", "vid1"]) {
-    const track = timeline.tracks.find((tr) => tr.id === id)
-    if (!track) continue
-    const hit = clipAt(track, t)
-    if (hit) return hit
-  }
-  return null
 }
 
 /** <video>-Element, folgt der Master-Clock. key={clip.id} sorgt für Remount bei Clip-Wechsel. */
@@ -31,7 +21,7 @@ function VideoSurface({ url, localTime, playing, muted }: { url: string; localTi
 }
 
 export function OutputMonitor({ timeline, media, currentTime, playing }: Props) {
-  const active = activeVisual(timeline, currentTime)
+  const active = activeVideoAt(timeline, currentTime)
   const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
 
   return (

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, type ComponentType, type PointerEvent } from "rea
 import type { MediaAssetReference } from "../../mediaProjectsApi"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import { ClipBlock } from "./ClipBlock"
+import { CutPointMarker } from "./CutPointMarker"
 import { useDragX } from "./useDragX"
 import { CUT_TRACKS } from "./useCutTimeline"
 
@@ -20,6 +21,10 @@ interface Props {
   /** Clip-Verschieben: live (preview) + persistiert (commit). */
   onClipPreview: (trackId: string, clipId: string, start: number) => void
   onClipCommit: (trackId: string, clipId: string, start: number) => void
+  /** Schnittpunkte: live verschieben (preview) + persistiert (commit) + löschen. */
+  onCutPreview: (cutId: string, time: number) => void
+  onCutCommit: (cutId: string, time: number) => void
+  onCutRemove: (cutId: string) => void
 }
 
 const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string; className?: string }>; tone: string }> = {
@@ -38,6 +43,7 @@ const GAP = 8
 export function TrackArea({
   timeline, assets, onRemoveClip, currentTime, onSeek,
   cursorTime, onCursorChange, onClipPreview, onClipCommit,
+  onCutPreview, onCutCommit, onCutRemove,
 }: Props) {
   const assetLabel = useMemo(() => new Map(assets.map((a) => [a.id, a.label])), [assets])
   const totalLen = Math.max(
@@ -121,6 +127,20 @@ export function TrackArea({
               </div>
             )
           })}
+
+          {/* Schnittpunkt-Marker (weiß, ziehbar) */}
+          {(timeline.cut_points ?? []).map((cut) => (
+            <CutPointMarker
+              key={cut.id}
+              cut={cut}
+              pxPerSecond={PX_PER_SECOND}
+              laneOffsetCss={`${LABEL_COL}px + ${GAP}px`}
+              snapTargets={clipEdges}
+              onPreview={(time) => onCutPreview(cut.id, time)}
+              onCommit={(time) => onCutCommit(cut.id, time)}
+              onRemove={() => onCutRemove(cut.id)}
+            />
+          ))}
 
           {/* Playhead-Linie (Wiedergabe) */}
           <div

--- a/frontend/src/features/cockpit/media/videocut/assembleOutput.ts
+++ b/frontend/src/features/cockpit/media/videocut/assembleOutput.ts
@@ -1,0 +1,36 @@
+import type { MediaCutPoint, MediaTimeline } from "../../mediaWorkspaceApi"
+import { clipAt, type ActiveClip } from "./useCutPlayback"
+
+/** Sortierte Schnittpunkt-Zeiten der Timeline (aufsteigend). */
+export function sortedCutTimes(timeline: MediaTimeline): number[] {
+  return (timeline.cut_points ?? []).map((cp) => cp.time).sort((a, b) => a - b)
+}
+
+/** Aktive Video-Spur an Position t nach A/B-Roll-Regel:
+ *  Start auf vid1, jeder Schnittpunkt links von t toggelt vid1↔vid2.
+ *  Gerade Anzahl → vid1, ungerade → vid2. */
+export function activeTrackId(timeline: MediaTimeline, t: number): "vid1" | "vid2" {
+  const before = sortedCutTimes(timeline).filter((time) => time <= t).length
+  return before % 2 === 0 ? "vid1" : "vid2"
+}
+
+/** Sichtbarer Clip im Output an Position t: aktive Spur nach Schnittpunkt-Toggle,
+ *  mit Fallback auf die andere Video-Spur, falls die aktive dort eine Lücke hat. */
+export function activeVideoAt(timeline: MediaTimeline, t: number): ActiveClip | null {
+  const primary = activeTrackId(timeline, t)
+  const fallback = primary === "vid1" ? "vid2" : "vid1"
+  for (const id of [primary, fallback]) {
+    const track = timeline.tracks.find((tr) => tr.id === id)
+    if (!track) continue
+    const hit = clipAt(track, t)
+    if (hit) return hit
+  }
+  return null
+}
+
+/** Für die UI: nächster/aktueller CutPoint-Zustand (nur Anzahl, z.B. Zähler). */
+export function cutPointCount(timeline: MediaTimeline): number {
+  return (timeline.cut_points ?? []).length
+}
+
+export type { MediaCutPoint }

--- a/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
@@ -20,7 +20,7 @@ function withDefaultTracks(timeline: MediaTimeline): MediaTimeline {
   const tracks: MediaTimelineTrack[] = CUT_TRACKS.map((def) =>
     existing.get(def.id) ?? { id: def.id, name: def.name, kind: def.kind, muted: false, clips: [] },
   )
-  return { ...timeline, tracks }
+  return { ...timeline, tracks, cut_points: timeline.cut_points ?? [] }
 }
 
 function trackEnd(track: MediaTimelineTrack): number {
@@ -151,5 +151,41 @@ export function useCutTimeline(projectId: string) {
     void persist(next)
   }, [timeline, persist])
 
-  return { timeline, assets, loading, saving, error, addClip, removeClip, previewClipStart, moveClip }
+  /** Fügt am Zeitpunkt time einen Schnittpunkt hinzu (persistiert). */
+  const addCutPoint = useCallback((time: number) => {
+    if (!timeline) return
+    const cut = { id: `cut-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`, time: Math.max(0, time) }
+    void persist({ ...timeline, cut_points: [...(timeline.cut_points ?? []), cut] })
+  }, [timeline, persist])
+
+  /** Setzt cut.time lokal (ohne PUT) — für flüssiges Ziehen. */
+  const previewCutPoint = useCallback((cutId: string, time: number) => {
+    setTimeline((cur) => {
+      if (!cur) return cur
+      return {
+        ...cur,
+        cut_points: (cur.cut_points ?? []).map((cp) => (cp.id === cutId ? { ...cp, time: Math.max(0, time) } : cp)),
+      }
+    })
+  }, [])
+
+  /** Persistiert die neue Schnittpunkt-Position (beim Loslassen). */
+  const moveCutPoint = useCallback((cutId: string, time: number) => {
+    if (!timeline) return
+    void persist({
+      ...timeline,
+      cut_points: (timeline.cut_points ?? []).map((cp) => (cp.id === cutId ? { ...cp, time: Math.max(0, time) } : cp)),
+    })
+  }, [timeline, persist])
+
+  const removeCutPoint = useCallback((cutId: string) => {
+    if (!timeline) return
+    void persist({ ...timeline, cut_points: (timeline.cut_points ?? []).filter((cp) => cp.id !== cutId) })
+  }, [timeline, persist])
+
+  return {
+    timeline, assets, loading, saving, error,
+    addClip, removeClip, previewClipStart, moveClip,
+    addCutPoint, previewCutPoint, moveCutPoint, removeCutPoint,
+  }
 }

--- a/frontend/src/features/cockpit/mediaWorkspaceApi.ts
+++ b/frontend/src/features/cockpit/mediaWorkspaceApi.ts
@@ -8,7 +8,8 @@ export interface MediaAgentContext { version?: number; note: string; active_scen
 export type MediaTrackKind = "video" | "voice" | "music" | "audio"
 export interface MediaTimelineClip { id: string; asset_id: string; start: number; duration: number; source_in: number; volume: number }
 export interface MediaTimelineTrack { id: string; name: string; kind: MediaTrackKind; muted: boolean; clips: MediaTimelineClip[] }
-export interface MediaTimeline { version?: number; fps: number; width: number; height: number; tracks: MediaTimelineTrack[]; updated_at?: string | null }
+export interface MediaCutPoint { id: string; time: number }
+export interface MediaTimeline { version?: number; fps: number; width: number; height: number; tracks: MediaTimelineTrack[]; cut_points?: MediaCutPoint[]; updated_at?: string | null }
 
 const base = (projectId: string, mediaSlug: string) => `/projects/${projectId}/media-projects/${mediaSlug}`
 export const mediaWorkspaceApi = {


### PR DESCRIPTION
## V3b — Schnittpunkte (A/B-Roll-Kern)

Baut auf V3a auf. Jetzt entscheiden **Schnittpunkte**, wo der Output zwischen Vid 1 und Vid 2 umschaltet.

### Was neu ist
- **Button „Schnittpunkt"** (Scissors) fixiert am roten Cut-Cursor einen Schnittpunkt.
- **Schnittpunkt-Marker** (weiß, vertikal über alle Spuren): ziehbar mit Snapping an Clip-Kanten, per X löschbar.
- **Output-Assemblierung bei Play:** Start auf vid1, jeder Schnittpunkt **toggelt** vid1↔vid2. Hat die aktive Spur an der Stelle eine **Lücke**, fällt der Output auf die andere Spur zurück (kein Schwarzbild). → du musst vid1 nicht bis zum Ende und vid2 nicht vom Anfang nehmen.

### Backend (additiv, kein Breaking Change)
- `CutPoint`-Model `{id, time}` + `Timeline.cut_points` (eindeutige IDs erzwungen).
- `timeline()`-Default + `save_timeline()`-Whitelist reichen `cut_points` durch.
- **+2 Tests:** round-trip persistiert, doppelte IDs → 422.

### Frontend
- `assembleOutput.ts` — reine `activeVideoAt(timeline, t)` (Toggle + Fallback), per Sanity-Check verifiziert.
- `CutPointMarker.tsx` — ziehbarer/löschbarer Marker.
- `useCutTimeline.ts` — `addCutPoint / previewCutPoint / moveCutPoint / removeCutPoint`.
- `OutputMonitor.tsx` nutzt jetzt die Assemblierung statt der V2-Regel „vid2>vid1".
- `MediaPostProduction.tsx` — Button + Schnitt-Zähler.

### Verifikation
- ✅ Backend-Tests grün (5/5 in test_media_workspace_api.py)
- ✅ tsc -b grün
- ✅ eslint grün (nur V3b-Dateien; ein vorbestehender Lint-Fehler in MediaIdeaOverlay.tsx ist nicht Teil dieses PRs)
- ✅ npm run build grün
- ✅ Assemblierungs-Logik per Sanity-Check verifiziert (Toggle + Lücken-Fallback)

### Als Nächstes
**V3c — Übergangseffekte** je Schnittpunkt (Crossfade / Wipe / …) mit Dauer.

Spec: `docs/specs/videocut-v3b.md`.
