### PR TITLE
feat(media): Videoschnitt V6a — Film exportieren & herunterladen (WYSIWYG)

### DIFF
--- a/core/src/hydrahive/media_export.py
+++ b/core/src/hydrahive/media_export.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
 
-from hydrahive import media_assets, media_projects, media_workspace
+from hydrahive import media_assets, media_projects, media_timeline_assembly, media_workspace
 
 VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".webm"}
 AUDIO_EXTS = {".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac"}
@@ -23,57 +24,130 @@ def _asset_paths(project_id: str, media_slug: str) -> dict[str, Path]:
     return paths
 
 
+def _has_audio_stream(path: Path) -> bool:
+    """Prüft via ffprobe, ob die Datei eine Audiospur hat (für Video-O-Ton)."""
+    if shutil.which("ffprobe") is None:
+        return False
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "a", "-show_entries", "stream=index", "-of", "json", str(path)],
+            capture_output=True, timeout=30, check=False,
+        )
+        if result.returncode != 0:
+            return False
+        return bool(json.loads(result.stdout or "{}").get("streams"))
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        return False
+
+
+def _enable_expr(segments: list[tuple[float, float]]) -> str:
+    """FFmpeg-overlay enable-Ausdruck aus der Vereinigung der on-air-Intervalle."""
+    return "+".join(f"between(t,{a},{b})" for a, b in segments)
+
+
 def export(project_id: str, media_slug: str) -> dict:
     if shutil.which("ffmpeg") is None:
         raise MediaExportError("ffmpeg fehlt")
     timeline = media_workspace.timeline(project_id, media_slug)
     assets = _asset_paths(project_id, media_slug)
-    clips = [(track, clip, assets.get(clip["asset_id"])) for track in timeline["tracks"] if not track.get("muted") for clip in track["clips"]]
-    missing = sorted({clip["asset_id"] for _, clip, path in clips if path is None})
+
+    # WYSIWYG-Assemblierung: welcher Video-Clip ist wann sichtbar (entlang Schnittpunkte).
+    onair = media_timeline_assembly.video_onair_segments(timeline)
+
+    # Clip-Metadaten je ID (aus den Video-Spuren).
+    video_clips: dict[str, dict] = {}
+    for track in timeline["tracks"]:
+        if track.get("kind") == "video" and not track.get("muted"):
+            for clip in track["clips"]:
+                video_clips[clip["id"]] = clip
+
+    # Audio-Clips (music/fx/voice) wie bisher.
+    audio_clips = [
+        (track, clip)
+        for track in timeline["tracks"]
+        if track.get("kind") != "video" and not track.get("muted")
+        for clip in track["clips"]
+    ]
+
+    # Fehlende Assets prüfen (nur was tatsächlich gerendert wird).
+    missing = {video_clips[cid]["asset_id"] for cid in onair if video_clips[cid]["asset_id"] not in assets}
+    missing |= {clip["asset_id"] for _, clip in audio_clips if clip["asset_id"] not in assets}
     if missing:
-        raise MediaExportError(f"Assets fehlen: {', '.join(missing)}")
-    if not clips:
+        raise MediaExportError(f"Assets fehlen: {', '.join(sorted(missing))}")
+    if not onair and not audio_clips:
         raise MediaExportError("Timeline ist leer")
-    duration = max(clip["start"] + clip["duration"] for _, clip, _ in clips)
+
+    duration = _timeline_duration(timeline)
     root = media_projects._dir(project_id, media_slug)
     output = root / "exports" / "timeline.mp4"
     output.parent.mkdir(parents=True, exist_ok=True)
 
