### PR TITLE
feat(media): Videoschnitt V6b — weiche Übergänge im Export

### DIFF
--- a/core/src/hydrahive/media_export.py
+++ b/core/src/hydrahive/media_export.py
@@ -45,14 +45,40 @@ def _enable_expr(segments: list[tuple[float, float]]) -> str:
     return "+".join(f"between(t,{a},{b})" for a, b in segments)
 
 
+def _fmt(x: float) -> str:
+    return f"{x:.4f}".rstrip("0").rstrip(".")
+
+
+def _transition_suffix(ops: dict, width: int) -> str:
+    """Filterkette-Suffix für die weichen Übergänge eines Video-Clips.
+
+    fades → format=yuva420p + fade(alpha=1); wipes → geq-Alpha-Maske (von links
+    wachsende Kante). Ohne Übergänge leer (Hartschnitt wie V6a). Die Zeitangaben
+    sind absolute Timeline-Sekunden — der Overlay-Layer trägt bereits das globale
+    PTS (setpts=…+start/TB), daher passen st-Werte direkt. """
+    fades = ops.get("fades", [])
+    wipes = ops.get("wipes", [])
+    if not fades and not wipes:
+        return ""
+    parts = [",format=yuva420p"]
+    for f in fades:
+        parts.append(f",fade=t={f['type']}:st={_fmt(f['st'])}:d={_fmt(f['d'])}:alpha=1")
+    for wp in wipes:
+        st, d = _fmt(wp["st"]), _fmt(wp["d"])
+        # Alpha 255 links der wachsenden Kante x = W * clip((T-st)/d, 0, 1), sonst 0.
+        parts.append(f",geq=lum='lum(X,Y)':a='if(lt(X,{width}*clip((T-{st})/{d},0,1)),255,0)'")
+    return "".join(parts)
+
+
 def export(project_id: str, media_slug: str) -> dict:
     if shutil.which("ffmpeg") is None:
         raise MediaExportError("ffmpeg fehlt")
     timeline = media_workspace.timeline(project_id, media_slug)
     assets = _asset_paths(project_id, media_slug)
 
-    # WYSIWYG-Assemblierung: welcher Video-Clip ist wann sichtbar (entlang Schnittpunkte).
-    onair = media_timeline_assembly.video_onair_segments(timeline)
+    # WYSIWYG-Render-Plan: welcher Video-Clip wann sichtbar ist (entlang Schnittpunkte)
+    # inkl. weicher Übergänge (Fades/Wipes) an den Schnittpunkten.
+    plan = media_timeline_assembly.video_render_plan(timeline)
 
     # Clip-Metadaten je ID (aus den Video-Spuren).
     video_clips: dict[str, dict] = {}
@@ -70,11 +96,11 @@ def export(project_id: str, media_slug: str) -> dict:
     ]
 
     # Fehlende Assets prüfen (nur was tatsächlich gerendert wird).
-    missing = {video_clips[cid]["asset_id"] for cid in onair if video_clips[cid]["asset_id"] not in assets}
+    missing = {video_clips[cid]["asset_id"] for cid in plan if video_clips[cid]["asset_id"] not in assets}
     missing |= {clip["asset_id"] for _, clip in audio_clips if clip["asset_id"] not in assets}
     if missing:
         raise MediaExportError(f"Assets fehlen: {', '.join(sorted(missing))}")
-    if not onair and not audio_clips:
+    if not plan and not audio_clips:
         raise MediaExportError("Timeline ist leer")
 
     duration = _timeline_duration(timeline)
@@ -85,15 +111,15 @@ def export(project_id: str, media_slug: str) -> dict:
     args = ["ffmpeg", "-y", "-f", "lavfi", "-i",
             f"color=c=black:s={timeline['width']}x{timeline['height']}:r={timeline['fps']}:d={duration}"]
 
