### PR TITLE
fix(media): Videoschnitt-Playback — Output-Stottern + tote Input-Monitore

### DIFF
--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -68,8 +68,8 @@ export function MediaPostProduction({ projectId }: Props) {
         <div className="grid gap-3 lg:grid-cols-3">
           {timeline ? (
             <>
-              <InputMonitor title="Input · Vid 1" trackId="vid1" timeline={timeline} media={media} cursorTime={cursorTime} accent="#5aa9ff" />
-              <InputMonitor title="Input · Vid 2" trackId="vid2" timeline={timeline} media={media} cursorTime={cursorTime} accent="#7c9cff" />
+              <InputMonitor title="Input · Vid 1" trackId="vid1" timeline={timeline} media={media} currentTime={currentTime} cursorTime={cursorTime} playing={playing} accent="#5aa9ff" />
+              <InputMonitor title="Input · Vid 2" trackId="vid2" timeline={timeline} media={media} currentTime={currentTime} cursorTime={cursorTime} playing={playing} accent="#7c9cff" />
               <OutputMonitor timeline={timeline} media={media} currentTime={currentTime} playing={playing} />
             </>
           ) : (

--- a/frontend/src/features/cockpit/media/videocut/InputMonitor.tsx
+++ b/frontend/src/features/cockpit/media/videocut/InputMonitor.tsx
@@ -1,7 +1,8 @@
 import { Film } from "lucide-react"
-import { useEffect, useRef } from "react"
+import { useRef } from "react"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import type { ClipMedia } from "./api"
+import { useMediaSync } from "./playbackSync"
 import { clipAt, timecode } from "./useCutPlayback"
 
 interface Props {
@@ -10,41 +11,40 @@ interface Props {
   trackId: string
   timeline: MediaTimeline
   media: Map<string, ClipMedia>
-  /** Position des roten Cut-Cursors in Sekunden. */
+  /** Playhead-Position (Wiedergabe) in Sekunden. */
+  currentTime: number
+  /** Roter Cut-Cursor (Justage) in Sekunden. */
   cursorTime: number
+  /** Läuft die Wiedergabe? Dann folgt der Monitor dem Playhead, sonst dem Cursor. */
+  playing: boolean
   accent: string
 }
 
-/** Setzt ein pausiertes <video> auf ein einzelnes Frame (localTime + source_in). */
-function FrozenFrame({ url, seekTo }: { url: string; seekTo: number }) {
+/** <video>, das der Master-Clock folgt: läuft bei playing, friert sonst am
+ *  Sollframe ein. Immer stumm (Ton kommt aus dem Output). */
+function VideoSurface({ url, localTime, playing }: { url: string; localTime: number; playing: boolean }) {
   const ref = useRef<HTMLVideoElement>(null)
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const apply = () => {
-      try { el.currentTime = seekTo } catch { /* metadata noch nicht bereit */ }
-    }
-    if (el.readyState >= 1) apply()
-    else el.addEventListener("loadedmetadata", apply, { once: true })
-  }, [seekTo, url])
-  return <video ref={ref} src={url} className="h-full w-full object-contain" preload="metadata" muted playsInline />
+  useMediaSync(ref, { localTime, playing, active: true, muted: true })
+  return <video ref={ref} src={url} className="h-full w-full object-contain" preload="auto" muted playsInline />
 }
 
-/** Input-Monitor: zeigt das Frame der gekoppelten Video-Spur am Cut-Cursor. */
-export function InputMonitor({ title, trackId, timeline, media, cursorTime, accent }: Props) {
+/** Input-Monitor: zeigt das Frame der gekoppelten Video-Spur. Bei Wiedergabe
+ *  läuft er am Playhead mit, sonst friert er am Justage-Cursor ein. */
+export function InputMonitor({ title, trackId, timeline, media, currentTime, cursorTime, playing, accent }: Props) {
+  const position = playing ? currentTime : cursorTime
   const track = timeline.tracks.find((t) => t.id === trackId)
-  const active = track ? clipAt(track, cursorTime) : null
+  const active = track ? clipAt(track, position) : null
   const clipMedia = active ? media.get(active.clip.asset_id) ?? null : null
 
   return (
     <div className="flex min-w-0 flex-col">
       <div className="flex items-center justify-between px-1 pb-1">
         <span className="font-mono text-[10px] uppercase tracking-[0.14em]" style={{ color: accent }}>{title}</span>
-        <span className="font-mono text-[10px] text-[#68758a]">{timecode(cursorTime)}</span>
+        <span className="font-mono text-[10px] text-[#68758a]">{timecode(position)}</span>
       </div>
       <div className="relative aspect-video overflow-hidden rounded-[4px] border border-[#2a364b] bg-black">
         {clipMedia && clipMedia.kind === "video" ? (
-          <FrozenFrame key={active!.clip.id} url={clipMedia.url} seekTo={active!.localTime + active!.clip.source_in} />
+          <VideoSurface key={active!.clip.id} url={clipMedia.url} localTime={active!.localTime + active!.clip.source_in} playing={playing} />
         ) : clipMedia && clipMedia.kind === "image" ? (
           <img key={active!.clip.id} src={clipMedia.url} alt="" className="h-full w-full object-contain" />
         ) : (

--- a/frontend/src/features/cockpit/media/videocut/playbackSync.ts
+++ b/frontend/src/features/cockpit/media/videocut/playbackSync.ts
@@ -1,11 +1,7 @@
-import { useEffect, type RefObject } from "react"
-
-/** Ab welchem Drift (Sekunden) currentTime des Elements nachgezogen wird.
- *  Grobe Sync reicht für die Preview — häufiges Nachziehen würde ruckeln. */
-const DRIFT_THRESHOLD = 0.3
+import { useEffect, useRef, type RefObject } from "react"
 
 interface SyncOptions {
-  /** Lokale Soll-Position im Medium (Sekunden ab Clip-Start). */
+  /** Soll-Position im Medium (Sekunden ab Clip-Start, inkl. source_in). */
   localTime: number
   /** Läuft die Master-Clock? */
   playing: boolean
@@ -17,15 +13,23 @@ interface SyncOptions {
   muted?: boolean
 }
 
-/** Hält ein <video>/<audio>-Element grob an der Master-Clock.
- *  - Drift > Schwelle → currentTime nachziehen
- *  - playing/active steuern play()/pause()
- *  play() kann rejecten (Autoplay-Policy) — bewusst verschluckt. */
+/** Koppelt ein <video>/<audio>-Element an die Master-Clock — ohne „Daumenkino".
+ *
+ *  Kernidee: Während der Wiedergabe läuft das Element mit seiner NATIVEN Clock
+ *  frei und wird NICHT pro Frame nachgezogen. Es wird nur einmal an den Sollwert
+ *  geseekt, wenn die Wiedergabe startet (oder das Element via key neu mountet).
+ *  Im pausierten Zustand folgt es dagegen jederzeit dem Sollwert (Scrub/Cursor).
+ *  Dadurch kämpfen Master-Clock und Video-Playback nicht mehr gegeneinander. */
 export function useMediaSync(
   ref: RefObject<HTMLMediaElement | null>,
   { localTime, playing, active, volume = 1, muted = false }: SyncOptions,
 ): void {
-  // Lautstärke/Mute getrennt anwenden (kein Re-Sync nötig).
+  // Aktuellen Sollwert in einem Ref halten, damit der Play-Start-Effekt ihn
+  // lesen kann, ohne bei jeder Positionsänderung neu zu laufen.
+  const localTimeRef = useRef(localTime)
+  useEffect(() => { localTimeRef.current = localTime })
+
+  // Lautstärke/Mute.
   useEffect(() => {
     const el = ref.current
     if (!el) return
@@ -33,27 +37,31 @@ export function useMediaSync(
     el.muted = muted
   }, [ref, volume, muted])
 
+  // Play/Pause + einmaliger Seek beim Start der Wiedergabe.
   useEffect(() => {
     const el = ref.current
     if (!el) return
-
     if (!active) {
       if (!el.paused) el.pause()
       return
     }
-
-    if (Math.abs(el.currentTime - localTime) > DRIFT_THRESHOLD) {
-      try {
-        el.currentTime = localTime
-      } catch {
-        /* Metadata evtl. noch nicht geladen — nächster Tick korrigiert. */
+    if (playing) {
+      // Einmal an die Soll-Position setzen, dann frei laufen lassen.
+      if (Math.abs(el.currentTime - localTimeRef.current) > 0.25) {
+        try { el.currentTime = localTimeRef.current } catch { /* Metadata noch nicht bereit */ }
       }
-    }
-
-    if (playing && el.paused) {
-      void el.play().catch(() => {})
-    } else if (!playing && !el.paused) {
+      if (el.paused) void el.play().catch(() => {})
+    } else if (!el.paused) {
       el.pause()
+    }
+  }, [ref, playing, active])
+
+  // Nur im pausierten Zustand dem Sollwert folgen (Scrub / Justage-Cursor).
+  useEffect(() => {
+    const el = ref.current
+    if (!el || !active || playing) return
+    if (Math.abs(el.currentTime - localTime) > 0.05) {
+      try { el.currentTime = localTime } catch { /* Metadata noch nicht bereit */ }
     }
   }, [ref, localTime, playing, active])
 }


### PR DESCRIPTION
## Fix: Videoschnitt-Playback — Output-Stottern + tote Input-Monitore

Du hattest gemeldet: beim Play läuft der Output wie ein Daumenkino und Vid 1 / Vid 2 laufen gar nicht. Zwei getrennte Root-Causes:

### 1. Output-„Daumenkino"
`useMediaSync` setzte bei **jedem** Animation-Frame `el.currentTime = localTime`, sobald der Drift > 0,3 s war. Weil das Video über `/api/files` leicht latenzt, entstand eine Reset-Schleife:

> Master-Clock läuft weiter → Video hinkt hinterher → `currentTime`-Reset → Bild springt → buffert → hinkt wieder → Reset → …

Das ist das frameweise Ruckeln.

**Fix:** Während der Wiedergabe läuft das Element mit seiner **nativen** Clock frei und wird **nicht** pro Frame nachgezogen — nur **einmal** beim Play-Start bzw. beim Clip-Wechsel (via `key`-Remount) an die Soll-Position geseekt. Im **pausierten** Zustand folgt es weiterhin exakt dem Scrub-/Justage-Cursor.

### 2. Input-Monitore standen still
Vid 1 / Vid 2 hingen fest am `cursorTime` (dem roten Justage-Cursor) — beim Abspielen bewegt sich der aber nicht.

**Fix:** Bei laufender Wiedergabe folgen die Input-Monitore dem **Playhead** (`currentTime`) und laufen über `useMediaSync` mit; pausiert frieren sie wie gehabt am Cut-Cursor ein.

### Verifikation
- ✅ tsc -b grün · eslint grün · npm run build grün
- ℹ️ Das finale visuelle Gegentesten braucht echte Video-Assets im Browser — der Fix beruht auf einer klaren Root-Cause-Analyse (Reset-Schleife) und ist build-verifiziert. Bitte einmal live mit Play prüfen.

Nur Frontend, kein Backend-Change.