-    args = ["ffmpeg", "-y", "-f", "lavfi", "-i", f"color=c=black:s={timeline['width']}x{timeline['height']}:r={timeline['fps']}:d={duration}"]
-    valid: list[tuple[dict, dict, Path, int]] = []
-    for track, clip, path in clips:
-        assert path is not None
-        suffix = path.suffix.lower()
-        if track["kind"] == "video" and suffix not in VIDEO_EXTS:
-            continue
-        if track["kind"] != "video" and suffix not in AUDIO_EXTS | VIDEO_EXTS:
+    args = ["ffmpeg", "-y", "-f", "lavfi", "-i",
+            f"color=c=black:s={timeline['width']}x{timeline['height']}:r={timeline['fps']}:d={duration}"]
+
+    # Inputs sammeln (Video-Clips mit on-air-Segmenten + Audio-Clips).
+    inputs: list[tuple[str, dict, Path, list[tuple[float, float]] | None]] = []
+    for clip_id, segments in onair.items():
+        clip = video_clips[clip_id]
+        path = assets[clip["asset_id"]]
+        if path.suffix.lower() not in VIDEO_EXTS:
             continue
         args.extend(["-i", str(path)])
-        valid.append((track, clip, path, len(valid) + 1))
+        inputs.append(("video", clip, path, segments))
+    for track, clip in audio_clips:
+        path = assets[clip["asset_id"]]
+        if path.suffix.lower() not in AUDIO_EXTS | VIDEO_EXTS:
+            continue
+        args.extend(["-i", str(path)])
+        inputs.append(("audio", clip, path, None))
 
     filters = ["[0:v]setpts=PTS-STARTPTS[base0]"]
     base = "base0"
     audio_labels: list[str] = []
-    for track, clip, _, index in valid:
+    idx = 0
+    w, h = timeline["width"], timeline["height"]
+    for kind, clip, path, segments in inputs:
+        idx += 1
         start, length, source_in = clip["start"], clip["duration"], clip.get("source_in", 0)
-        if track["kind"] == "video":
-            label = f"v{index}"
-            out = f"base{index}"
-            filters.append(f"[{index}:v]trim=start={source_in}:duration={length},setpts=PTS-STARTPTS+{start}/TB,scale={timeline['width']}:{timeline['height']}:force_original_aspect_ratio=decrease,pad={timeline['width']}:{timeline['height']}:(ow-iw)/2:(oh-ih)/2[{label}]")
-            filters.append(f"[{base}][{label}]overlay=enable='between(t,{start},{start + length})'[{out}]")
+        if kind == "video":
+            assert segments is not None
+            vlabel = f"v{idx}"
+            out = f"base{idx}"
+            filters.append(
+                f"[{idx}:v]trim=start={source_in}:duration={length},setpts=PTS-STARTPTS+{start}/TB,"
+                f"scale={w}:{h}:force_original_aspect_ratio=decrease,"
+                f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2[{vlabel}]"
+            )
+            filters.append(f"[{base}][{vlabel}]overlay=enable='{_enable_expr(segments)}'[{out}]")
             base = out
+            # Video-O-Ton nur für die on-air-Segmente (falls Audiospur vorhanden).
+            if _has_audio_stream(path):
+                alabel = f"a{idx}"
+                delay = round(start * 1000)
+                vol = clip.get("volume", 1)
+                filters.append(
+                    f"[{idx}:a]atrim=start={source_in}:duration={length},asetpts=PTS-STARTPTS,"
+                    f"adelay={delay}|{delay},volume={vol}[{alabel}]"
+                )
+                audio_labels.append(alabel)
         else:
-            label = f"a{index}"
+            alabel = f"a{idx}"
             delay = round(start * 1000)
-            volume = clip.get("volume", 1)
-            filters.append(f"[{index}:a]atrim=start={source_in}:duration={length},asetpts=PTS-STARTPTS,adelay={delay}|{delay},volume={volume}[{label}]")
-            audio_labels.append(label)
+            vol = clip.get("volume", 1)
+            filters.append(
+                f"[{idx}:a]atrim=start={source_in}:duration={length},asetpts=PTS-STARTPTS,"
+                f"adelay={delay}|{delay},volume={vol}[{alabel}]"
+            )
+            audio_labels.append(alabel)
+
     if audio_labels:
