### PR TITLE
feat(media): Videoschnitt V3c — Übergangseffekte je Schnittpunkt

### DIFF
--- a/core/src/hydrahive/api/routes/media_workspace.py
+++ b/core/src/hydrahive/api/routes/media_workspace.py
@@ -68,10 +68,17 @@ class Track(BaseModel):
 
 
 class CutPoint(BaseModel):
-    """A/B-Roll-Schnittpunkt: schaltet den Output zwischen den Video-Spuren um."""
+    """A/B-Roll-Schnittpunkt: schaltet den Output zwischen den Video-Spuren um.
+
+    ``effect`` + ``duration`` beschreiben den Übergang: ``cut`` ist der
+    Hartschnitt (Dauer ignoriert), sonst wird über ``duration`` Sekunden
+    zentriert um ``time`` übergeblendet.
+    """
 
     id: str = Field(..., min_length=1, max_length=100)
     time: float = Field(ge=0, le=86_400)
+    effect: Literal["cut", "crossfade", "wipe", "fade-black"] = "cut"
+    duration: float = Field(default=0, ge=0, le=30)
 
 
 class Timeline(BaseModel):

--- a/core/tests/test_media_workspace_api.py
+++ b/core/tests/test_media_workspace_api.py
@@ -48,3 +48,21 @@ def test_timeline_rejects_duplicate_cut_point_ids(client, auth_headers):
     base = _base(client, auth_headers)
     payload = {"cut_points": [{"id": "same", "time": 1}, {"id": "same", "time": 2}]}
     assert client.put(f"{base}/timeline", headers=auth_headers, json=payload).status_code == 422
+
+
+def test_cut_point_transition_persists_and_defaults(client, auth_headers):
+    base = _base(client, auth_headers)
+    payload = {"cut_points": [
+        {"id": "cut-1", "time": 3, "effect": "crossfade", "duration": 1.5},
+        {"id": "cut-2", "time": 6},  # ohne effect/duration → Defaults
+    ]}
+    assert client.put(f"{base}/timeline", headers=auth_headers, json=payload).status_code == 200
+    cuts = client.get(f"{base}/timeline", headers=auth_headers).json()["cut_points"]
+    assert cuts[0]["effect"] == "crossfade" and cuts[0]["duration"] == 1.5
+    assert cuts[1]["effect"] == "cut" and cuts[1]["duration"] == 0
+
+
+def test_cut_point_rejects_unknown_effect(client, auth_headers):
+    base = _base(client, auth_headers)
+    payload = {"cut_points": [{"id": "cut-1", "time": 1, "effect": "explode"}]}
+    assert client.put(f"{base}/timeline", headers=auth_headers, json=payload).status_code == 422

--- a/docs/specs/videocut-v3c.md
+++ b/docs/specs/videocut-v3c.md
@@ -1,0 +1,58 @@
+# Videoschnitt V3c — Übergangseffekte je Schnittpunkt
+
+## Was
+Jeder Schnittpunkt bekommt einen **Übergangseffekt** mit **Dauer**. Statt eines
+harten Cuts blendet der Output am Schnittpunkt von Vid 1 auf Vid 2 (bzw. zurück)
+über — z.B. Crossfade oder Wipe. Ein **Inspector** erscheint bei ausgewähltem
+Schnittpunkt und lässt Effekt + Dauer einstellen.
+
+## Warum
+Letzter Baustein des A/B-Roll-Schnitts (nach Justage V3a und Schnittpunkten V3b).
+Weiche Übergänge sind der visuelle Standard jedes Schnitts.
+
+## Effekt-Typen (V3c)
+- `cut` — Hartschnitt (Default, Dauer ignoriert, = bisheriges V3b-Verhalten)
+- `crossfade` — Überblendung (Opacity)
+- `wipe` — horizontaler Wisch (clip-path Overlay von links)
+- `fade-black` — kurz nach Schwarz und wieder auf (über Zwischenblende)
+
+## Umschalt-/Render-Logik
+- Ein Schnittpunkt bei `time` mit Dauer `d` erzeugt ein Übergangsfenster
+  `[time − d/2, time + d/2]` (zentriert um den Schnittpunkt).
+- **Außerhalb** jedes Fensters: genau eine aktive Spur (V3b-Toggle, mit Fallback).
+- **Innerhalb** eines Fensters: `base` = Spur vor dem Schnittpunkt, `overlay` =
+  Spur nach dem Schnittpunkt, `progress` 0→1. Der Output rendert beide Layer
+  und mischt sie je nach Effekt (Opacity/clip-path). `cut`/`d=0` → harte Umschaltung.
+- Fallback bei Lücken bleibt erhalten (base/overlay können auf die jeweils andere
+  Video-Spur zeigen).
+
+## Wie
+### Backend (additiv)
+- `CutPoint` um `effect: Literal["cut","crossfade","wipe","fade-black"] = "cut"`
+  und `duration: float = 0 (0..30)` erweitern. Rückwärtskompatibel (Defaults).
+- Test: effect+duration round-trip.
+
+### Frontend
+- **`timelineOps.ts`** (neu, rein): `withDefaultTracks`, `probeDuration`, alle
+  Clip-/Cut-Transformationen (add/remove/move) als pure Funktionen → entschlackt
+  `useCutTimeline` unter die 200-Zeilen-Grenze. Neu: `updateCutPoint(patch)`.
+- **`assembleOutput.outputLayersAt(timeline, t)`** → `{ base, overlay?, progress, effect }`.
+  `base`/`overlay` sind `ActiveClip | null`.
+- **`OutputMonitor`**: rendert base-Layer immer, overlay-Layer nur im Fenster mit
+  Effekt-Styling (`crossfade`→opacity, `wipe`→clip-path inset, `fade-black`→
+  Schwarzblende in zwei Halbphasen).
+- **`transitions.ts`** (neu): Effekt-Metadaten (Label/Icon) + Style-Berechnung
+  `overlayStyle(effect, progress)`.
+- **`CutPointMarker`**: auswählbar (Klick), zeigt Effekt-Kürzel; selektierter
+  Marker hervorgehoben.
+- **`CutPointInspector`** (neu): Panel bei ausgewähltem Schnittpunkt — Effekt-Wahl
+  + Dauer-Slider + Löschen.
+- **`MediaPostProduction`**: `selectedCutId`-State, Inspector einblenden.
+
+## Akzeptanzkriterien
+- [ ] Schnittpunkt anklicken wählt ihn aus; Inspector zeigt Effekt + Dauer.
+- [ ] Effekt/Dauer ändern persistiert und wirkt im Output bei Play.
+- [ ] Crossfade/Wipe/Fade-to-black sind im Output sichtbar; `cut` bleibt hart.
+- [ ] Übergangsfenster zentriert um den Schnittpunkt, Fallback bei Lücken erhalten.
+- [ ] Alte Schnittpunkte ohne effect/duration → Hartschnitt (rückwärtskompatibel).
+- [ ] Backend-Test grün, Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -2,6 +2,7 @@ import { Pause, Play, Scissors, SkipBack, SkipForward, Square } from "lucide-rea
 import { useEffect, useState, type ComponentType } from "react"
 import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