-    # Inputs sammeln (Video-Clips mit on-air-Segmenten + Audio-Clips).
-    inputs: list[tuple[str, dict, Path, list[tuple[float, float]] | None]] = []
-    for clip_id, segments in onair.items():
+    # Inputs sammeln (Video-Clips aus dem Render-Plan + Audio-Clips).
+    inputs: list[tuple[str, dict, Path, dict | None]] = []
+    for clip_id, ops in plan.items():
         clip = video_clips[clip_id]
         path = assets[clip["asset_id"]]
         if path.suffix.lower() not in VIDEO_EXTS:
             continue
         args.extend(["-i", str(path)])
-        inputs.append(("video", clip, path, segments))
+        inputs.append(("video", clip, path, ops))
     for track, clip in audio_clips:
         path = assets[clip["asset_id"]]
         if path.suffix.lower() not in AUDIO_EXTS | VIDEO_EXTS:
@@ -106,19 +132,21 @@ def export(project_id: str, media_slug: str) -> dict:
     audio_labels: list[str] = []
     idx = 0
     w, h = timeline["width"], timeline["height"]
-    for kind, clip, path, segments in inputs:
+    for kind, clip, path, ops in inputs:
         idx += 1
         start, length, source_in = clip["start"], clip["duration"], clip.get("source_in", 0)
         if kind == "video":
-            assert segments is not None
+            assert ops is not None
             vlabel = f"v{idx}"
             out = f"base{idx}"