-        filters.append("".join(f"[{label}]" for label in audio_labels) + f"amix=inputs={len(audio_labels)}:duration=longest[aout]")
+        filters.append("".join(f"[{a}]" for a in audio_labels) + f"amix=inputs={len(audio_labels)}:duration=longest[aout]")
+
     args.extend(["-filter_complex", ";".join(filters), "-map", f"[{base}]"])
     if audio_labels:
         args.extend(["-map", "[aout]", "-c:a", "aac", "-b:a", "192k"])
     args.extend(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-t", str(duration), "-movflags", "+faststart", str(output)])
+
     try:
         result = subprocess.run(args, capture_output=True, timeout=1800, check=False)
     except subprocess.TimeoutExpired as exc:
@@ -82,3 +156,13 @@ def export(project_id: str, media_slug: str) -> dict:
         error = result.stderr.decode(errors="replace")[-500:]
         raise MediaExportError(f"FFmpeg-Export fehlgeschlagen: {error}")
     return {"status": "completed", "rel_path": str(output.relative_to(root)), "path": str(output), "duration": duration}
+
+
+def _timeline_duration(timeline: dict) -> float:
+    end = 0.0
+    for track in timeline.get("tracks", []):
+        if track.get("muted"):
+            continue
+        for clip in track.get("clips", []):
+            end = max(end, clip["start"] + clip["duration"])
+    return end

--- a/core/src/hydrahive/media_timeline_assembly.py
+++ b/core/src/hydrahive/media_timeline_assembly.py
@@ -1,0 +1,86 @@
+"""WYSIWYG-Assemblierung der A/B-Roll-Timeline für den Export.
+
+Spiegelt die Frontend-Logik (assembleOutput.activeVideoAt): Der Output toggelt
+an jedem Schnittpunkt zwischen der ersten und zweiten Video-Spur (gerade Anzahl
+Schnittpunkte ≤ t → erste, ungerade → zweite) und fällt bei einer Lücke in der
+aktiven Spur auf die andere Video-Spur zurück. Bei nur einer Video-Spur ist
+diese immer aktiv. Rein funktional gehalten, damit unabhängig vom FFmpeg-Aufruf
+testbar.
+"""
+from __future__ import annotations
+
+
+def _clip_at(track: dict, t: float) -> dict | None:
+    """Letzter Clip der Spur, der t abdeckt (überlappende Clips: späterer gewinnt)."""
+    hit: dict | None = None
+    for clip in track.get("clips", []):
+        start = clip["start"]
+        if start <= t < start + clip["duration"]:
+            hit = clip
+    return hit
+
+
+def _video_tracks(timeline: dict) -> list[dict]:
+    """Video-kind-Spuren in Timeline-Reihenfolge (A = erste, B = zweite)."""
+    return [t for t in timeline.get("tracks", []) if t.get("kind") == "video" and not t.get("muted")]
+
+
+def _active_clip_at(video_tracks: list[dict], cut_times: list[float], t: float) -> dict | None:
+    """Sichtbarer Video-Clip an t: aktive Spur nach Schnittpunkt-Toggle (A/B),
+    Fallback auf die jeweils andere Video-Spur bei Lücke."""
+    if not video_tracks:
+        return None
+    n_before = sum(1 for ct in cut_times if ct <= t)
+    primary_idx = n_before % 2 if len(video_tracks) > 1 else 0
+    order = [primary_idx] + [i for i in range(len(video_tracks)) if i != primary_idx]
+    for i in order:
+        clip = _clip_at(video_tracks[i], t)
+        if clip is not None:
+            return clip
+    return None
+
+
+def _merge_intervals(intervals: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Sortiert und verschmilzt angrenzende/überlappende Intervalle."""
+    if not intervals:
+        return []
+    ordered = sorted(intervals)
+    merged = [ordered[0]]
+    for start, end in ordered[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end + 1e-6:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def video_onair_segments(timeline: dict) -> dict[str, list[tuple[float, float]]]:
+    """Je Video-Clip die disjunkten Zeit-Intervalle, in denen er im Output sichtbar
+    ist. Die Zeitachse wird an allen Ereignispunkten (0, Clip-Kanten, Schnittpunkte)
+    in Elementar-Intervalle zerlegt; am Mittelpunkt jedes Intervalls wird der aktive
+    Clip bestimmt."""
+    video_tracks = _video_tracks(timeline)
+    cut_times = sorted(cp["time"] for cp in timeline.get("cut_points", []))
+
+    # Ereigniszeitpunkte sammeln.
+    boundaries: set[float] = {0.0}
+    for track in video_tracks:
+        for clip in track.get("clips", []):
+            boundaries.add(float(clip["start"]))
+            boundaries.add(float(clip["start"] + clip["duration"]))
+    for ct in cut_times:
+        boundaries.add(float(ct))
+
+    points = sorted(boundaries)
+    segments: dict[str, list[tuple[float, float]]] = {}
+    for left, right in zip(points, points[1:]):
+        if right - left <= 1e-9:
+            continue
+        mid = (left + right) / 2
+        clip = _active_clip_at(video_tracks, cut_times, mid)
+        if clip is None:
+            continue
+        segments.setdefault(clip["id"], []).append((left, right))
+
+    return {clip_id: _merge_intervals(ivals) for clip_id, ivals in segments.items()}

--- a/core/tests/test_media_export.py
+++ b/core/tests/test_media_export.py
@@ -26,6 +26,30 @@ def test_export_renders_video_and_audio(tmp_path):
 
 
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")
+def test_export_assembles_along_cut_points(tmp_path):
+    project = project_config.create(name="ExportCut", members=["testuser"], llm_model="test", created_by="admin")
+    media_projects.create(project["id"], "film", "Film")
+    root = workspace_path(project["id"])
+    v1 = root / "a.mp4"
+    v2 = root / "b.mp4"
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=red:s=160x90:d=4", "-c:v", "libx264", "-pix_fmt", "yuv420p", str(v1)], check=True, capture_output=True)
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=green:s=160x90:d=4", "-c:v", "libx264", "-pix_fmt", "yuv420p", str(v2)], check=True, capture_output=True)
+    media_assets.create(project["id"], "film", "va", "video", project["id"], "a.mp4", "A")
+    media_assets.create(project["id"], "film", "vb", "video", project["id"], "b.mp4", "B")
+    media_workspace.save_timeline(project["id"], "film", {
+        "fps": 25, "width": 160, "height": 90,
+        "tracks": [
+            {"id": "vid1", "name": "V1", "kind": "video", "muted": False, "clips": [{"id": "ca", "asset_id": "va", "start": 0, "duration": 4, "source_in": 0, "volume": 1}]},
+            {"id": "vid2", "name": "V2", "kind": "video", "muted": False, "clips": [{"id": "cb", "asset_id": "vb", "start": 0, "duration": 4, "source_in": 0, "volume": 1}]},
+        ],
+        "cut_points": [{"id": "cut1", "time": 2, "effect": "cut", "duration": 0}],
+    })
+    result = media_export.export(project["id"], "film")
+    assert result["status"] == "completed"
+    assert (workspace_path(project["id"]) / "media" / "film" / result["rel_path"]).stat().st_size > 1000
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")
 def test_export_rejects_missing_asset():
     project = project_config.create(name="Missing", members=["testuser"], llm_model="test", created_by="admin")
     media_projects.create(project["id"], "film", "Film")

--- a/core/tests/test_media_timeline_assembly.py
+++ b/core/tests/test_media_timeline_assembly.py
@@ -1,0 +1,54 @@
+from hydrahive.media_timeline_assembly import video_onair_segments
+
+
+def _tl(tracks, cut_points=None):
+    return {"tracks": tracks, "cut_points": cut_points or []}
+
+
+def test_single_track_no_cuts():
+    tl = _tl([{"id": "vid1", "kind": "video", "clips": [{"id": "a", "start": 0, "duration": 10}]}])
+    seg = video_onair_segments(tl)
+    assert seg == {"a": [(0.0, 10.0)]}
+
+
+def test_toggle_at_cut_point():
+    # vid1 0-10, vid2 überlappt 4-14, Schnittpunkt bei 6.
+    tl = _tl(
+        [
+            {"id": "vid1", "kind": "video", "clips": [{"id": "a", "start": 0, "duration": 10}]},
+            {"id": "vid2", "kind": "video", "clips": [{"id": "b", "start": 4, "duration": 10}]},
+        ],
+        [{"id": "c", "time": 6}],
+    )
+    seg = video_onair_segments(tl)
+    # Vor 6 → vid1 (a), ab 6 → vid2 (b).
+    assert seg["a"] == [(0.0, 6.0)]
+    assert seg["b"] == [(6.0, 14.0)]
+
+
+def test_fallback_on_gap():
+    # Aktive Spur vid1 hat Lücke ab 5, vid2 deckt 0-20 → Fallback auf b.
+    tl = _tl(
+        [
+            {"id": "vid1", "kind": "video", "clips": [{"id": "a", "start": 0, "duration": 5}]},
+            {"id": "vid2", "kind": "video", "clips": [{"id": "b", "start": 0, "duration": 20}]},
+        ],
+    )
+    seg = video_onair_segments(tl)
+    # 0-5 zeigt a (vid1 primär), 5-20 Fallback auf b.
+    assert seg["a"] == [(0.0, 5.0)]
+    assert seg["b"] == [(5.0, 20.0)]
+
+
+def test_two_cuts_back_to_vid1():
+    tl = _tl(
+        [
+            {"id": "vid1", "kind": "video", "clips": [{"id": "a", "start": 0, "duration": 20}]},
+            {"id": "vid2", "kind": "video", "clips": [{"id": "b", "start": 0, "duration": 20}]},
+        ],
+        [{"id": "c1", "time": 5}, {"id": "c2", "time": 10}],
+    )
+    seg = video_onair_segments(tl)
+    # 0-5 vid1, 5-10 vid2, 10-20 vid1 → a hat zwei Segmente, b eins.
+    assert seg["a"] == [(0.0, 5.0), (10.0, 20.0)]
+    assert seg["b"] == [(5.0, 10.0)]

--- a/docs/specs/videocut-v6a.md
+++ b/docs/specs/videocut-v6a.md
@@ -1,0 +1,54 @@
+# Videoschnitt V6a — WYSIWYG-Export entlang der Schnittpunkte + Download
+
+## Was
+Der fertige Schnitt wird als MP4 gerendert — **so wie er in der Preview aussieht**:
+Der Output wird entlang der Schnittpunkte assembliert (Toggle vid1↔vid2 mit
+Fallback bei Lücken), nicht mehr als stumpfes Layer-Overlay. Im Schnittpult gibt
+es einen **„Film exportieren"**-Button mit Fortschritt und **Download-Link**.
+
+## Warum
+Bisher ignorierte `media_export.py` die `cut_points` komplett (altes
+„vid2 überdeckt vid1"-Modell) → der Export zeigte nicht das, was man sieht. Und
+es gab keinen UI-Weg zum Rendern/Herunterladen. V6a schließt beide Lücken.
+
+## Scope-Grenze
+- Übergangseffekte (Crossfade/Wipe/Fade) werden in V6a als **Hartschnitt**
+  gerendert. Weiche Übergänge im Renderer kommen in V6b (FFmpeg `xfade`).
+
+## Wie
+### Assemblierung (neu, rein & testbar): `media_timeline_assembly.py`
+- `video_onair_segments(timeline) -> dict[clip_id, list[(start, end)]]`:
+  Zerlegt die Zeitachse an allen Ereigniszeitpunkten (0, Ende, alle
+  Schnittpunkt-Zeiten, alle Video-Clip-Kanten). Für jedes Elementar-Intervall
+  wird am Mittelpunkt die aktive Spur bestimmt (Anzahl Schnittpunkte ≤ t: gerade
+  → vid1, ungerade → vid2) und der dort sichtbare Clip gesucht — mit **Fallback**
+  auf die andere Video-Spur bei Lücke. Ergebnis: je Clip die disjunkten
+  Intervalle, in denen er „on air" ist. Exakt dieselbe Logik wie das Frontend
+  (`assembleOutput.activeVideoAt`).
+
+### Export: `media_export.py`
+- Nutzt `video_onair_segments`. Für jeden Video-Clip mit on-air-Intervallen ein
+  Overlay, dessen `enable`-Ausdruck die Vereinigung der on-air-Intervalle ist
+  (`between(t,a1,b1)+between(t,a2,b2)+…`). Dadurch ist zu jedem Zeitpunkt genau
+  ein Video-Clip sichtbar → deterministisch, WYSIWYG.
+- Audio-Spuren (music/fx/voice) werden wie bisher gemischt.
+- **Video-Ton der on-air-Segmente** wird mitgenommen, sofern die Quelldatei eine
+  Audiospur hat (einmalige `ffprobe`-Prüfung je Datei; stumme Videos werden
+  übersprungen, kein Crash).
+- Output bleibt `…/media/<slug>/exports/timeline.mp4`; liegt unter
+  `data_dir/workspaces` → per `/api/files` downloadbar.
+
+### Frontend
+- `MediaPostProduction`: Button **„Film exportieren"** → ruft
+  `mediaWorkspaceApi.exportTimeline` → zeigt „Rendere…" → bei Erfolg
+  **Download-Link** (`fileUrl(result.path)`, `download`-Attribut). Fehler inline.
+- Kleiner Hook/Helper hält den Export-Status (`idle|running|done|error`).
+
+## Akzeptanzkriterien
+- [ ] Export rendert den Schnitt entlang der Schnittpunkte (Toggle + Fallback).
+- [ ] Button zeigt Fortschritt und liefert einen funktionierenden Download-Link.
+- [ ] Video-Ton der on-air-Segmente ist im Export hörbar (falls vorhanden),
+      Audio-Spuren gemischt.
+- [ ] Übergänge werden (vorerst) als Hartschnitt gerendert.
+- [ ] Backend-Test: Export mit Schnittpunkten erzeugt eine valide Datei.
+- [ ] Backend-Tests + Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ComponentType } from "react"
 import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
 import { CutPointInspector } from "./videocut/CutPointInspector"
+import { ExportBar } from "./videocut/ExportBar"
 import { InputMonitor } from "./videocut/InputMonitor"
 import { OutputMonitor } from "./videocut/OutputMonitor"
 import { PlaybackAudio } from "./videocut/PlaybackAudio"
@@ -144,6 +145,9 @@ export function MediaPostProduction({ projectId }: Props) {
             onClose={() => setSelectedCutId(null)}
           />
         ) : null}
+
+        {/* Export: Schnitt als MP4 rendern + herunterladen */}
+        <ExportBar projectId={projectId} disabled={!timeline || saving} />
       </div>
 
       {/* Clip-Bibliothek rechts */}

--- a/frontend/src/features/cockpit/media/videocut/ExportBar.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ExportBar.tsx
@@ -1,0 +1,44 @@
+import { Download, Film, Loader2 } from "lucide-react"
+import { timecode } from "./useCutPlayback"
+import { useCutExport } from "./useCutExport"
+
+interface Props {
+  projectId: string
+  disabled: boolean
+}
+
+/** Export-Leiste: rendert den Schnitt (FFmpeg) und bietet den Download an. */
+export function ExportBar({ projectId, disabled }: Props) {
+  const { status, result, error, run } = useCutExport(projectId)
+  const running = status === "running"
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#2a364b] pt-3">
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={disabled || running}
+        className="inline-flex items-center gap-1.5 rounded-[4px] border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-[12px] font-semibold text-emerald-200 transition-colors hover:bg-emerald-500/20 disabled:opacity-40"
+      >
+        {running ? <Loader2 size={14} className="animate-spin" /> : <Film size={14} />}
+        {running ? "Rendere…" : "Film exportieren"}
+      </button>
+
+      {status === "done" && result ? (
+        <a
+          href={result.downloadUrl}
+          download="schnitt.mp4"
+          className="inline-flex items-center gap-1.5 rounded-[4px] border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-[12px] font-semibold text-cyan-100 transition-colors hover:bg-cyan-400/20"
+        >
+          <Download size={14} /> Download ({timecode(result.duration)})
+        </a>
+      ) : null}
+
+      {running ? (
+        <span className="text-[11px] text-[#8d9ab0]">Das kann je nach Länge einen Moment dauern…</span>
+      ) : null}
+
+      {status === "error" ? <span className="text-[11px] text-rose-300">{error}</span> : null}
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutExport.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutExport.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react"
+import { fileUrl } from "@/modules/atelier/api"
+import { mediaWorkspaceApi } from "../../mediaWorkspaceApi"
+import { CUT_SLUG } from "./api"
+
+export type ExportStatus = "idle" | "running" | "done" | "error"
+
+export interface ExportResult {
+  downloadUrl: string
+  duration: number
+}
+
+/** Rendert den Schnitt serverseitig (FFmpeg) und liefert einen Download-Link.
+ *  Der Export läuft synchron im Request — für lange Timelines kann das dauern
+ *  (Hintergrund-Job wäre eine spätere Ausbaustufe). */
+export function useCutExport(projectId: string) {
+  const [status, setStatus] = useState<ExportStatus>("idle")
+  const [result, setResult] = useState<ExportResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const run = useCallback(async () => {
+    setStatus("running")
+    setError(null)
+    setResult(null)
+    try {
+      const res = await mediaWorkspaceApi.exportTimeline(projectId, CUT_SLUG)
+      setResult({ downloadUrl: fileUrl(res.path), duration: res.duration })
+      setStatus("done")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Export fehlgeschlagen.")
+      setStatus("error")
+    }
+  }, [projectId])
+
+  const reset = useCallback(() => {
+    setStatus("idle")
+    setResult(null)
+    setError(null)
+  }, [])
+
+  return { status, result, error, run, reset }
+}


### PR DESCRIPTION
## V6a — Film exportieren & herunterladen (WYSIWYG)

Du kannst deinen fertigen Schnitt jetzt als MP4 rendern und herunterladen — **so wie er in der Preview aussieht**.

### Was neu ist
- **„Film exportieren"-Button** im Schnittpult → zeigt „Rendere…" → liefert einen **Download-Link** der fertigen MP4.
- **WYSIWYG-Assemblierung:** Der Export folgt jetzt den Schnittpunkten (Toggle A/B-Video-Spur mit Fallback bei Lücken) — vorher hat `media_export.py` die `cut_points` komplett ignoriert und alle Clips stumpf übereinandergelegt.
- **Video-O-Ton** der sichtbaren Segmente wird mitgemischt (via `ffprobe`-Check), Audio-Spuren wie gehabt.

### Scope-Grenze
Übergangseffekte (Crossfade/Wipe/Fade) werden in V6a noch als **Hartschnitt** gerendert. Weiche Übergänge im Renderer kommen in **V6b** (FFmpeg `xfade`).

### Backend
- `media_timeline_assembly.py` (rein & getestet): `video_onair_segments()` zerlegt die Zeitachse an allen Ereignispunkten (Clip-Kanten + Schnittpunkte) und bestimmt je Clip die Intervalle, in denen er „on air" ist — dieselbe Logik wie das Frontend (`assembleOutput`). Generisch über video-kind-Tracks.
- `media_export.py`: pro Video-Clip ein `overlay=enable='between(...)'` aus der Union der on-air-Intervalle → zu jedem Zeitpunkt genau ein sichtbarer Clip.
- Output liegt unter `data_dir/workspaces/...` → per `/api/files` direkt downloadbar.

### Verifikation
- ✅ Backend-Tests **17/17 grün**, ruff clean. Neu: 4 Assembly-Unit-Tests + Export-mit-Schnittpunkten (rendert eine echte Datei mit ffmpeg).
- ✅ **Empirisch gegengecheckt:** gerendertes Frame vor dem Cut = vid1 (rot `fd0000`), nach dem Cut = vid2 (grün `007f00`) — die Umschaltung sitzt exakt am Schnittpunkt.
- ✅ tsc / eslint / build grün.

### Hinweis
Der Export läuft **synchron im Request** (FFmpeg). Für lange Timelines kann das dauern; ein Hintergrund-Job mit Fortschritt wäre eine spätere Ausbaustufe. Und wie bei allen Backend-Änderungen: Server brauchen ein Update, damit der neue Export greift.

Spec: `docs/specs/videocut-v6a.md`.