+import { CutPointInspector } from "./videocut/CutPointInspector"
 import { InputMonitor } from "./videocut/InputMonitor"
 import { OutputMonitor } from "./videocut/OutputMonitor"
 import { PlaybackAudio } from "./videocut/PlaybackAudio"
@@ -9,8 +10,9 @@ import { TrackArea } from "./videocut/TrackArea"
 import { timecode, useCutPlayback } from "./videocut/useCutPlayback"
 import { useCutTimeline } from "./videocut/useCutTimeline"
 
-/** Videoschnitt (V3a): A/B-Roll-Justage. Input 1 zeigt vid1, Input 2 zeigt vid2
- *  am roten Cut-Cursor; Clips frei verschiebbar (Überlappung erlaubt). */
+/** Videoschnitt (V3c): A/B-Roll mit Übergangseffekten. Input 1/2 zeigen vid1/vid2
+ *  am roten Cut-Cursor; Clips überlappen; Schnittpunkte schalten den Output um,
+ *  mit optionalem Übergang (Crossfade/Wipe/Schwarzblende). */
 
 function TransportButton({ icon: Icon, label, onClick, primary, disabled }: {
   icon: ComponentType<{ size?: number | string }>
@@ -36,12 +38,15 @@ export function MediaPostProduction({ projectId }: Props) {
   const {
     timeline, assets, loading, saving, error,
     addClip, removeClip, previewClipStart, moveClip,
-    addCutPoint, previewCutPoint, moveCutPoint, removeCutPoint,
+    addCutPoint, previewCutPoint, moveCutPoint, updateCutPoint, removeCutPoint,
   } = useCutTimeline(projectId)
   const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
 
   // Roter Cut-Cursor (Justage-Position der Input-Monitore).
   const [cursorTime, setCursorTime] = useState(0)
+  // Ausgewählter Schnittpunkt (für Inspector).
+  const [selectedCutId, setSelectedCutId] = useState<string | null>(null)
+  const selectedCut = timeline?.cut_points?.find((cp) => cp.id === selectedCutId) ?? null
 
   // Atelier-Root → asset_id-Medien-Map für Playback + Frozen-Frames.
   const [media, setMedia] = useState<Map<string, ClipMedia>>(new Map())
@@ -84,10 +89,10 @@ export function MediaPostProduction({ projectId }: Props) {
           <TransportButton icon={SkipForward} label="Zum Ende" onClick={toEnd} disabled={!canPlay} />
           <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">{timecode(currentTime)} / {timecode(duration)}</span>
 
-          {/* Schnittpunkt am roten Cursor setzen */}
+          {/* Schnittpunkt am roten Cursor setzen und direkt auswählen */}
           <button
             type="button"
-            onClick={() => addCutPoint(cursorTime)}
+            onClick={() => { const id = addCutPoint(cursorTime); if (id) setSelectedCutId(id) }}
             disabled={!timeline || saving}
             title="Schnittpunkt am Cut-Cursor hinzufügen"
             className="ml-3 inline-flex items-center gap-1.5 rounded-[4px] border border-rose-500/50 bg-rose-500/10 px-2 py-1 text-[11px] font-semibold text-rose-200 transition-colors hover:bg-rose-500/20 disabled:opacity-40"
@@ -121,12 +126,24 @@ export function MediaPostProduction({ projectId }: Props) {
               onClipCommit={moveClip}
               onCutPreview={previewCutPoint}
               onCutCommit={moveCutPoint}
-              onCutRemove={removeCutPoint}
+              onCutRemove={(id) => { removeCutPoint(id); if (id === selectedCutId) setSelectedCutId(null) }}
+              selectedCutId={selectedCutId}
+              onSelectCut={setSelectedCutId}
             />
           ) : (
             <p className="text-xs text-[#7a869c]">{loading ? "Timeline wird geladen…" : "Keine Timeline verfügbar."}</p>
           )}
         </div>
+
+        {/* Inspector für den ausgewählten Schnittpunkt (Übergangseffekt + Dauer) */}
+        {selectedCut ? (
+          <CutPointInspector
+            cut={selectedCut}
+            onChange={(patch) => updateCutPoint(selectedCut.id, patch)}
+            onRemove={() => { removeCutPoint(selectedCut.id); setSelectedCutId(null) }}
+            onClose={() => setSelectedCutId(null)}
+          />
+        ) : null}
       </div>
 
       {/* Clip-Bibliothek rechts */}

--- a/frontend/src/features/cockpit/media/videocut/CutPointInspector.tsx
+++ b/frontend/src/features/cockpit/media/videocut/CutPointInspector.tsx
@@ -1,0 +1,77 @@
+import { Trash2 } from "lucide-react"
+import type { MediaCutPoint, MediaTransitionEffect } from "../../mediaWorkspaceApi"
+import { timecode } from "./useCutPlayback"
+import { TRANSITIONS } from "./transitions"
+
+interface Props {
+  cut: MediaCutPoint
+  onChange: (patch: Partial<MediaCutPoint>) => void
+  onRemove: () => void
+  onClose: () => void
+}
+
+const DEFAULT_DURATION = 1
+
+/** Inspector für einen ausgewählten Schnittpunkt: Übergangseffekt + Dauer. */
+export function CutPointInspector({ cut, onChange, onRemove, onClose }: Props) {
+  const effect = cut.effect ?? "cut"
+  const duration = cut.duration ?? 0
+
+  const selectEffect = (next: MediaTransitionEffect) => {
+    // Beim Wechsel von Hartschnitt auf einen Übergang eine sinnvolle Default-Dauer setzen.
+    if (next !== "cut" && duration <= 0) onChange({ effect: next, duration: DEFAULT_DURATION })
+    else if (next === "cut") onChange({ effect: next })
+    else onChange({ effect: next })
+  }
+
+  return (
+    <div className="mt-3 rounded-[4px] border border-rose-500/30 bg-[#141b28] p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-rose-300">
+          Schnittpunkt · {timecode(cut.time)}
+        </span>
+        <button onClick={onClose} className="text-[10px] uppercase tracking-[0.12em] text-[#68758a] hover:text-[#c3ccdd]">
+          schließen
+        </button>
+      </div>
+
+      {/* Effekt-Auswahl */}
+      <div className="flex flex-wrap gap-1.5">
+        {TRANSITIONS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => selectEffect(t.id)}
+            className={["rounded-[3px] border px-2 py-1 text-[11px] font-semibold transition-colors",
+              effect === t.id
+                ? "border-rose-400/60 bg-rose-500/15 text-rose-100"
+                : "border-[#2a364b] bg-[#111827] text-[#8d9ab0] hover:text-[#c3ccdd]"].join(" ")}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Dauer-Slider (nur bei echten Übergängen) */}
+      {effect !== "cut" ? (
+        <div className="mt-3 flex items-center gap-2">
+          <span className="text-[11px] text-[#8d9ab0]">Dauer</span>
+          <input
+            type="range" min={0.2} max={5} step={0.1} value={duration || DEFAULT_DURATION}
+            onChange={(e) => onChange({ duration: Number(e.target.value) })}
+            className="h-1 flex-1 cursor-pointer accent-rose-400"
+          />
+          <span className="w-12 text-right font-mono text-[11px] text-rose-200">{(duration || DEFAULT_DURATION).toFixed(1)}s</span>
+        </div>
+      ) : (
+        <p className="mt-2 text-[11px] text-[#68758a]">Hartschnitt — kein Übergang.</p>
+      )}
+
+      <button
+        onClick={onRemove}
+        className="mt-3 inline-flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] px-2 py-1 text-[11px] text-rose-300 hover:bg-rose-500/10"
+      >
+        <Trash2 size={12} /> Schnittpunkt löschen
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/CutPointMarker.tsx
+++ b/frontend/src/features/cockpit/media/videocut/CutPointMarker.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react"
 import { useCallback, type PointerEvent } from "react"
 import type { MediaCutPoint } from "../../mediaWorkspaceApi"
+import { transitionShort } from "./transitions"
 import { useDragX } from "./useDragX"
 
 const SNAP_THRESHOLD = 0.4
@@ -12,14 +13,17 @@ interface Props {
   laneOffsetCss: string
   /** Snap-Ziele in Sekunden (Clip-Kanten, 0). */
   snapTargets: number[]
+  selected: boolean
+  onSelect: () => void
   onPreview: (time: number) => void
   onCommit: (time: number) => void
   onRemove: () => void
 }
 
 /** Weißer, vertikal über alle Spuren gehender Schnittpunkt-Marker. Ziehbar
- *  (mit Snapping an Clip-Kanten), löschbar. Der Griff sitzt unten am Marker. */
-export function CutPointMarker({ cut, pxPerSecond, laneOffsetCss, snapTargets, onPreview, onCommit, onRemove }: Props) {
+ *  (Snapping an Clip-Kanten), auswählbar (Klick), löschbar. Bei Übergang mit
+ *  Effekt zeigt er das Effekt-Kürzel; die Übergangsdauer wird als Band angedeutet. */
+export function CutPointMarker({ cut, pxPerSecond, laneOffsetCss, snapTargets, selected, onSelect, onPreview, onCommit, onRemove }: Props) {
   const snap = useCallback((value: number): number => {
     let best = value
     let bestDelta = SNAP_THRESHOLD
@@ -35,21 +39,44 @@ export function CutPointMarker({ cut, pxPerSecond, laneOffsetCss, snapTargets, o
   const onPointerDown = useCallback((e: PointerEvent) => {
     if (e.button !== 0) return
     e.stopPropagation()
+    onSelect()
     start(e, cut.time)
-  }, [start, cut.time])
+  }, [start, cut.time, onSelect])
+
+  const effect = cut.effect ?? "cut"
+  const dur = cut.duration ?? 0
+  const short = transitionShort(effect)
+  const bandWidth = effect !== "cut" && dur > 0 ? dur * pxPerSecond : 0
+  const color = selected ? "#f43f5e" : "#ffffff"
 
   return (
     <div
-      className="group/cut absolute inset-y-0 z-30 w-[2px] bg-white"
+      className="group/cut absolute inset-y-0 z-30"
       style={{ left: `calc(${laneOffsetCss} + ${cut.time * pxPerSecond}px)` }}
     >
-      {/* Griff oben: ziehen */}
+      {/* Übergangs-Band (zentriert um den Schnittpunkt) */}
+      {bandWidth > 0 ? (
+        <div
+          className="pointer-events-none absolute inset-y-0"
+          style={{ left: `${-bandWidth / 2}px`, width: `${bandWidth}px`, background: `${color}22`, borderLeft: `1px dashed ${color}66`, borderRight: `1px dashed ${color}66` }}
+        />
+      ) : null}
+
+      {/* Marker-Linie */}
+      <div className="absolute inset-y-0 w-[2px]" style={{ background: color }} />
+
+      {/* Griff oben: auswählen + ziehen */}
       <div
         onPointerDown={onPointerDown}
-        title="Schnittpunkt ziehen"
-        className={["absolute -top-1 -left-[5px] h-3 w-3 cursor-ew-resize touch-none rounded-[2px] border border-white bg-[#0d1420]",
+        title={`Schnittpunkt (${effect})`}
+        className={["absolute -top-1 -left-[6px] grid h-3.5 w-3.5 cursor-ew-resize touch-none place-items-center rounded-[2px] border font-mono text-[7px] font-bold leading-none",
+          selected ? "border-rose-400 text-rose-100" : "border-white text-white",
           dragging ? "ring-2 ring-white/70" : ""].join(" ")}
-      />
+        style={{ background: "#0d1420" }}
+      >
+        {short}
+      </div>
+
       {/* Löschen unten */}
       <button
         onPointerDown={(e) => e.stopPropagation()}

--- a/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
+++ b/frontend/src/features/cockpit/media/videocut/OutputMonitor.tsx
@@ -1,10 +1,11 @@
 import { Film } from "lucide-react"
-import { useRef } from "react"
+import { useRef, type CSSProperties } from "react"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import type { ClipMedia } from "./api"
-import { activeVideoAt } from "./assembleOutput"
+import { outputLayersAt } from "./assembleOutput"
 import { useMediaSync } from "./playbackSync"
-import { timecode } from "./useCutPlayback"
+import { blackVeilOpacity, overlayStyle } from "./transitions"
+import { timecode, type ActiveClip } from "./useCutPlayback"
 
 interface Props {
   timeline: MediaTimeline
@@ -20,9 +21,33 @@ function VideoSurface({ url, localTime, playing, muted }: { url: string; localTi
   return <video ref={ref} src={url} className="h-full w-full object-contain" playsInline preload="auto" muted={muted} />
 }
 
-export function OutputMonitor({ timeline, media, currentTime, playing }: Props) {
-  const active = activeVideoAt(timeline, currentTime)
+/** Ein Layer (Video oder Standbild) für einen aktiven Clip. Absolut positioniert,
+ *  Effekt-Styling via style. muted, damit im Übergang nicht zwei Tonspuren doppeln
+ *  (der Ton kommt aus dem base-Layer / den Audio-Spuren). */
+function ClipLayer({ active, media, playing, style, muted }: {
+  active: ActiveClip | null
+  media: Map<string, ClipMedia>
+  playing: boolean
+  style?: CSSProperties
+  muted: boolean
+}) {
   const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
+  if (!active || !clipMedia) return null
+  return (
+    <div className="absolute inset-0" style={style}>
+      {clipMedia.kind === "video" ? (
+        <VideoSurface key={active.clip.id} url={clipMedia.url} localTime={active.localTime} playing={playing} muted={muted || active.track.muted} />
+      ) : (
+        <img key={active.clip.id} src={clipMedia.url} alt="" className="h-full w-full object-contain" />
+      )}
+    </div>
+  )
+}
+
+export function OutputMonitor({ timeline, media, currentTime, playing }: Props) {
+  const { base, overlay, progress, effect } = outputLayersAt(timeline, currentTime)
+  const hasSignal = Boolean(base) || Boolean(overlay)
+  const veil = blackVeilOpacity(effect, progress)
 
   return (
     <div className="flex min-w-0 flex-col">
@@ -31,17 +56,16 @@ export function OutputMonitor({ timeline, media, currentTime, playing }: Props) 
         <span className="font-mono text-[10px] text-[#68758a]">{timecode(currentTime)}</span>
       </div>
       <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
-        {clipMedia && clipMedia.kind === "video" ? (
-          <VideoSurface
-            key={active!.clip.id}
-            url={clipMedia.url}
-            localTime={active!.localTime}
-            playing={playing}
-            muted={active!.track.muted}
-          />
-        ) : clipMedia && clipMedia.kind === "image" ? (
-          <img key={active!.clip.id} src={clipMedia.url} alt="" className="h-full w-full object-contain" />
-        ) : (
+        {/* Base-Layer (Spur vor dem Schnittpunkt) — trägt den Ton */}
+        <ClipLayer active={base} media={media} playing={playing} muted={false} />
+
+        {/* Overlay-Layer (Spur nach dem Schnittpunkt) — nur im Übergang */}
+        {overlay ? <ClipLayer active={overlay} media={media} playing={playing} muted style={overlayStyle(effect, progress)} /> : null}
+
+        {/* Schwarzblende (fade-black) */}
+        {veil > 0 ? <div className="pointer-events-none absolute inset-0 bg-black" style={{ opacity: veil }} /> : null}
+
+        {!hasSignal ? (
           <>
             <div className="absolute inset-0 opacity-[0.06]" style={{ backgroundImage: "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: "24px 24px" }} />
             <div className="absolute inset-0 grid place-items-center">
@@ -51,7 +75,7 @@ export function OutputMonitor({ timeline, media, currentTime, playing }: Props) 
               </div>
             </div>
           </>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -25,6 +25,9 @@ interface Props {
   onCutPreview: (cutId: string, time: number) => void
   onCutCommit: (cutId: string, time: number) => void
   onCutRemove: (cutId: string) => void
+  /** Ausgewählter Schnittpunkt (für Inspector). */
+  selectedCutId: string | null
+  onSelectCut: (cutId: string) => void
 }
 
 const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string; className?: string }>; tone: string }> = {
@@ -43,7 +46,7 @@ const GAP = 8
 export function TrackArea({
   timeline, assets, onRemoveClip, currentTime, onSeek,
   cursorTime, onCursorChange, onClipPreview, onClipCommit,
-  onCutPreview, onCutCommit, onCutRemove,
+  onCutPreview, onCutCommit, onCutRemove, selectedCutId, onSelectCut,
 }: Props) {
   const assetLabel = useMemo(() => new Map(assets.map((a) => [a.id, a.label])), [assets])
   const totalLen = Math.max(
@@ -136,6 +139,8 @@ export function TrackArea({
               pxPerSecond={PX_PER_SECOND}
               laneOffsetCss={`${LABEL_COL}px + ${GAP}px`}
               snapTargets={clipEdges}
+              selected={selectedCutId === cut.id}
+              onSelect={() => onSelectCut(cut.id)}
               onPreview={(time) => onCutPreview(cut.id, time)}
               onCommit={(time) => onCutCommit(cut.id, time)}
               onRemove={() => onCutRemove(cut.id)}

--- a/frontend/src/features/cockpit/media/videocut/assembleOutput.ts
+++ b/frontend/src/features/cockpit/media/videocut/assembleOutput.ts
@@ -1,25 +1,26 @@
-import type { MediaCutPoint, MediaTimeline } from "../../mediaWorkspaceApi"
+import type { MediaCutPoint, MediaTimeline, MediaTransitionEffect } from "../../mediaWorkspaceApi"
 import { clipAt, type ActiveClip } from "./useCutPlayback"
 
-/** Sortierte Schnittpunkt-Zeiten der Timeline (aufsteigend). */
-export function sortedCutTimes(timeline: MediaTimeline): number[] {
-  return (timeline.cut_points ?? []).map((cp) => cp.time).sort((a, b) => a - b)
+/** Nach Zeit sortierte Schnittpunkte. */
+export function sortedCuts(timeline: MediaTimeline): MediaCutPoint[] {
+  return [...(timeline.cut_points ?? [])].sort((a, b) => a.time - b.time)
 }
 
-/** Aktive Video-Spur an Position t nach A/B-Roll-Regel:
- *  Start auf vid1, jeder Schnittpunkt links von t toggelt vid1↔vid2.
- *  Gerade Anzahl → vid1, ungerade → vid2. */
+/** Aktive Video-Spur nach n Schnittpunkten: gerade → vid1, ungerade → vid2. */
+function trackForIndex(n: number): "vid1" | "vid2" {
+  return n % 2 === 0 ? "vid1" : "vid2"
+}
+
+/** Aktive Video-Spur an Position t (Anzahl Schnittpunkte ≤ t bestimmt Toggle). */
 export function activeTrackId(timeline: MediaTimeline, t: number): "vid1" | "vid2" {
-  const before = sortedCutTimes(timeline).filter((time) => time <= t).length
-  return before % 2 === 0 ? "vid1" : "vid2"
+  const n = sortedCuts(timeline).filter((cp) => cp.time <= t).length
+  return trackForIndex(n)
 }
 
-/** Sichtbarer Clip im Output an Position t: aktive Spur nach Schnittpunkt-Toggle,
- *  mit Fallback auf die andere Video-Spur, falls die aktive dort eine Lücke hat. */
-export function activeVideoAt(timeline: MediaTimeline, t: number): ActiveClip | null {
-  const primary = activeTrackId(timeline, t)
-  const fallback = primary === "vid1" ? "vid2" : "vid1"
-  for (const id of [primary, fallback]) {
+/** Clip einer Video-Spur an t, mit Fallback auf die andere Video-Spur bei Lücke. */
+function clipOnTrackWithFallback(timeline: MediaTimeline, trackId: "vid1" | "vid2", t: number): ActiveClip | null {
+  const other = trackId === "vid1" ? "vid2" : "vid1"
+  for (const id of [trackId, other]) {
     const track = timeline.tracks.find((tr) => tr.id === id)
     if (!track) continue
     const hit = clipAt(track, t)
@@ -28,7 +29,52 @@ export function activeVideoAt(timeline: MediaTimeline, t: number): ActiveClip | 
   return null
 }
 
-/** Für die UI: nächster/aktueller CutPoint-Zustand (nur Anzahl, z.B. Zähler). */
+/** Sichtbarer Clip im Output an Position t (ohne Übergangs-Layer). */
+export function activeVideoAt(timeline: MediaTimeline, t: number): ActiveClip | null {
+  return clipOnTrackWithFallback(timeline, activeTrackId(timeline, t), t)
+}
+
+export interface OutputLayers {
+  base: ActiveClip | null
+  /** Overlay-Layer während eines Übergangsfensters, sonst null. */
+  overlay: ActiveClip | null
+  /** 0..1 innerhalb des Fensters; 0 außerhalb. */
+  progress: number
+  effect: MediaTransitionEffect
+}
+
+/** Übergangsfenster eines Schnittpunkts: [time − d/2, time + d/2]. */
+function windowOf(cp: MediaCutPoint): { from: number; to: number } | null {
+  const d = cp.duration ?? 0
+  const effect = cp.effect ?? "cut"
+  if (effect === "cut" || d <= 0) return null
+  return { from: cp.time - d / 2, to: cp.time + d / 2 }
+}
+
+/** Output-Layer an Position t: base immer, overlay+progress+effect im Fenster.
+ *  Der Schnittpunkt-Index bestimmt base = Spur davor, overlay = Spur danach. */
+export function outputLayersAt(timeline: MediaTimeline, t: number): OutputLayers {
+  const cuts = sortedCuts(timeline)
+
+  // Aktives Übergangsfenster suchen (erstes, das t enthält).
+  for (let i = 0; i < cuts.length; i++) {
+    const win = windowOf(cuts[i])
+    if (!win || t < win.from || t >= win.to) continue
+    const before = trackForIndex(i)       // Schnittpunkte VOR diesem: i
+    const after = trackForIndex(i + 1)    // nach diesem Schnittpunkt
+    const progress = (t - win.from) / (win.to - win.from)
+    return {
+      base: clipOnTrackWithFallback(timeline, before, t),
+      overlay: clipOnTrackWithFallback(timeline, after, t),
+      progress,
+      effect: cuts[i].effect ?? "cut",
+    }
+  }
+
+  // Kein Übergang aktiv → einzelne Spur.
+  return { base: activeVideoAt(timeline, t), overlay: null, progress: 0, effect: "cut" }
+}
+
 export function cutPointCount(timeline: MediaTimeline): number {
   return (timeline.cut_points ?? []).length
 }

--- a/frontend/src/features/cockpit/media/videocut/timelineOps.ts
+++ b/frontend/src/features/cockpit/media/videocut/timelineOps.ts
@@ -1,0 +1,90 @@
+import type { MediaCutPoint, MediaTimeline, MediaTimelineTrack } from "../../mediaWorkspaceApi"
+
+/** Feste UI-Spuren des Schnittpults → Timeline-Track-Kinds. */
+export const CUT_TRACKS = [
+  { id: "vid1", name: "Video 1", kind: "video" as const },
+  { id: "vid2", name: "Video 2", kind: "video" as const },
+  { id: "music", name: "Musik", kind: "music" as const },
+  { id: "fx", name: "Effekt", kind: "audio" as const },
+  { id: "voice", name: "Sprache", kind: "voice" as const },
+]
+
+export const IMAGE_DEFAULT_DURATION = 5
+export const AUDIO_FALLBACK_DURATION = 30
+
+/** Stellt sicher, dass alle festen Spuren + ein cut_points-Array existieren. */
+export function withDefaultTracks(timeline: MediaTimeline): MediaTimeline {
+  const existing = new Map(timeline.tracks.map((t) => [t.id, t]))
+  const tracks: MediaTimelineTrack[] = CUT_TRACKS.map((def) =>
+    existing.get(def.id) ?? { id: def.id, name: def.name, kind: def.kind, muted: false, clips: [] },
+  )
+  return { ...timeline, tracks, cut_points: timeline.cut_points ?? [] }
+}
+
+export function trackEnd(track: MediaTimelineTrack): number {
+  return track.clips.reduce((max, clip) => Math.max(max, clip.start + clip.duration), 0)
+}
+
+/** Dauer einer Audio-/Videodatei clientseitig über Element-Metadata ermitteln. */
+export function probeDuration(url: string, kind: "audio" | "video"): Promise<number | null> {
+  return new Promise((resolve) => {
+    const el = document.createElement(kind)
+    const done = (value: number | null) => { el.src = ""; resolve(value) }
+    el.preload = "metadata"
+    el.onloadedmetadata = () => done(Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null)
+    el.onerror = () => done(null)
+    setTimeout(() => done(null), 8000)
+    el.src = url
+  })
+}
+
+const genId = (prefix: string) => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+
+// --- reine Timeline-Transformationen (immer neues Objekt) ---
+
+export function setClipStart(tl: MediaTimeline, trackId: string, clipId: string, start: number): MediaTimeline {
+  return {
+    ...tl,
+    tracks: tl.tracks.map((track) =>
+      track.id !== trackId
+        ? track
+        : { ...track, clips: track.clips.map((c) => (c.id === clipId ? { ...c, start: Math.max(0, start) } : c)) },
+    ),
+  }
+}
+
+export function removeClipFrom(tl: MediaTimeline, trackId: string, clipId: string): MediaTimeline {
+  return {
+    ...tl,
+    tracks: tl.tracks.map((track) =>
+      track.id === trackId ? { ...track, clips: track.clips.filter((c) => c.id !== clipId) } : track,
+    ),
+  }
+}
+
+export function appendClip(tl: MediaTimeline, trackId: string, assetId: string, duration: number): MediaTimeline {
+  return {
+    ...tl,
+    tracks: tl.tracks.map((track) => {
+      if (track.id !== trackId) return track
+      const clip = { id: genId("clip"), asset_id: assetId, start: trackEnd(track), duration, source_in: 0, volume: 1 }
+      return { ...track, clips: [...track.clips, clip] }
+    }),
+  }
+}
+
+export function addCut(tl: MediaTimeline, time: number): { timeline: MediaTimeline; cut: MediaCutPoint } {
+  const cut: MediaCutPoint = { id: genId("cut"), time: Math.max(0, time), effect: "cut", duration: 0 }
+  return { timeline: { ...tl, cut_points: [...(tl.cut_points ?? []), cut] }, cut }
+}
+
+export function patchCut(tl: MediaTimeline, cutId: string, patch: Partial<MediaCutPoint>): MediaTimeline {
+  return {
+    ...tl,
+    cut_points: (tl.cut_points ?? []).map((cp) => (cp.id === cutId ? { ...cp, ...patch } : cp)),
+  }
+}
+
+export function removeCut(tl: MediaTimeline, cutId: string): MediaTimeline {
+  return { ...tl, cut_points: (tl.cut_points ?? []).filter((cp) => cp.id !== cutId) }
+}

--- a/frontend/src/features/cockpit/media/videocut/transitions.ts
+++ b/frontend/src/features/cockpit/media/videocut/transitions.ts
@@ -1,0 +1,52 @@
+import type { CSSProperties } from "react"
+import type { MediaTransitionEffect } from "../../mediaWorkspaceApi"
+
+export interface TransitionMeta {
+  id: MediaTransitionEffect
+  label: string
+  /** Kurz-Kürzel für den Marker. */
+  short: string
+}
+
+export const TRANSITIONS: TransitionMeta[] = [
+  { id: "cut", label: "Hartschnitt", short: "" },
+  { id: "crossfade", label: "Überblendung", short: "X" },
+  { id: "wipe", label: "Wisch", short: "W" },
+  { id: "fade-black", label: "Nach Schwarz", short: "B" },
+]
+
+export function transitionLabel(effect: MediaTransitionEffect | undefined): string {
+  return TRANSITIONS.find((t) => t.id === (effect ?? "cut"))?.label ?? "Hartschnitt"
+}
+
+export function transitionShort(effect: MediaTransitionEffect | undefined): string {
+  return TRANSITIONS.find((t) => t.id === (effect ?? "cut"))?.short ?? ""
+}
+
+/** Style für den Overlay-Layer (Spur NACH dem Schnittpunkt) je Effekt.
+ *  progress 0 → Overlay unsichtbar, 1 → Overlay voll sichtbar.
+ *  Der base-Layer liegt darunter und ist immer voll sichtbar. */
+export function overlayStyle(effect: MediaTransitionEffect, progress: number): CSSProperties {
+  const p = Math.max(0, Math.min(1, progress))
+  switch (effect) {
+    case "crossfade":
+      return { opacity: p }
+    case "wipe":
+      // Overlay wischt von links herein: rechter Teil bleibt zunächst abgeschnitten.
+      return { opacity: 1, clipPath: `inset(0 ${(1 - p) * 100}% 0 0)` }
+    case "fade-black":
+      // Erste Hälfte: base nach Schwarz (Overlay unsichtbar). Zweite Hälfte:
+      // Overlay aus Schwarz heraus. Die Schwarzblende macht OutputMonitor separat.
+      return { opacity: p < 0.5 ? 0 : (p - 0.5) * 2 }
+    case "cut":
+    default:
+      return { opacity: p >= 0.5 ? 1 : 0 }
+  }
+}
+
+/** Deckkraft der Schwarzblende (nur fade-black): 1 in der Mitte, 0 an den Rändern. */
+export function blackVeilOpacity(effect: MediaTransitionEffect, progress: number): number {
+  if (effect !== "fade-black") return 0
+  const p = Math.max(0, Math.min(1, progress))
+  return 1 - Math.abs(p - 0.5) * 2
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
@@ -1,44 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { MediaAssetReference } from "../../mediaProjectsApi"
-import type { MediaTimeline, MediaTimelineTrack } from "../../mediaWorkspaceApi"
+import type { MediaCutPoint, MediaTimeline } from "../../mediaWorkspaceApi"
 import { ensureAssetRef, ensureCutProject, loadTimelineAndAssets, saveTimeline, type LibraryItem } from "./api"
+import {
+  addCut, appendClip, AUDIO_FALLBACK_DURATION, CUT_TRACKS, IMAGE_DEFAULT_DURATION,
+  patchCut, probeDuration, removeClipFrom, removeCut, setClipStart, withDefaultTracks,
+} from "./timelineOps"
 
-/** Feste UI-Spuren des Schnittpults → Timeline-Track-Kinds. */
-export const CUT_TRACKS = [
-  { id: "vid1", name: "Video 1", kind: "video" as const },
-  { id: "vid2", name: "Video 2", kind: "video" as const },
-  { id: "music", name: "Musik", kind: "music" as const },
-  { id: "fx", name: "Effekt", kind: "audio" as const },
-  { id: "voice", name: "Sprache", kind: "voice" as const },
-]
-
-export const IMAGE_DEFAULT_DURATION = 5
-const AUDIO_FALLBACK_DURATION = 30
-
-function withDefaultTracks(timeline: MediaTimeline): MediaTimeline {
-  const existing = new Map(timeline.tracks.map((t) => [t.id, t]))
-  const tracks: MediaTimelineTrack[] = CUT_TRACKS.map((def) =>
-    existing.get(def.id) ?? { id: def.id, name: def.name, kind: def.kind, muted: false, clips: [] },
-  )
-  return { ...timeline, tracks, cut_points: timeline.cut_points ?? [] }
-}
-
-function trackEnd(track: MediaTimelineTrack): number {
-  return track.clips.reduce((max, clip) => Math.max(max, clip.start + clip.duration), 0)
-}
-
-/** Dauer einer Audio-/Videodatei clientseitig über Element-Metadata ermitteln. */
-function probeDuration(url: string, kind: "audio" | "video"): Promise<number | null> {
-  return new Promise((resolve) => {
-    const el = document.createElement(kind)
-    const done = (value: number | null) => { el.src = ""; resolve(value) }
-    el.preload = "metadata"
-    el.onloadedmetadata = () => done(Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null)
-    el.onerror = () => done(null)
-    setTimeout(() => done(null), 8000)
-    el.src = url
-  })
-}
+// Re-Export für bestehende Importe (TrackArea, ClipLibrary, InputMonitor …).
+export { CUT_TRACKS, IMAGE_DEFAULT_DURATION }
 
 export function useCutTimeline(projectId: string) {
   const [timeline, setTimeline] = useState<MediaTimeline | null>(null)
@@ -90,102 +60,54 @@ export function useCutTimeline(projectId: string) {
       }
       if (duration == null) duration = item.kind === "image" ? IMAGE_DEFAULT_DURATION : AUDIO_FALLBACK_DURATION
 
-      const next: MediaTimeline = {
-        ...timeline,
-        tracks: timeline.tracks.map((track) => {
-          if (track.id !== trackId) return track
-          const clip = {
-            id: `clip-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
-            asset_id: ref.id,
-            start: trackEnd(track),
-            duration,
-            source_in: 0,
-            volume: 1,
-          }
-          return { ...track, clips: [...track.clips, clip] }
-        }),
-      }
-      await persist(next)
+      await persist(appendClip(timeline, trackId, ref.id, duration))
     } catch {
       setError("Clip konnte nicht hinzugefügt werden.")
     }
   }, [timeline, assets, projectId, persist])
 
   const removeClip = useCallback((trackId: string, clipId: string) => {
-    if (!timeline) return
-    const next: MediaTimeline = {
-      ...timeline,
-      tracks: timeline.tracks.map((track) =>
-        track.id === trackId ? { ...track, clips: track.clips.filter((c) => c.id !== clipId) } : track,
-      ),
-    }
-    void persist(next)
+    if (timeline) void persist(removeClipFrom(timeline, trackId, clipId))
   }, [timeline, persist])
 
   /** Setzt clip.start lokal (ohne PUT) — für flüssiges Ziehen. */
   const previewClipStart = useCallback((trackId: string, clipId: string, start: number) => {
-    setTimeline((cur) => {
-      if (!cur) return cur
-      return {
-        ...cur,
-        tracks: cur.tracks.map((track) =>
-          track.id !== trackId
-            ? track
-            : { ...track, clips: track.clips.map((c) => (c.id === clipId ? { ...c, start: Math.max(0, start) } : c)) },
-        ),
-      }
-    })
+    setTimeline((cur) => (cur ? setClipStart(cur, trackId, clipId, start) : cur))
   }, [])
 
-  /** Persistiert die neue Clip-Position (beim Loslassen). */
   const moveClip = useCallback((trackId: string, clipId: string, start: number) => {
-    if (!timeline) return
-    const next: MediaTimeline = {
-      ...timeline,
-      tracks: timeline.tracks.map((track) =>
-        track.id !== trackId
-          ? track
-          : { ...track, clips: track.clips.map((c) => (c.id === clipId ? { ...c, start: Math.max(0, start) } : c)) },
-      ),
-    }
-    void persist(next)
+    if (timeline) void persist(setClipStart(timeline, trackId, clipId, start))
   }, [timeline, persist])
 
-  /** Fügt am Zeitpunkt time einen Schnittpunkt hinzu (persistiert). */
-  const addCutPoint = useCallback((time: number) => {
-    if (!timeline) return
-    const cut = { id: `cut-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`, time: Math.max(0, time) }
-    void persist({ ...timeline, cut_points: [...(timeline.cut_points ?? []), cut] })
+  /** Fügt am Zeitpunkt time einen Schnittpunkt hinzu und gibt dessen ID zurück. */
+  const addCutPoint = useCallback((time: number): string | null => {
+    if (!timeline) return null
+    const { timeline: next, cut } = addCut(timeline, time)
+    void persist(next)
+    return cut.id
   }, [timeline, persist])
 
   /** Setzt cut.time lokal (ohne PUT) — für flüssiges Ziehen. */
   const previewCutPoint = useCallback((cutId: string, time: number) => {
-    setTimeline((cur) => {
-      if (!cur) return cur
-      return {
-        ...cur,
-        cut_points: (cur.cut_points ?? []).map((cp) => (cp.id === cutId ? { ...cp, time: Math.max(0, time) } : cp)),
-      }
-    })
+    setTimeline((cur) => (cur ? patchCut(cur, cutId, { time: Math.max(0, time) }) : cur))
   }, [])
 
-  /** Persistiert die neue Schnittpunkt-Position (beim Loslassen). */
   const moveCutPoint = useCallback((cutId: string, time: number) => {
-    if (!timeline) return
-    void persist({
-      ...timeline,
-      cut_points: (timeline.cut_points ?? []).map((cp) => (cp.id === cutId ? { ...cp, time: Math.max(0, time) } : cp)),
-    })
+    if (timeline) void persist(patchCut(timeline, cutId, { time: Math.max(0, time) }))
+  }, [timeline, persist])
+
+  /** Ändert Effekt/Dauer (o.ä.) eines Schnittpunkts und persistiert. */
+  const updateCutPoint = useCallback((cutId: string, patch: Partial<MediaCutPoint>) => {
+    if (timeline) void persist(patchCut(timeline, cutId, patch))
   }, [timeline, persist])
 
   const removeCutPoint = useCallback((cutId: string) => {
-    if (!timeline) return
-    void persist({ ...timeline, cut_points: (timeline.cut_points ?? []).filter((cp) => cp.id !== cutId) })
+    if (timeline) void persist(removeCut(timeline, cutId))
   }, [timeline, persist])
 
   return {
     timeline, assets, loading, saving, error,
     addClip, removeClip, previewClipStart, moveClip,
-    addCutPoint, previewCutPoint, moveCutPoint, removeCutPoint,
+    addCutPoint, previewCutPoint, moveCutPoint, updateCutPoint, removeCutPoint,
   }
 }

--- a/frontend/src/features/cockpit/mediaWorkspaceApi.ts
+++ b/frontend/src/features/cockpit/mediaWorkspaceApi.ts
@@ -8,7 +8,8 @@ export interface MediaAgentContext { version?: number; note: string; active_scen
 export type MediaTrackKind = "video" | "voice" | "music" | "audio"
 export interface MediaTimelineClip { id: string; asset_id: string; start: number; duration: number; source_in: number; volume: number }
 export interface MediaTimelineTrack { id: string; name: string; kind: MediaTrackKind; muted: boolean; clips: MediaTimelineClip[] }
-export interface MediaCutPoint { id: string; time: number }
+export type MediaTransitionEffect = "cut" | "crossfade" | "wipe" | "fade-black"
+export interface MediaCutPoint { id: string; time: number; effect?: MediaTransitionEffect; duration?: number }
 export interface MediaTimeline { version?: number; fps: number; width: number; height: number; tracks: MediaTimelineTrack[]; cut_points?: MediaCutPoint[]; updated_at?: string | null }
 
 const base = (projectId: string, mediaSlug: string) => `/projects/${projectId}/media-projects/${mediaSlug}`


### PR DESCRIPTION
## V3c — Übergangseffekte je Schnittpunkt

Letzter Baustein des A/B-Roll-Schnitts. Aus harten Cuts werden weiche Übergänge.

### Was neu ist
- **Schnittpunkt anklicken** wählt ihn aus → **Inspector** blendet ein: Effekt-Wahl + Dauer-Slider + Löschen.
- **Effekte:** `Hartschnitt` (Default, wie V3b), `Überblendung` (Crossfade), `Wisch` (Wipe), `Nach Schwarz` (Fade-to-black).
- **Output rendert den Übergang bei Play:** im Fenster `[time − d/2, time + d/2]` blendet die Spur *vor* dem Schnittpunkt (base) auf die *danach* (overlay) über — via Opacity / clip-path / Schwarzblende.
- **Marker** zeigt jetzt ein Effekt-Kürzel + ein Übergangsband (Dauer), der ausgewählte Marker ist rot.
- Fallback bei Lücken bleibt erhalten; `cut` / Dauer 0 = harter Schnitt wie bisher.

### Backend (additiv, rückwärtskompatibel)
- `CutPoint.effect` (`cut|crossfade|wipe|fade-black`, Default `cut`) + `CutPoint.duration` (Default 0, 0..30).
- Alte Schnittpunkte ohne die Felder → Hartschnitt.
- **+2 Tests:** effect/duration round-trip inkl. Defaults, unbekannter Effekt → 422.

### Refactor (unter die 200-Zeilen-Grenze)
- Reine Timeline-Transformationen nach `timelineOps.ts` ausgelagert.
- `useCutTimeline` von **191 → 113 Zeilen** entschlackt.

### Verifikation
- ✅ Backend-Tests grün (7/7 in test_media_workspace_api.py)
- ✅ tsc -b grün · eslint grün · npm run build grün
- ✅ `outputLayersAt` per Sanity-Check verifiziert (Übergangsfenster, base/overlay-Toggle, progress-Rampe, Hartschnitt-Fallback)

### ⚠️ Deploy-Hinweis
Wie V3b hat auch dieser PR eine **Backend-Änderung** (`effect`/`duration` an CutPoint). Server brauchen ein Update, damit die Felder persistiert werden. Alte Backends verwerfen die Felder still (kein Crash) — der Übergang wäre dann nur clientseitig sichtbar, aber nach Reload weg.

Spec: `docs/specs/videocut-v3c.md`. Damit ist die A/B-Roll-Kette (V3a–c) komplett. Als Nächstes stünde **Trim/Split** (das ursprüngliche V3) an.