-            filters.append(
+            chain = (
                 f"[{idx}:v]trim=start={source_in}:duration={length},setpts=PTS-STARTPTS+{start}/TB,"
                 f"scale={w}:{h}:force_original_aspect_ratio=decrease,"
-                f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2[{vlabel}]"
+                f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2"
             )
-            filters.append(f"[{base}][{vlabel}]overlay=enable='{_enable_expr(segments)}'[{out}]")
+            chain += _transition_suffix(ops, w)
+            filters.append(f"{chain}[{vlabel}]")
+            filters.append(f"[{base}][{vlabel}]overlay=enable='{_enable_expr(ops['segments'])}'[{out}]")
             base = out
             # Video-O-Ton nur für die on-air-Segmente (falls Audiospur vorhanden).
             if _has_audio_stream(path):

--- a/core/src/hydrahive/media_timeline_assembly.py
+++ b/core/src/hydrahive/media_timeline_assembly.py
@@ -84,3 +84,82 @@ def video_onair_segments(timeline: dict) -> dict[str, list[tuple[float, float]]]
         segments.setdefault(clip["id"], []).append((left, right))
 
     return {clip_id: _merge_intervals(ivals) for clip_id, ivals in segments.items()}
+
+
+_EPS = 1e-4
+
+
+def _extend_segment_start(segs: list[tuple[float, float]], boundary: float, new_start: float) -> None:
+    """Zieht den Anfang des Segments, das bei `boundary` beginnt, auf `new_start`."""
+    for i, (s, e) in enumerate(segs):
+        if abs(s - boundary) < _EPS:
+            segs[i] = (min(new_start, s), e)
+            return
+
+
+def _extend_segment_end(segs: list[tuple[float, float]], boundary: float, new_end: float) -> None:
+    """Zieht das Ende des Segments, das bei `boundary` endet, auf `new_end`."""
+    for i, (s, e) in enumerate(segs):
+        if abs(e - boundary) < _EPS:
+            segs[i] = (s, max(new_end, e))
+            return
+
+
+def video_render_plan(timeline: dict) -> dict[str, dict]:
+    """Render-Plan je Video-Clip für den Export mit weichen Übergängen.
+
+    Baut auf ``video_onair_segments`` auf und ergänzt an jedem Schnittpunkt mit
+    Übergang (effect ∈ {crossfade, wipe, fade-black}, duration > 0) die nötigen
+    Alpha-/Wipe-Operationen. Fenster: [time − d/2, time + d/2].
+
+    Rückgabe je clip_id: {
+        "segments": [(start, end), …]   # Overlay-enable-Fenster (ggf. erweitert)
+        "fades":    [{"type": "in"|"out", "st": s, "d": d}, …]
+        "wipes":    [{"st": s, "d": d}, …]   # von links wachsende Kante
+    }
+
+    Grenze (bewusst, für V6b): Übergänge werden pro Clip als Filterkette auf den
+    gemeinsamen Layer angewandt; die Overlay-Reihenfolge ist global chronologisch.
+    Für den Standard-A/B-Schnitt (zeitlich benachbarte Clips) ist das WYSIWYG-treu.
+    """
+    base = video_onair_segments(timeline)
+    plan: dict[str, dict] = {
+        cid: {"segments": list(segs), "fades": [], "wipes": []} for cid, segs in base.items()
+    }
+
+    video_tracks = _video_tracks(timeline)
+    cut_times = sorted(cp["time"] for cp in timeline.get("cut_points", []))
+    transitions = sorted(
+        (cp for cp in timeline.get("cut_points", []) if cp.get("effect", "cut") != "cut" and (cp.get("duration") or 0) > 0),
+        key=lambda cp: cp["time"],
+    )
+
+    for cp in transitions:
+        t = float(cp["time"])
+        d = float(cp["duration"])
+        effect = cp["effect"]
+        before = _active_clip_at(video_tracks, cut_times, t - _EPS)
+        after = _active_clip_at(video_tracks, cut_times, t + _EPS)
+        if before is None or after is None or before["id"] == after["id"]:
+            continue
+        b_id, a_id = before["id"], after["id"]
+        if b_id not in plan or a_id not in plan:
+            continue
+        win_start, win_end = t - d / 2, t + d / 2
+
+        if effect in ("crossfade", "wipe"):
+            # danach-Clip erscheint früher (ab Fensterstart), davor-Clip bleibt bis Fensterende.
+            _extend_segment_start(plan[a_id]["segments"], t, win_start)
+            _extend_segment_end(plan[b_id]["segments"], t, win_end)
+            if effect == "crossfade":
+                plan[a_id]["fades"].append({"type": "in", "st": win_start, "d": d})
+            else:
+                plan[a_id]["wipes"].append({"st": win_start, "d": d})
+        elif effect == "fade-black":
+            # davor-Clip faded in erster Hälfte raus, danach-Clip in zweiter rein.
+            plan[b_id]["fades"].append({"type": "out", "st": win_start, "d": d / 2})
+            plan[a_id]["fades"].append({"type": "in", "st": t, "d": d / 2})
+
+    for cid in plan:
+        plan[cid]["segments"] = _merge_intervals(plan[cid]["segments"])
+    return plan

--- a/core/tests/test_media_export.py
+++ b/core/tests/test_media_export.py
@@ -49,6 +49,46 @@ def test_export_assembles_along_cut_points(tmp_path):
     assert (workspace_path(project["id"]) / "media" / "film" / result["rel_path"]).stat().st_size > 1000
 
 
+def _sample_center(video_path, t):
+    """RGB-Pixel in der Bildmitte zum Zeitpunkt t (via ffmpeg + PIL)."""
+    import tempfile
+    from pathlib import Path
+
+    from PIL import Image
+    with tempfile.TemporaryDirectory() as tmp:
+        frame = Path(tmp) / "f.png"
+        subprocess.run(["ffmpeg", "-y", "-ss", str(t), "-i", str(video_path), "-frames:v", "1", str(frame)], check=True, capture_output=True)
+        im = Image.open(frame).convert("RGB")
+        return im.getpixel((im.size[0] // 2, im.size[1] // 2))
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")
+def test_export_crossfade_blends_midpoint(tmp_path):
+    project = project_config.create(name="ExportXf", members=["testuser"], llm_model="test", created_by="admin")
+    media_projects.create(project["id"], "film", "Film")
+    root = workspace_path(project["id"])
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=red:s=160x90:d=8", "-c:v", "libx264", "-pix_fmt", "yuv420p", str(root / "a.mp4")], check=True, capture_output=True)
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=green:s=160x90:d=8", "-c:v", "libx264", "-pix_fmt", "yuv420p", str(root / "b.mp4")], check=True, capture_output=True)
+    media_assets.create(project["id"], "film", "va", "video", project["id"], "a.mp4", "A")
+    media_assets.create(project["id"], "film", "vb", "video", project["id"], "b.mp4", "B")
+    media_workspace.save_timeline(project["id"], "film", {
+        "fps": 25, "width": 160, "height": 90,
+        "tracks": [
+            {"id": "vid1", "name": "V1", "kind": "video", "muted": False, "clips": [{"id": "ca", "asset_id": "va", "start": 0, "duration": 8, "source_in": 0, "volume": 1}]},
+            {"id": "vid2", "name": "V2", "kind": "video", "muted": False, "clips": [{"id": "cb", "asset_id": "vb", "start": 0, "duration": 8, "source_in": 0, "volume": 1}]},
+        ],
+        "cut_points": [{"id": "cut1", "time": 4, "effect": "crossfade", "duration": 2}],
+    })
+    result = media_export.export(project["id"], "film")
+    out = workspace_path(project["id"]) / "media" / "film" / result["rel_path"]
+    r1, g1, b1 = _sample_center(out, 1)   # vor Übergang → rot
+    rm, gm, bm = _sample_center(out, 4)   # Mitte Übergang → Mischung
+    r3, g3, b3 = _sample_center(out, 7)   # nach Übergang → grün
+    assert r1 > 150 and g1 < 80           # rot
+    assert r3 < 80 and g3 > 80            # grün
+    assert rm > 30 and gm > 30           # beide Kanäle präsent → Überblendung
+
+
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")
 def test_export_rejects_missing_asset():
     project = project_config.create(name="Missing", members=["testuser"], llm_model="test", created_by="admin")

--- a/core/tests/test_media_timeline_assembly.py
+++ b/core/tests/test_media_timeline_assembly.py
@@ -1,4 +1,4 @@
-from hydrahive.media_timeline_assembly import video_onair_segments
+from hydrahive.media_timeline_assembly import video_onair_segments, video_render_plan
 
 
 def _tl(tracks, cut_points=None):
@@ -52,3 +52,43 @@ def test_two_cuts_back_to_vid1():
     # 0-5 vid1, 5-10 vid2, 10-20 vid1 → a hat zwei Segmente, b eins.
     assert seg["a"] == [(0.0, 5.0), (10.0, 20.0)]
     assert seg["b"] == [(5.0, 10.0)]
+
+
+def _ab_timeline(effect, duration, cut=6):
+    return _tl(
+        [
+            {"id": "vid1", "kind": "video", "clips": [{"id": "a", "start": 0, "duration": 12}]},
+            {"id": "vid2", "kind": "video", "clips": [{"id": "b", "start": 0, "duration": 12}]},
+        ],
+        [{"id": "c", "time": cut, "effect": effect, "duration": duration}],
+    )
+
+
+def test_render_plan_hardcut_no_fades():
+    plan = video_render_plan(_ab_timeline("cut", 0))
+    assert plan["a"]["fades"] == [] and plan["a"]["wipes"] == []
+    assert plan["a"]["segments"] == [(0.0, 6.0)]
+    assert plan["b"]["segments"] == [(6.0, 12.0)]
+
+
+def test_render_plan_crossfade_extends_and_fades():
+    # cut@6, d=2 → Fenster [5,7]. b erscheint ab 5 mit fade-in, a bleibt bis 7.
+    plan = video_render_plan(_ab_timeline("crossfade", 2))
+    assert plan["b"]["segments"] == [(5.0, 12.0)]
+    assert plan["a"]["segments"] == [(0.0, 7.0)]
+    assert plan["b"]["fades"] == [{"type": "in", "st": 5.0, "d": 2.0}]
+    assert plan["a"]["fades"] == []
+
+
+def test_render_plan_wipe():
+    plan = video_render_plan(_ab_timeline("wipe", 2))
+    assert plan["b"]["wipes"] == [{"st": 5.0, "d": 2.0}]
+    assert plan["b"]["segments"] == [(5.0, 12.0)]
+    assert plan["a"]["segments"] == [(0.0, 7.0)]
+
+
+def test_render_plan_fade_black():
+    # cut@6, d=2 → a fade-out [5,6], b fade-in [6,7].
+    plan = video_render_plan(_ab_timeline("fade-black", 2))
+    assert plan["a"]["fades"] == [{"type": "out", "st": 5.0, "d": 1.0}]
+    assert plan["b"]["fades"] == [{"type": "in", "st": 6.0, "d": 1.0}]

--- a/docs/specs/videocut-v6b.md
+++ b/docs/specs/videocut-v6b.md
@@ -1,0 +1,56 @@
+# Videoschnitt V6b — Weiche Übergänge im Export
+
+## Was
+Die Übergangseffekte (Crossfade / Wipe / Fade-to-black), die man schon in der
+Preview sieht, werden jetzt auch in die exportierte MP4 gerendert. Bisher (V6a)
+wurden sie als Hartschnitt exportiert.
+
+## Warum
+WYSIWYG: die heruntergeladene Datei soll dem entsprechen, was man im Output-
+Monitor sieht. V6b schließt die letzte Lücke zwischen Preview und Export.
+
+## Warum NICHT ffmpeg `xfade`
+`xfade` erwartet zwei zeitlich **aufeinanderfolgende** Streams und verkürzt die
+Gesamtdauer um die Überblendzeit. Unser Export nutzt aber ein **Overlay-
+Compositing-Modell** (jeder Clip als Layer mit `enable=between(...)` auf schwarzem
+Grund), das das Timing exakt wie die Preview hält. Übergänge werden deshalb im
+Overlay-Modell über **Alpha-Rampen** umgesetzt — timing-treu, kein Längenversatz.
+Empirisch verifiziert (Frame-Sampling: Crossfade mischt, Wipe wischt, Fade geht
+über Schwarz).
+
+## Wie
+### Assembly (`media_timeline_assembly.py`)
+- Neue reine Funktion `video_render_plan(timeline) -> list[ClipRenderOp]`.
+  Baut auf `video_onair_segments` auf und ergänzt je Clip die im Übergangsfenster
+  nötigen Info. Fenster eines Schnittpunkts: `[time − d/2, time + d/2]`
+  (effect ∈ {crossfade, wipe, fade-black}, d>0). Pro Clip:
+  - `segments`: on-air-Basisintervalle (wie V6a; Hartschnitt-Grenzen).
+  - `enter`: optionaler Übergang, mit dem der Clip **erscheint** (er ist der
+    „danach"-Clip eines Schnittpunkts) → `{effect, at, duration}`.
+  - `leave`: optionaler Übergang, mit dem der Clip **verschwindet** (er ist der
+    „davor"-Clip) → für crossfade/wipe implizit durch das enter des Nachfolgers,
+    für **fade-black** braucht der davor-Clip ein eigenes Fade-out.
+  Der einbezogene Zeitbereich wird an den Fenster-Rändern erweitert, damit sich
+  die Clips im Übergang überlappen.
+
+### Export (`media_export.py`)
+Pro Video-Clip wird aus der Render-Op die Filterkette gebaut:
+- **crossfade** (enter): Overlay-Fenster nach links um `d` erweitern,
+  `format=yuva420p,fade=t=in:st=<winStart>:d=<d>:alpha=1`.
+- **fade-black**: enter-Clip `fade=in` ab Fenstermitte (`d/2`); der davor-Clip
+  bekommt zusätzlich `fade=out` in der ersten Fensterhälfte, sodass zwischen den
+  beiden der schwarze Base-Layer durchscheint.
+- **wipe** (enter): Overlay mit `geq`-Alpha-Maske, die eine von links wachsende
+  Kante erzeugt: `a='if(lt(X,W*clip((T-<winStart>)/<d>,0,1)),255,0)'`.
+- **cut / d=0**: unverändert wie V6a (harte `enable`-Grenze).
+- Audio: an Schnittpunkten mit Übergang ein kurzer `acrossfade`-artiger
+  Lautstärke-Übergang ist optional; V6b hält Audio wie V6a (Clip-Volumes,
+  amix) — der Bild-Übergang ist das Sichtbare.
+
+## Akzeptanzkriterien
+- [ ] Crossfade wird im Export als Überblendung gerendert (Mischframe in der Mitte).
+- [ ] Wipe wird als von links wachsende Kante gerendert.
+- [ ] Fade-to-black geht sichtbar über Schwarz.
+- [ ] Hartschnitt (cut/d=0) bleibt unverändert (V6a-Verhalten).
+- [ ] Gesamtdauer bleibt exakt (kein `xfade`-Längenversatz).
+- [ ] Backend-Tests grün inkl. Frame-Sampling je Effekt; ruff clean.


### PR DESCRIPTION
## V6b — Weiche Übergänge im Export

Die Übergangseffekte (Crossfade / Wipe / Fade-to-black), die man schon in der Preview sieht, landen jetzt auch in der exportierten MP4. V6a hat sie noch als Hartschnitt gerendert.

### Warum kein ffmpeg `xfade`
`xfade` erwartet zwei zeitlich aufeinanderfolgende Streams und **verkürzt die Gesamtdauer** um die Überblendzeit — das würde von deiner Preview abweichen. Unser Export nutzt ein **Overlay-Compositing-Modell** (jeder Clip als Layer mit `enable=between(...)` auf schwarzem Grund), das das Timing exakt hält. Die Übergänge werden deshalb über **Alpha-Rampen** im Overlay-Modell umgesetzt — timing-treu, kein Längenversatz.

### Umsetzung
- `media_timeline_assembly.video_render_plan()` (rein, getestet): baut auf `video_onair_segments` auf und ergänzt je Clip `fades`/`wipes` + erweitert die Overlay-Fenster im Übergangsbereich.
  - **crossfade** → der „danach"-Clip erscheint früher mit `fade-in`
  - **fade-black** → „davor"-Clip `fade-out` in der ersten Hälfte, „danach"-Clip `fade-in` in der zweiten (der schwarze Base-Layer scheint dazwischen durch)
  - **wipe** → von links wachsende Kante via `geq`-Alpha-Maske
  - **cut / d=0** → unverändert (V6a-Hartschnitt)
- `media_export._transition_suffix()` baut die Filterkette: `format=yuva420p` + `fade(alpha=1)` bzw. `geq`.

### Verifikation
- ✅ **8 Assembly-Unit-Tests** (Segment-Erweiterung + Fade/Wipe-Listen je Effekt)
- ✅ **Export-Crossfade-Frame-Sampling:** gerendertes Video ausgelesen — vor Übergang rot, in der Mitte Mischung (beide Kanäle), nach Übergang grün
- ✅ FFmpeg-Rezepte vorab **empirisch gegengecheckt** (crossfade mischt `804000`, wipe wischt von links, fade geht über schwarz `39,0,0`→`0,29,0`)
- ✅ 19/19 Backend-Tests grün, ruff clean

Rein Backend, WYSIWYG-treu. Wie immer: Server brauchen ein Update, damit der neue Export greift.

Spec: `docs/specs/videocut-v6b.md`. Damit ist Export (V6) komplett.
