### PR TITLE
feat(media): Export-Historie „Fertige Filme" im Videoschnitt

### DIFF
--- a/core/src/hydrahive/api/routes/media_workspace.py
+++ b/core/src/hydrahive/api/routes/media_workspace.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any, Literal
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field, model_validator
 
-from hydrahive import media_export, media_workspace
+from hydrahive import media_export, media_exports, media_workspace
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api.routes.media_projects import _authorize
@@ -149,3 +149,20 @@ def export_timeline(project_id: str, media_slug: str, auth: Annotated[tuple[str,
         raise coded(status.HTTP_404_NOT_FOUND, "media_project_or_asset_not_found")
     except media_export.MediaExportError:
         raise coded(status.HTTP_400_BAD_REQUEST, "media_export_failed")
+
+
+@router.get("/timeline/exports")
+def list_timeline_exports(project_id: str, media_slug: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> list[dict]:
+    return _run(project_id, auth, lambda: media_exports.list_exports(project_id, media_slug))
+
+
+@router.delete("/timeline/exports/{name}")
+def delete_timeline_export(project_id: str, media_slug: str, name: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        media_exports.delete_export(project_id, media_slug, name)
+        return {"status": "deleted", "name": name}
+    except FileNotFoundError:
+        raise coded(status.HTTP_404_NOT_FOUND, "export_not_found")
+    except media_exports.MediaExportError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "invalid_export_name")

--- a/core/src/hydrahive/media_export.py
+++ b/core/src/hydrahive/media_export.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 from hydrahive import media_assets, media_projects, media_timeline_assembly, media_workspace
@@ -105,7 +106,8 @@ def export(project_id: str, media_slug: str) -> dict:
 
     duration = _timeline_duration(timeline)
     root = media_projects._dir(project_id, media_slug)
-    output = root / "exports" / "timeline.mp4"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    output = root / "exports" / f"schnitt-{stamp}.mp4"
     output.parent.mkdir(parents=True, exist_ok=True)
 
     args = ["ffmpeg", "-y", "-f", "lavfi", "-i",
@@ -183,7 +185,15 @@ def export(project_id: str, media_slug: str) -> dict:
     if result.returncode != 0 or not output.is_file():
         error = result.stderr.decode(errors="replace")[-500:]
         raise MediaExportError(f"FFmpeg-Export fehlgeschlagen: {error}")
-    return {"status": "completed", "rel_path": str(output.relative_to(root)), "path": str(output), "duration": duration}
+
+    created_at = datetime.now(timezone.utc).isoformat()
+    output.with_suffix(".json").write_text(
+        json.dumps({"created_at": created_at, "duration": duration}), encoding="utf-8"
+    )
+    return {
+        "status": "completed", "name": output.name, "rel_path": str(output.relative_to(root)),
+        "path": str(output), "duration": duration, "created_at": created_at,
+    }
 
 
 def _timeline_duration(timeline: dict) -> float:

--- a/core/src/hydrahive/media_exports.py
+++ b/core/src/hydrahive/media_exports.py
@@ -1,0 +1,58 @@
+"""Verwaltung der fertigen Film-Exporte (Historie): Auflisten & Löschen.
+
+Der eigentliche Render liegt in media_export.py; hier die persistente Sicht auf
+die erzeugten MP4s (+ Sidecar-Meta) im exports/-Ordner eines Media-Projekts.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from hydrahive import media_projects
+
+
+class MediaExportError(ValueError):
+    pass
+
+
+def list_exports(project_id: str, media_slug: str) -> list[dict]:
+    """Alle fertigen Export-MP4s eines Media-Projekts, neueste zuerst."""
+    root = media_projects._dir(project_id, media_slug)
+    exports_dir = root / "exports"
+    if not exports_dir.is_dir():
+        return []
+    items: list[dict] = []
+    for mp4 in exports_dir.glob("*.mp4"):
+        meta: dict = {}
+        sidecar = mp4.with_suffix(".json")
+        if sidecar.is_file():
+            try:
+                meta = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                meta = {}
+        stat = mp4.stat()
+        items.append({
+            "name": mp4.name,
+            "rel_path": str(mp4.relative_to(root)),
+            "path": str(mp4),
+            "size": stat.st_size,
+            "created_at": meta.get("created_at") or datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+            "duration": meta.get("duration"),
+        })
+    items.sort(key=lambda e: e["created_at"], reverse=True)
+    return items
+
+
+def delete_export(project_id: str, media_slug: str, name: str) -> None:
+    """Löscht eine Export-Datei + Sidecar. name ist ein Basename im exports/-Ordner."""
+    root = media_projects._dir(project_id, media_slug)
+    exports_dir = (root / "exports").resolve()
+    target = (exports_dir / name).resolve()
+    if target.parent != exports_dir or target.suffix != ".mp4":
+        raise MediaExportError("Ungültiger Export-Name")
+    if not target.is_file():
+        raise FileNotFoundError(name)
+    target.unlink()
+    sidecar = target.with_suffix(".json")
+    if sidecar.is_file():
+        sidecar.unlink()

--- a/core/tests/test_media_export.py
+++ b/core/tests/test_media_export.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from hydrahive import media_assets, media_export, media_projects, media_workspace
+from hydrahive import media_assets, media_export, media_exports, media_projects, media_workspace
 from hydrahive.projects import config as project_config
 from hydrahive.projects._paths import workspace_path
 
@@ -87,6 +87,38 @@ def test_export_crossfade_blends_midpoint(tmp_path):
     assert r1 > 150 and g1 < 80           # rot
     assert r3 < 80 and g3 > 80            # grün
     assert rm > 30 and gm > 30           # beide Kanäle präsent → Überblendung
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")
+def test_exports_list_and_delete(tmp_path):
+    project = project_config.create(name="ExportList", members=["testuser"], llm_model="test", created_by="admin")
+    media_projects.create(project["id"], "film", "Film")
+    root = workspace_path(project["id"])
+    subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "color=c=blue:s=160x90:d=1", "-c:v", "libx264", "-pix_fmt", "yuv420p", str(root / "s.mp4")], check=True, capture_output=True)
+    media_assets.create(project["id"], "film", "video", "video", project["id"], "s.mp4", "Video")
+    media_workspace.save_timeline(project["id"], "film", {"fps": 25, "width": 160, "height": 90, "tracks": [{"id": "vid1", "name": "V", "kind": "video", "muted": False, "clips": [{"id": "c", "asset_id": "video", "start": 0, "duration": 1, "source_in": 0, "volume": 1}]}]})
+
+    r1 = media_export.export(project["id"], "film")
+    import time as _t
+    _t.sleep(1.1)  # eindeutiger Zeitstempel (Sekunden-Auflösung)
+    r2 = media_export.export(project["id"], "film")
+    assert r1["name"] != r2["name"]  # keine Überschreibung
+
+    exports = media_exports.list_exports(project["id"], "film")
+    assert len(exports) == 2
+    assert exports[0]["created_at"] >= exports[1]["created_at"]  # neueste zuerst
+    assert all(e["duration"] == 1 for e in exports)
+
+    media_exports.delete_export(project["id"], "film", r1["name"])
+    remaining = media_exports.list_exports(project["id"], "film")
+    assert [e["name"] for e in remaining] == [r2["name"]]
+
+
+def test_delete_export_rejects_traversal():
+    project = project_config.create(name="ExportTrav", members=["testuser"], llm_model="test", created_by="admin")
+    media_projects.create(project["id"], "film", "Film")
+    with pytest.raises(media_exports.MediaExportError):
+        media_exports.delete_export(project["id"], "film", "../secret.mp4")
 
 
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg fehlt")

--- a/docs/specs/videocut-export-library.md
+++ b/docs/specs/videocut-export-library.md
@@ -1,0 +1,42 @@
+# Videoschnitt — Export-Historie „Fertige Filme"
+
+## Was
+Exportierte Filme werden dauerhaft gelistet und sind jederzeit erneut
+herunterladbar — in einer eigenen Box **„Fertige Filme"** unter der
+Clip-Bibliothek. Bisher gab es nur einen flüchtigen Download-Link, der nach
+Reload verschwand.
+
+## Warum
+Ein Export ist Arbeit (FFmpeg-Render). Das Ergebnis darf nicht verloren gehen,
+nur weil man die Seite neu lädt. Eine persistente Liste macht die Exporte
+wiederauffindbar, vergleichbar und löschbar.
+
+## Wie
+### Backend
+- **Eindeutiger Dateiname:** Export schreibt `exports/schnitt-<YYYYMMDD-HHMMSS>.mp4`
+  statt immer `exports/timeline.mp4` zu überschreiben → Historie bleibt erhalten.
+- **Sidecar-Meta:** je Export eine `…​.json` mit `{created_at, duration}`.
+- **`media_export.list_exports(project_id, media_slug)`**: liest den
+  `exports/`-Ordner, liefert je MP4 `{name, rel_path, path, size, created_at,
+  duration}` (created_at/duration aus Sidecar, Fallback mtime/None), neueste zuerst.
+- **`media_export.delete_export(project_id, media_slug, name)`**: löscht MP4 +
+  Sidecar. `name` wird gegen Path-Traversal validiert (nur Basename, muss im
+  exports/-Ordner liegen).
+- **Routen** (media_workspace.py Router):
+  - `GET  /timeline/exports` → Liste
+  - `DELETE /timeline/exports/{name}` → löschen
+- Output liegt weiter unter `data_dir/workspaces` → Download via `/api/files`.
+
+### Frontend
+- `mediaWorkspaceApi.listExports` + `deleteExport` + Typ `MediaExportEntry`.
+- **`ExportLibrary`-Box** unter der Bibliothek (rechte Spalte): Liste der Exporte
+  mit Name, Dauer, Größe, Zeit; je Eintrag Download (`fileUrl(path)`) + Löschen.
+- `useCutExport` lädt die Liste initial und nach jedem erfolgreichen Export neu.
+- `ExportBar` behält den frischen Direkt-Link, die Box ist die persistente Sicht.
+
+## Akzeptanzkriterien
+- [ ] Jeder Export erzeugt eine eigene Datei (überschreibt keine ältere).
+- [ ] „Fertige Filme"-Box listet alle Exporte, neueste zuerst, überlebt Reload.
+- [ ] Download je Eintrag funktioniert; Löschen entfernt Datei + Sidecar.
+- [ ] Nach einem Export erscheint der neue Film sofort in der Box.
+- [ ] Backend-Tests grün; Build/Typecheck/ESLint grün.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -4,11 +4,13 @@ import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api
 import { ClipLibrary } from "./videocut/ClipLibrary"
 import { CutPointInspector } from "./videocut/CutPointInspector"
 import { ExportBar } from "./videocut/ExportBar"
+import { ExportLibrary } from "./videocut/ExportLibrary"
 import { InputMonitor } from "./videocut/InputMonitor"
 import { OutputMonitor } from "./videocut/OutputMonitor"
 import { PlaybackAudio } from "./videocut/PlaybackAudio"
 import { TrackArea } from "./videocut/TrackArea"
 import { timecode, useCutPlayback } from "./videocut/useCutPlayback"
+import { useCutExport } from "./videocut/useCutExport"
 import { useCutTimeline } from "./videocut/useCutTimeline"
 
 /** Videoschnitt (V3c): A/B-Roll mit Übergangseffekten. Input 1/2 zeigen vid1/vid2
@@ -42,6 +44,7 @@ export function MediaPostProduction({ projectId }: Props) {
     addCutPoint, previewCutPoint, moveCutPoint, updateCutPoint, removeCutPoint,
   } = useCutTimeline(projectId)
   const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
+  const cutExport = useCutExport(projectId)
 
   // Roter Cut-Cursor (Justage-Position der Input-Monitore).
   const [cursorTime, setCursorTime] = useState(0)
@@ -146,14 +149,17 @@ export function MediaPostProduction({ projectId }: Props) {
           />
         ) : null}
 
-        {/* Export: Schnitt als MP4 rendern + herunterladen */}
-        <ExportBar projectId={projectId} disabled={!timeline || saving} />
+        {/* Export: Schnitt als MP4 rendern (Ergebnis in „Fertige Filme") */}
+        <ExportBar status={cutExport.status} error={cutExport.error} disabled={!timeline || saving} onExport={() => void cutExport.run()} />
       </div>
 
-      {/* Clip-Bibliothek rechts */}
-      <aside className="min-h-0 rounded-[4px] border border-[#2a364b] bg-[#111827] p-2 xl:max-h-[calc(100vh-220px)]">
-        <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Bibliothek</p>
-        <ClipLibrary projectId={projectId} onAdd={(item, trackId, url) => void addClip(item, trackId, url)} disabled={!timeline || saving} />
+      {/* Rechte Spalte: Clip-Bibliothek + fertige Filme */}
+      <aside className="min-w-0">
+        <div className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-2">
+          <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Bibliothek</p>
+          <ClipLibrary projectId={projectId} onAdd={(item, trackId, url) => void addClip(item, trackId, url)} disabled={!timeline || saving} />
+        </div>
+        <ExportLibrary exports={cutExport.exports} downloadUrl={cutExport.downloadUrl} onRemove={(name) => void cutExport.remove(name)} />
       </aside>
 
       {/* Parallele Audio-Wiedergabe (versteckt) */}

--- a/frontend/src/features/cockpit/media/videocut/ExportBar.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ExportBar.tsx
@@ -1,43 +1,30 @@
-import { Download, Film, Loader2 } from "lucide-react"
-import { timecode } from "./useCutPlayback"
-import { useCutExport } from "./useCutExport"
+import { Film, Loader2 } from "lucide-react"
+import type { ExportStatus } from "./useCutExport"
 
 interface Props {
-  projectId: string
+  status: ExportStatus
+  error: string | null
   disabled: boolean
+  onExport: () => void
 }
 
-/** Export-Leiste: rendert den Schnitt (FFmpeg) und bietet den Download an. */
-export function ExportBar({ projectId, disabled }: Props) {
-  const { status, result, error, run } = useCutExport(projectId)
+/** Export-Auslöser: rendert den Schnitt (FFmpeg). Die fertigen Filme erscheinen
+ *  in der „Fertige Filme"-Box (ExportLibrary). */
+export function ExportBar({ status, error, disabled, onExport }: Props) {
   const running = status === "running"
-
   return (
     <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-[#2a364b] pt-3">
       <button
         type="button"
-        onClick={() => void run()}
+        onClick={onExport}
         disabled={disabled || running}
         className="inline-flex items-center gap-1.5 rounded-[4px] border border-emerald-500/50 bg-emerald-500/10 px-3 py-1.5 text-[12px] font-semibold text-emerald-200 transition-colors hover:bg-emerald-500/20 disabled:opacity-40"
       >
         {running ? <Loader2 size={14} className="animate-spin" /> : <Film size={14} />}
         {running ? "Rendere…" : "Film exportieren"}
       </button>
-
-      {status === "done" && result ? (
-        <a
-          href={result.downloadUrl}
-          download="schnitt.mp4"
-          className="inline-flex items-center gap-1.5 rounded-[4px] border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-[12px] font-semibold text-cyan-100 transition-colors hover:bg-cyan-400/20"
-        >
-          <Download size={14} /> Download ({timecode(result.duration)})
-        </a>
-      ) : null}
-
-      {running ? (
-        <span className="text-[11px] text-[#8d9ab0]">Das kann je nach Länge einen Moment dauern…</span>
-      ) : null}
-
+      {running ? <span className="text-[11px] text-[#8d9ab0]">Das kann je nach Länge einen Moment dauern…</span> : null}
+      {status === "done" ? <span className="text-[11px] text-emerald-300">Fertig — siehe „Fertige Filme".</span> : null}
       {status === "error" ? <span className="text-[11px] text-rose-300">{error}</span> : null}
     </div>
   )

--- a/frontend/src/features/cockpit/media/videocut/ExportLibrary.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ExportLibrary.tsx
@@ -1,0 +1,63 @@
+import { Download, Film, Trash2 } from "lucide-react"
+import type { MediaExportEntry } from "../../mediaWorkspaceApi"
+import { timecode } from "./useCutPlayback"
+
+interface Props {
+  exports: MediaExportEntry[]
+  downloadUrl: (path: string) => string
+  onRemove: (name: string) => void
+}
+
+function fmtSize(bytes?: number): string {
+  if (!bytes) return ""
+  const mb = bytes / (1024 * 1024)
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${Math.round(bytes / 1024)} KB`
+}
+
+function fmtWhen(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ""
+  return d.toLocaleString(undefined, { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })
+}
+
+/** „Fertige Filme": persistente Liste der exportierten MP4s mit Download + Löschen. */
+export function ExportLibrary({ exports, downloadUrl, onRemove }: Props) {
+  return (
+    <div className="mt-3 rounded-[4px] border border-[#2a364b] bg-[#111827] p-2">
+      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Fertige Filme</p>
+      {exports.length === 0 ? (
+        <p className="text-[11px] text-[#7a869c]">Noch keine Exporte — oben „Film exportieren".</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {exports.map((exp) => (
+            <li key={exp.name} className="flex items-center gap-2 rounded-[3px] border border-[#223048] bg-[#0d1420] p-1.5">
+              <Film size={14} className="shrink-0 text-emerald-300" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[11px] font-semibold text-[#c3ccdd]" title={exp.name}>{exp.name}</p>
+                <p className="font-mono text-[9px] text-[#68758a]">
+                  {exp.duration != null ? timecode(exp.duration) : "—"} · {fmtSize(exp.size)} · {fmtWhen(exp.created_at)}
+                </p>
+              </div>
+              <a
+                href={downloadUrl(exp.path)}
+                download={exp.name}
+                title="Herunterladen"
+                className="grid h-6 w-6 shrink-0 place-items-center rounded-[3px] border border-cyan-400/40 bg-cyan-400/10 text-cyan-100 hover:bg-cyan-400/20"
+              >
+                <Download size={12} />
+              </a>
+              <button
+                type="button"
+                onClick={() => onRemove(exp.name)}
+                title="Löschen"
+                className="grid h-6 w-6 shrink-0 place-items-center rounded-[3px] border border-[#2a364b] text-[#8d9ab0] hover:border-rose-500/40 hover:text-rose-300"
+              >
+                <Trash2 size={12} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutExport.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutExport.ts
@@ -1,42 +1,56 @@
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { fileUrl } from "@/modules/atelier/api"
-import { mediaWorkspaceApi } from "../../mediaWorkspaceApi"
+import { mediaWorkspaceApi, type MediaExportEntry } from "../../mediaWorkspaceApi"
 import { CUT_SLUG } from "./api"
 
 export type ExportStatus = "idle" | "running" | "done" | "error"
 
-export interface ExportResult {
-  downloadUrl: string
-  duration: number
-}
-
-/** Rendert den Schnitt serverseitig (FFmpeg) und liefert einen Download-Link.
- *  Der Export läuft synchron im Request — für lange Timelines kann das dauern
- *  (Hintergrund-Job wäre eine spätere Ausbaustufe). */
+/** Rendert den Schnitt serverseitig (FFmpeg) und verwaltet die Liste der
+ *  fertigen Filme (persistente Export-Historie). */
 export function useCutExport(projectId: string) {
   const [status, setStatus] = useState<ExportStatus>("idle")
-  const [result, setResult] = useState<ExportResult | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [exports, setExports] = useState<MediaExportEntry[]>([])
+
+  const refresh = useCallback(async () => {
+    try {
+      setExports(await mediaWorkspaceApi.listExports(projectId, CUT_SLUG))
+    } catch {
+      /* Liste ist optional — Fehler still schlucken. */
+    }
+  }, [projectId])
+
+  // Initiales Laden der Export-Historie (setState erfolgt asynchron nach await).
+  useEffect(() => {
+    if (!projectId) return
+    let alive = true
+    void mediaWorkspaceApi.listExports(projectId, CUT_SLUG)
+      .then((list) => { if (alive) setExports(list) })
+      .catch(() => { /* Liste optional */ })
+    return () => { alive = false }
+  }, [projectId])
 
   const run = useCallback(async () => {
     setStatus("running")
     setError(null)
-    setResult(null)
     try {
-      const res = await mediaWorkspaceApi.exportTimeline(projectId, CUT_SLUG)
-      setResult({ downloadUrl: fileUrl(res.path), duration: res.duration })
+      await mediaWorkspaceApi.exportTimeline(projectId, CUT_SLUG)
       setStatus("done")
+      await refresh()
     } catch (err) {
       setError(err instanceof Error ? err.message : "Export fehlgeschlagen.")
       setStatus("error")
     }
-  }, [projectId])
+  }, [projectId, refresh])
 
-  const reset = useCallback(() => {
-    setStatus("idle")
-    setResult(null)
-    setError(null)
-  }, [])
+  const remove = useCallback(async (name: string) => {
+    try {
+      await mediaWorkspaceApi.deleteExport(projectId, CUT_SLUG, name)
+      await refresh()
+    } catch {
+      /* Fehler still — Liste bleibt wie sie ist. */
+    }
+  }, [projectId, refresh])
 
-  return { status, result, error, run, reset }
+  return { status, error, exports, run, remove, downloadUrl: (path: string) => fileUrl(path) }
 }

--- a/frontend/src/features/cockpit/mediaWorkspaceApi.ts
+++ b/frontend/src/features/cockpit/mediaWorkspaceApi.ts
@@ -20,5 +20,16 @@ export const mediaWorkspaceApi = {
   saveAgentContext: (projectId: string, mediaSlug: string, value: MediaAgentContext) => api.put<MediaAgentContext>(`${base(projectId, mediaSlug)}/agent-context`, value),
   getTimeline: (projectId: string, mediaSlug: string) => api.get<MediaTimeline>(`${base(projectId, mediaSlug)}/timeline`),
   saveTimeline: (projectId: string, mediaSlug: string, value: MediaTimeline) => api.put<MediaTimeline>(`${base(projectId, mediaSlug)}/timeline`, value),
-  exportTimeline: (projectId: string, mediaSlug: string) => api.post<{ status: string; rel_path: string; path: string; duration: number }>(`${base(projectId, mediaSlug)}/timeline/export`, {}),
+  exportTimeline: (projectId: string, mediaSlug: string) => api.post<MediaExportEntry & { status: string }>(`${base(projectId, mediaSlug)}/timeline/export`, {}),
+  listExports: (projectId: string, mediaSlug: string) => api.get<MediaExportEntry[]>(`${base(projectId, mediaSlug)}/timeline/exports`),
+  deleteExport: (projectId: string, mediaSlug: string, name: string) => api.delete<{ status: string; name: string }>(`${base(projectId, mediaSlug)}/timeline/exports/${encodeURIComponent(name)}`),
+}
+
+export interface MediaExportEntry {
+  name: string
+  rel_path: string
+  path: string
+  size?: number
+  created_at: string
+  duration: number | null
 }


### PR DESCRIPTION
## Export-Historie „Fertige Filme" im Videoschnitt

Du hattest nur einen flüchtigen Download-Link, der nach Reload weg war. Jetzt werden die exportierten Filme **dauerhaft gelistet** — in einer eigenen Box **„Fertige Filme"** unter der Clip-Bibliothek.

### Was neu ist
- **Persistente Liste:** jeder Export erscheint als Eintrag mit Name, Dauer, Größe, Zeit — mit **Download** und **Löschen** je Film. Überlebt Reload.
- **Keine Überschreibung mehr:** Export schreibt jetzt `exports/schnitt-<timestamp>.mp4` (+ Sidecar-JSON mit `created_at`/`duration`) statt immer dieselbe `timeline.mp4` → volle Historie.
- Nach einem Export erscheint der neue Film **sofort** in der Box.

### Backend
- `media_exports.py` (neu): `list_exports()` (neueste zuerst, Meta aus Sidecar + Fallback auf mtime) und `delete_export()` (Path-Traversal-Schutz — nur Basename im `exports/`-Ordner, `.mp4`). Bewusst ausgelagert, damit `media_export.py` auf die Render-Logik fokussiert bleibt.
- Routen: `GET /timeline/exports`, `DELETE /timeline/exports/{name}`.
- Download läuft weiter über `/api/files` (Output liegt unter `data_dir/workspaces`).

### Frontend
- `mediaWorkspaceApi.listExports/deleteExport` + `MediaExportEntry`.
- `useCutExport` lädt die Liste initial und nach jedem Export neu; `remove()` löscht.
- `ExportLibrary`-Box + `ExportBar` auf reinen Auslöser reduziert.

### Verifikation
- ✅ Backend **24/24 grün**, ruff clean. Neu: mehrere Exporte überschreiben sich nicht, Liste korrekt sortiert, Delete entfernt Datei+Sidecar, Traversal wird abgelehnt.
- ✅ tsc / eslint / build grün.

Wie immer: Server brauchen ein Update, damit die neuen Routen + das Namensschema greifen. **Hinweis:** ältere Exporte hießen `timeline.mp4` — die tauchen weiterhin in der Liste auf (Fallback auf mtime), nur neue bekommen den Zeitstempel-Namen.

Spec: `docs/specs/videocut-export-library.md`.
