### PR TITLE
feat(media): Videoschnitt-UX — Vorschau, volle Timeline-Breite, größere Spuren

### DIFF
--- a/frontend/src/features/cockpit/media/videocut/ClipLibrary.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ClipLibrary.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
-import { Image as ImageIcon, Music, Video } from "lucide-react"
+import { Image as ImageIcon, Music, Play, Video } from "lucide-react"
 import { atelierApi } from "@/modules/atelier/api"
 import { libraryFileUrl, loadLibrary, type LibraryItem } from "./api"
+import { MediaLightbox, type LightboxSource } from "./MediaLightbox"
 
 interface Props {
   projectId: string
@@ -27,6 +28,12 @@ export function ClipLibrary({ projectId, onAdd, disabled }: Props) {
   const [items, setItems] = useState<LibraryItem[] | null>(null)
   const [kind, setKind] = useState<LibraryItem["kind"]>("video")
   const [pending, setPending] = useState<LibraryItem | null>(null)
+  const [preview, setPreview] = useState<LightboxSource | null>(null)
+
+  const openPreview = (item: LibraryItem) => {
+    if (!item.absPath) return
+    setPreview({ url: libraryFileUrl(item.absPath), kind: item.kind, label: item.label })
+  }
 
   useEffect(() => {
     if (!projectId) return
@@ -67,7 +74,13 @@ export function ClipLibrary({ projectId, onAdd, disabled }: Props) {
       <div className="mt-2 grid min-h-0 flex-1 auto-rows-min grid-cols-2 gap-1.5 overflow-y-auto pr-1 sm:grid-cols-3">
         {visible.map((item) => (
           <div key={item.key} className="rounded-[3px] border border-[#223048] bg-[#111827] p-1">
-            <div className="relative aspect-video overflow-hidden rounded-[2px] bg-black">
+            <button
+              type="button"
+              onClick={() => openPreview(item)}
+              disabled={!item.absPath}
+              title="Vorschau ansehen"
+              className="group/thumb relative block aspect-video w-full overflow-hidden rounded-[2px] bg-black disabled:cursor-default"
+            >
               {item.kind === "image" && item.absPath ? (
                 <img src={libraryFileUrl(item.absPath)} alt="" className="h-full w-full object-cover" loading="lazy" />
               ) : item.kind === "video" && item.absPath ? (
@@ -75,7 +88,12 @@ export function ClipLibrary({ projectId, onAdd, disabled }: Props) {
               ) : (
                 <div className="grid h-full place-items-center text-[#3f4b60]"><Music size={18} /></div>
               )}
-            </div>
+              {item.absPath ? (
+                <span className="absolute inset-0 grid place-items-center bg-black/0 opacity-0 transition-opacity group-hover/thumb:bg-black/30 group-hover/thumb:opacity-100">
+                  <Play size={18} className="text-white drop-shadow" />
+                </span>
+              ) : null}
+            </button>
             <p className="mt-1 truncate text-[10px] text-[#c3ccdd]" title={item.label}>{item.label}</p>
             {pending?.key === item.key ? (
               <div className="mt-1 flex flex-wrap gap-1">
@@ -96,6 +114,8 @@ export function ClipLibrary({ projectId, onAdd, disabled }: Props) {
           </div>
         ))}
       </div>
+
+      <MediaLightbox source={preview} onClose={() => setPreview(null)} />
     </div>
   )
 }

--- a/frontend/src/features/cockpit/media/videocut/ExportLibrary.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ExportLibrary.tsx
@@ -1,5 +1,7 @@
-import { Download, Film, Trash2 } from "lucide-react"
+import { Download, Play, Trash2 } from "lucide-react"
+import { useState } from "react"
 import type { MediaExportEntry } from "../../mediaWorkspaceApi"
+import { MediaLightbox, type LightboxSource } from "./MediaLightbox"
 import { timecode } from "./useCutPlayback"
 
 interface Props {
@@ -22,6 +24,7 @@ function fmtWhen(iso: string): string {
 
 /** „Fertige Filme": persistente Liste der exportierten MP4s mit Download + Löschen. */
 export function ExportLibrary({ exports, downloadUrl, onRemove }: Props) {
+  const [preview, setPreview] = useState<LightboxSource | null>(null)
   return (
     <div className="mt-3 rounded-[4px] border border-[#2a364b] bg-[#111827] p-2">
       <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Fertige Filme</p>
@@ -31,7 +34,17 @@ export function ExportLibrary({ exports, downloadUrl, onRemove }: Props) {
         <ul className="space-y-1.5">
           {exports.map((exp) => (
             <li key={exp.name} className="flex items-center gap-2 rounded-[3px] border border-[#223048] bg-[#0d1420] p-1.5">
-              <Film size={14} className="shrink-0 text-emerald-300" />
+              <button
+                type="button"
+                onClick={() => setPreview({ url: downloadUrl(exp.path), kind: "video", label: exp.name })}
+                title="Vorschau ansehen"
+                className="group/thumb relative h-9 w-16 shrink-0 overflow-hidden rounded-[3px] border border-[#2a364b] bg-black"
+              >
+                <video src={downloadUrl(exp.path)} className="h-full w-full object-cover" preload="metadata" muted />
+                <span className="absolute inset-0 grid place-items-center bg-black/25 transition-colors group-hover/thumb:bg-black/40">
+                  <Play size={14} className="text-white drop-shadow" />
+                </span>
+              </button>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-[11px] font-semibold text-[#c3ccdd]" title={exp.name}>{exp.name}</p>
                 <p className="font-mono text-[9px] text-[#68758a]">
@@ -58,6 +71,8 @@ export function ExportLibrary({ exports, downloadUrl, onRemove }: Props) {
           ))}
         </ul>
       )}
+
+      <MediaLightbox source={preview} onClose={() => setPreview(null)} />
     </div>
   )
 }

--- a/frontend/src/features/cockpit/media/videocut/MediaLightbox.tsx
+++ b/frontend/src/features/cockpit/media/videocut/MediaLightbox.tsx
@@ -1,0 +1,50 @@
+import { X } from "lucide-react"
+import { useEffect } from "react"
+
+export interface LightboxSource {
+  url: string
+  kind: "video" | "image" | "audio"
+  label?: string
+}
+
+interface Props {
+  source: LightboxSource | null
+  onClose: () => void
+}
+
+/** Vollbild-Vorschau (Modal) für einen Clip/Film: Video mit Steuerung, Bild
+ *  oder Audio. Klick auf den Hintergrund oder Esc schließt. */
+export function MediaLightbox({ source, onClose }: Props) {
+  useEffect(() => {
+    if (!source) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose() }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [source, onClose])
+
+  if (!source) return null
+
+  return (
+    <div className="fixed inset-0 z-[60] grid place-items-center bg-black/80 p-6" onClick={onClose}>
+      <div className="relative flex max-h-[90vh] w-full max-w-4xl flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between">
+          <span className="truncate font-mono text-[12px] text-[#c3ccdd]" title={source.label}>{source.label ?? ""}</span>
+          <button onClick={onClose} aria-label="Schließen" className="grid h-8 w-8 place-items-center rounded-[4px] border border-white/20 bg-white/5 text-white hover:bg-white/10">
+            <X size={16} />
+          </button>
+        </div>
+        <div className="grid min-h-0 place-items-center overflow-hidden rounded-lg border border-white/10 bg-black">
+          {source.kind === "video" ? (
+            <video src={source.url} controls autoPlay className="max-h-[80vh] w-full object-contain" />
+          ) : source.kind === "image" ? (
+            <img src={source.url} alt={source.label ?? ""} className="max-h-[80vh] w-full object-contain" />
+          ) : (
+            <div className="w-full p-8">
+              <audio src={source.url} controls autoPlay className="w-full" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -5,6 +5,7 @@ import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import { ClipBlock } from "./ClipBlock"
 import { CutPointMarker } from "./CutPointMarker"
 import { useDragX } from "./useDragX"
+import { useElementWidth } from "./useElementWidth"
 import { CUT_TRACKS } from "./useCutTimeline"
 
 interface Props {
@@ -40,7 +41,7 @@ const TRACK_META: Record<string, { icon: ComponentType<{ size?: number | string;
   voice: { icon: Mic, tone: "#ffb86b" },
 }
 
-const PX_PER_SECOND = 6
+const MIN_PX_PER_SECOND = 6   // untere Grenze für lange Filme (dann scrollbar)
 const MIN_RULER_SECONDS = 30
 const LABEL_COL = 84
 const GAP = 8
@@ -51,14 +52,21 @@ export function TrackArea({
   onCutPreview, onCutCommit, onCutRemove, selectedCutId, onSelectCut,
 }: Props) {
   const assetLabel = useMemo(() => new Map(assets.map((a) => [a.id, a.label])), [assets])
+  const { ref: outerRef, width: outerWidth } = useElementWidth<HTMLDivElement>()
+
   const totalLen = Math.max(
     MIN_RULER_SECONDS,
     ...timeline.tracks.flatMap((t) => t.clips.map((c) => c.start + c.duration)),
   )
+  // Dynamische Skala: Spurbereich füllt die verfügbare Breite; bei langen Filmen
+  // greift die Mindest-Skala und die Timeline wird scrollbar.
+  const laneWidth = Math.max(0, outerWidth - LABEL_COL - GAP)
+  const pxPerSecond = laneWidth > 0 ? Math.max(MIN_PX_PER_SECOND, laneWidth / totalLen) : MIN_PX_PER_SECOND
+
   const rulerSteps = Math.ceil(totalLen / 5)
-  const innerWidth = totalLen * PX_PER_SECOND
-  const playheadLeft = Math.min(currentTime, totalLen) * PX_PER_SECOND
-  const cursorLeft = Math.min(cursorTime, totalLen) * PX_PER_SECOND
+  const innerWidth = totalLen * pxPerSecond
+  const playheadLeft = Math.min(currentTime, totalLen) * pxPerSecond
+  const cursorLeft = Math.min(cursorTime, totalLen) * pxPerSecond
 
   // Alle Clip-Kanten (Start/Ende) über beide Video-Spuren als Snap-Ziele.
   const clipEdges = useMemo(() => {
@@ -70,14 +78,14 @@ export function TrackArea({
     return edges
   }, [timeline])
 
-  const cursorDrag = useDragX({ pxPerSecond: PX_PER_SECOND, onMove: onCursorChange })
+  const cursorDrag = useDragX({ pxPerSecond: pxPerSecond, onMove: onCursorChange })
   const onCursorPointerDown = useCallback((e: PointerEvent) => {
     e.stopPropagation()
     cursorDrag.start(e, cursorTime)
   }, [cursorDrag, cursorTime])
 
   // Playhead-Drag: pausiert die Wiedergabe und scrubbt über onSeek.
-  const playheadDrag = useDragX({ pxPerSecond: PX_PER_SECOND, onMove: onSeek })
+  const playheadDrag = useDragX({ pxPerSecond: pxPerSecond, onMove: onSeek })
   const onPlayheadPointerDown = useCallback((e: PointerEvent) => {
     e.stopPropagation()
     onScrubStart?.()
@@ -88,22 +96,22 @@ export function TrackArea({
     onScrubStart?.()
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
     const x = Math.max(0, Math.min(e.clientX - rect.left, innerWidth))
-    onSeek(x / PX_PER_SECOND)
-  }, [innerWidth, onSeek, onScrubStart])
+    onSeek(x / pxPerSecond)
+  }, [innerWidth, pxPerSecond, onSeek, onScrubStart])
 
   return (
-    <div className="overflow-x-auto">
+    <div ref={outerRef} className="overflow-x-auto">
       <div style={{ minWidth: `${innerWidth + LABEL_COL + GAP}px` }}>
         {/* Ruler — Scrub-Fläche (Playhead) */}
         <div className="grid gap-2" style={{ gridTemplateColumns: `${LABEL_COL}px 1fr` }}>
           <div />
           <div
-            className="relative h-5 cursor-pointer touch-none rounded-[3px] border border-[#2a364b] bg-[#111827]"
+            className="relative h-6 cursor-pointer touch-none rounded-[3px] border border-[#2a364b] bg-[#111827]"
             style={{ width: `${innerWidth}px` }}
             onPointerDown={seekFromRuler}
           >
             {Array.from({ length: rulerSteps + 1 }, (_, i) => (
-              <span key={i} className="pointer-events-none absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * PX_PER_SECOND + 2}px` }}>
+              <span key={i} className="pointer-events-none absolute top-0.5 font-mono text-[9px] text-[#68758a]" style={{ left: `${i * 5 * pxPerSecond + 2}px` }}>
                 {i * 5}s
               </span>
             ))}
@@ -118,19 +126,19 @@ export function TrackArea({
             const Icon = meta.icon
             return (
               <div key={def.id} className="grid gap-2" style={{ gridTemplateColumns: `${LABEL_COL}px 1fr` }}>
-                <div className="flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-1.5" style={{ borderLeft: `3px solid ${meta.tone}` }}>
-                  <Icon size={13} className="shrink-0" />
-                  <span className="truncate text-[11px] font-semibold text-[#c3ccdd]">{def.name}</span>
+                <div className="flex items-center gap-1.5 rounded-[3px] border border-[#2a364b] bg-[#111827] px-2 py-2" style={{ borderLeft: `3px solid ${meta.tone}` }}>
+                  <Icon size={14} className="shrink-0" />
+                  <span className="truncate text-[12px] font-semibold text-[#c3ccdd]">{def.name}</span>
                 </div>
-                <div className="relative h-10 rounded-[3px] border border-[#223048] bg-[#0d1420]" style={{ width: `${innerWidth}px` }}>
-                  <div className="absolute inset-0 opacity-[0.04]" style={{ backgroundImage: "linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: `${5 * PX_PER_SECOND}px 100%` }} />
+                <div className="relative h-14 rounded-[3px] border border-[#223048] bg-[#0d1420]" style={{ width: `${innerWidth}px` }}>
+                  <div className="absolute inset-0 opacity-[0.04]" style={{ backgroundImage: "linear-gradient(90deg, #fff 1px, transparent 1px)", backgroundSize: `${5 * pxPerSecond}px 100%` }} />
                   {(track?.clips ?? []).map((clip) => (
                     <ClipBlock
                       key={clip.id}
                       clip={clip}
                       label={assetLabel.get(clip.asset_id) ?? clip.asset_id}
                       tone={meta.tone}
-                      pxPerSecond={PX_PER_SECOND}
+                      pxPerSecond={pxPerSecond}
                       snapTargets={def.kind === "video" ? [...clipEdges, cursorTime] : [0, cursorTime]}
                       onPreview={(start) => onClipPreview(def.id, clip.id, start)}
                       onCommit={(start) => onClipCommit(def.id, clip.id, start)}
@@ -147,7 +155,7 @@ export function TrackArea({
             <CutPointMarker
               key={cut.id}
               cut={cut}
-              pxPerSecond={PX_PER_SECOND}
+              pxPerSecond={pxPerSecond}
               laneOffsetCss={`${LABEL_COL}px + ${GAP}px`}
               snapTargets={clipEdges}
               selected={selectedCutId === cut.id}

--- a/frontend/src/features/cockpit/media/videocut/useElementWidth.ts
+++ b/frontend/src/features/cockpit/media/videocut/useElementWidth.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from "react"
+
+/** Misst die Breite eines Elements live (ResizeObserver). Für die dynamische
+ *  Timeline-Skalierung, damit die Spuren die volle verfügbare Breite füllen. */
+export function useElementWidth<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const update = () => setWidth(el.clientWidth)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  return { ref, width }
+}


### PR DESCRIPTION
## Videoschnitt-UX: Vorschau + volle Timeline-Breite + größere Spuren

Vier UI-Wünsche aus dem Feedback umgesetzt.

### 1. Klickbare Vorschau (neu: `MediaLightbox`)
Vollbild-Modal mit `<video controls>` (bzw. Bild/Audio). Esc oder Klick auf den Hintergrund schließt.

### 2. Bibliothek — anschauen was man einbaut
Die Thumbnails sind jetzt klickbar (mit Play-Overlay beim Hover) → Vorschau des Clips, bevor man ihn auf eine Spur legt.

### 3. „Fertige Filme" — Filmvorschau wie im Archiv
Statt eines Icons zeigt jeder Export jetzt ein **Video-Thumbnail**; Klick öffnet die Vorschau. Download + Löschen bleiben.

### 4. Timeline auf volle Breite + größere Spuren
- **Dynamische Skala** (`px/s` via ResizeObserver): die Timeline füllt jetzt die **volle verfügbare Breite** statt schmal „abgehackt" zu sein. Bei langen Filmen greift eine Mindest-Skala (6 px/s) und die Spur bleibt scrollbar.
- **Größere Spuren:** Höhe `h-10` → `h-14` (~×1,4), Ruler `h-5` → `h-6`, Labels etwas größer.

### Verifikation
- ✅ Skala-Logik gegengecheckt: kurze Filme füllen die Breite (`fillsWidth: true`), lange bleiben bei Mindest-Skala scrollbar
- ✅ tsc / eslint / build grün
- Nur Frontend, kein Backend-Change

Bitte live anschauen — besonders ob die volle Breite + Spurhöhe optisch passt. Feineinstellung (noch höher/breiter) geht schnell nach.
