### PR TITLE
feat(media): Videoschnitt Trim & Split — Feinschnitt an Clips

### DIFF
--- a/docs/specs/videocut-trim-split.md
+++ b/docs/specs/videocut-trim-split.md
@@ -1,0 +1,50 @@
+# Videoschnitt — Trim & Split (Feinschnitt)
+
+## Was
+Zwei Feinschnitt-Operationen an einzelnen Clips:
+- **Split**: einen Clip an der Playhead-Position in zwei Clips teilen.
+- **Trim**: die linke oder rechte Kante eines Clips ziehen, um ihn zu kürzen
+  (bzw. wieder zu verlängern, im Rahmen der Quelldauer).
+
+## Warum
+Bisher konnte man Clips nur ganz auf eine Spur legen und verschieben. Für einen
+echten Schnitt muss man Clips kürzen und teilen können — der letzte fehlende
+Kernbaustein des Schnittpults.
+
+## Datenmodell (vorhanden, keine Backend-Änderung)
+`Clip{ start, duration, source_in, … }`:
+- `start` = Position auf der Timeline
+- `source_in` = Startzeit innerhalb der Quelldatei
+- `duration` = abgespielte Länge
+
+Damit sind Trim/Split reine Umrechnungen — **kein** Backend-Change nötig.
+
+## Operationen (rein, in timelineOps.ts, getestet)
+- **`splitClipAt(tl, trackId, clipId, t)`**: t ist eine absolute Timeline-Sekunde
+  innerhalb des Clips. Ergebnis: Clip A `duration = t − start`; Clip B (neue ID)
+  `start = t`, `source_in = source_in + (t − start)`, `duration = Rest`. Liegt t
+  nicht echt im Clip-Inneren (mit Mindestabstand), passiert nichts.
+- **`trimClipEdge(tl, trackId, clipId, edge, newValue)`**:
+  - `edge = "start"`: neue linke Kante bei `newValue` (Timeline-Sek). Verschiebt
+    `start` und `source_in` um denselben Delta, `duration` gegenläufig. Begrenzt
+    so, dass `duration ≥ MIN` und `source_in ≥ 0` bleibt.
+  - `edge = "end"`: neue rechte Kante bei `newValue`. Nur `duration = newValue −
+    start`, begrenzt auf `≥ MIN`. (Obergrenze durch echte Quelldauer wäre ideal,
+    ist aber nicht immer bekannt → weich, ohne harte Obergrenze.)
+- `MIN_CLIP_DURATION = 0.1 s`.
+
+## UI
+- **`ClipBlock`**: schmale Trim-Handles an linker/rechter Kante (erscheinen beim
+  Hover). Ziehen → `trimClip`-Preview, Loslassen → persistiert. Der bestehende
+  Body-Drag (Verschieben) bleibt; Handles haben Vorrang (stopPropagation).
+- **Split-Button** (Schere-artig) in der Transport-Leiste: teilt den Clip der
+  ausgewählten/aktiven Video-Spur an der Playhead-Position. Da beide Video-Spuren
+  aktiv sein können, splittet der Button in **allen** Video-Spuren, die an der
+  Playhead-Position einen Clip haben.
+
+## Akzeptanzkriterien
+- [ ] Split am Playhead macht aus einem Clip zwei, korrekt mit source_in/duration.
+- [ ] Trim linke/rechte Kante kürzt den Clip; Mindestdauer wird eingehalten.
+- [ ] Verschieben (Body-Drag) funktioniert weiterhin.
+- [ ] Reine Ops per Sanity-Check verifiziert; Build/Typecheck/ESLint grün.
+- [ ] Keine Backend-Änderung.

--- a/frontend/src/features/cockpit/media/MediaPostProduction.tsx
+++ b/frontend/src/features/cockpit/media/MediaPostProduction.tsx
@@ -1,4 +1,4 @@
-import { Pause, Play, Scissors, SkipBack, SkipForward, Square } from "lucide-react"
+import { Pause, Play, Scissors, SkipBack, SkipForward, SplitSquareHorizontal, Square } from "lucide-react"
 import { useEffect, useState, type ComponentType } from "react"
 import { buildAssetMedia, loadAtelierRoot, type ClipMedia } from "./videocut/api"
 import { ClipLibrary } from "./videocut/ClipLibrary"
@@ -41,6 +41,7 @@ export function MediaPostProduction({ projectId }: Props) {
   const {
     timeline, assets, loading, saving, error,
     addClip, removeClip, previewClipStart, moveClip,
+    previewClipTrim, trimClip, splitAt,
     addCutPoint, previewCutPoint, moveCutPoint, updateCutPoint, removeCutPoint,
   } = useCutTimeline(projectId)
   const { currentTime, duration, playing, play, pause, stop, seek, toStart, toEnd } = useCutPlayback(timeline)
@@ -91,6 +92,7 @@ export function MediaPostProduction({ projectId }: Props) {
           )}
           <TransportButton icon={Square} label="Stopp" onClick={stop} disabled={!canPlay} />
           <TransportButton icon={SkipForward} label="Zum Ende" onClick={toEnd} disabled={!canPlay} />
+          <TransportButton icon={SplitSquareHorizontal} label="Am Playhead teilen" onClick={() => splitAt(currentTime)} disabled={!timeline || saving} />
           <span className="ml-1 font-mono text-[11px] text-[#8d9ab0]">{timecode(currentTime)} / {timecode(duration)}</span>
 
           {/* Schnittpunkt am roten Cursor setzen und direkt auswählen */}
@@ -129,6 +131,8 @@ export function MediaPostProduction({ projectId }: Props) {
               onCursorChange={setCursorTime}
               onClipPreview={previewClipStart}
               onClipCommit={moveClip}
+              onClipTrimPreview={previewClipTrim}
+              onClipTrimCommit={trimClip}
               onCutPreview={previewCutPoint}
               onCutCommit={moveCutPoint}
               onCutRemove={(id) => { removeCutPoint(id); if (id === selectedCutId) setSelectedCutId(null) }}

--- a/frontend/src/features/cockpit/media/videocut/ClipBlock.tsx
+++ b/frontend/src/features/cockpit/media/videocut/ClipBlock.tsx
@@ -14,6 +14,9 @@ interface Props {
   snapTargets: number[]
   onPreview: (start: number) => void
   onCommit: (start: number) => void
+  /** Trim: Kante live ziehen (preview) + persistieren (commit). */
+  onTrimPreview: (edge: "start" | "end", value: number) => void
+  onTrimCommit: (edge: "start" | "end", value: number) => void
   onRemove: () => void
 }
 
@@ -22,9 +25,34 @@ function fmtDur(s: number): string {
   return `${Math.round(s * 10) / 10}s`
 }
 
-/** Ein horizontal verschiebbarer Clip. Snapping an fremde Kanten/0/Cursor —
- *  sowohl Start- als auch Endkante rastet ein. Überlappung ist erlaubt. */
-export function ClipBlock({ clip, label, tone, pxPerSecond, snapTargets, onPreview, onCommit, onRemove }: Props) {
+/** Kleiner Trim-Griff an einer Clip-Kante. Eigene Komponente wegen useDragX-Hook. */
+function TrimHandle({ side, edgeTime, pxPerSecond, onPreview, onCommit }: {
+  side: "left" | "right"
+  edgeTime: number
+  pxPerSecond: number
+  onPreview: (value: number) => void
+  onCommit: (value: number) => void
+}) {
+  const { start, dragging } = useDragX({ pxPerSecond, onMove: onPreview, onCommit })
+  const onPointerDown = useCallback((e: PointerEvent) => {
+    if (e.button !== 0) return
+    e.stopPropagation()
+    start(e, edgeTime)
+  }, [start, edgeTime])
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      title={side === "left" ? "Anfang trimmen" : "Ende trimmen"}
+      className={["absolute inset-y-0 z-10 w-2 cursor-ew-resize touch-none",
+        side === "left" ? "left-0" : "right-0",
+        dragging ? "bg-white/70" : "bg-white/0 hover:bg-white/40"].join(" ")}
+    />
+  )
+}
+
+/** Ein horizontal verschiebbarer Clip mit Trim-Handles an beiden Kanten.
+ *  Body-Drag verschiebt (Snap an Kanten/0/Cursor), Kanten-Handles trimmen. */
+export function ClipBlock({ clip, label, tone, pxPerSecond, snapTargets, onPreview, onCommit, onTrimPreview, onTrimCommit, onRemove }: Props) {
   const snap = useCallback((value: number): number => {
     let best = value
     let bestDelta = SNAP_THRESHOLD
@@ -56,13 +84,18 @@ export function ClipBlock({ clip, label, tone, pxPerSecond, snapTargets, onPrevi
         background: `${tone}22`,
       }}
       title={`${label} · ${fmtDur(clip.duration)}`}>
+      <TrimHandle side="left" edgeTime={clip.start} pxPerSecond={pxPerSecond}
+        onPreview={(v) => onTrimPreview("start", v)} onCommit={(v) => onTrimCommit("start", v)} />
+      <TrimHandle side="right" edgeTime={clip.start + clip.duration} pxPerSecond={pxPerSecond}
+        onPreview={(v) => onTrimPreview("end", v)} onCommit={(v) => onTrimCommit("end", v)} />
+
       <p className="truncate text-[9px] font-semibold leading-3 text-[#e8eef8]">{label}</p>
       <p className="font-mono text-[8px] text-[#8d9ab0]">{fmtDur(clip.duration)}</p>
       <button
         onPointerDown={(e) => e.stopPropagation()}
         onClick={onRemove}
         aria-label="Clip entfernen"
-        className="absolute right-0.5 top-0.5 hidden rounded-[2px] bg-black/60 p-0.5 text-zinc-300 hover:text-white group-hover:block">
+        className="absolute right-1.5 top-0.5 z-20 hidden rounded-[2px] bg-black/60 p-0.5 text-zinc-300 hover:text-white group-hover:block">
         <X size={9} />
       </button>
     </div>

--- a/frontend/src/features/cockpit/media/videocut/TimelineCursors.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TimelineCursors.tsx
@@ -1,0 +1,42 @@
+import type { PointerEvent } from "react"
+
+interface Props {
+  laneOffsetCss: string
+  playheadLeft: number
+  cursorLeft: number
+  onPlayheadPointerDown: (e: PointerEvent) => void
+  onCursorPointerDown: (e: PointerEvent) => void
+  playheadDragging: boolean
+  cursorDragging: boolean
+}
+
+/** Die beiden ziehbaren Linien über den Spuren: orange Playhead (Wiedergabe)
+ *  und roter Cut-Cursor (Justage der Input-Monitore). */
+export function TimelineCursors({
+  laneOffsetCss, playheadLeft, cursorLeft,
+  onPlayheadPointerDown, onCursorPointerDown, playheadDragging, cursorDragging,
+}: Props) {
+  return (
+    <>
+      {/* Playhead-Linie (Wiedergabe) — Griff oben ziehbar zum Vor-/Zurückscrollen */}
+      <div className="absolute inset-y-0 z-10 w-px bg-[#ffb86b]" style={{ left: `calc(${laneOffsetCss} + ${playheadLeft}px)` }}>
+        <div
+          onPointerDown={onPlayheadPointerDown}
+          title="Abspielposition ziehen"
+          className={["absolute -top-1.5 -left-[6px] h-3.5 w-3.5 cursor-ew-resize touch-none rounded-[2px] bg-[#ffb86b] shadow",
+            playheadDragging ? "ring-2 ring-[#ffd9a8]" : ""].join(" ")}
+        />
+      </div>
+
+      {/* Roter Cut-Cursor (Justage) — ziehbar */}
+      <div className="absolute inset-y-0 z-20 w-[2px] touch-none bg-rose-500" style={{ left: `calc(${laneOffsetCss} + ${cursorLeft}px)` }}>
+        <div
+          onPointerDown={onCursorPointerDown}
+          title="Cut-Cursor ziehen"
+          className={["absolute -top-1 -left-[6px] h-3 w-3.5 cursor-ew-resize rounded-[2px] bg-rose-500 shadow",
+            cursorDragging ? "ring-2 ring-rose-300" : ""].join(" ")}
+        />
+      </div>
+    </>
+  )
+}

--- a/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
+++ b/frontend/src/features/cockpit/media/videocut/TrackArea.tsx
@@ -4,6 +4,7 @@ import type { MediaAssetReference } from "../../mediaProjectsApi"
 import type { MediaTimeline } from "../../mediaWorkspaceApi"
 import { ClipBlock } from "./ClipBlock"
 import { CutPointMarker } from "./CutPointMarker"
+import { TimelineCursors } from "./TimelineCursors"
 import { useDragX } from "./useDragX"
 import { useElementWidth } from "./useElementWidth"
 import { CUT_TRACKS } from "./useCutTimeline"
@@ -24,6 +25,9 @@ interface Props {
   /** Clip-Verschieben: live (preview) + persistiert (commit). */
   onClipPreview: (trackId: string, clipId: string, start: number) => void
   onClipCommit: (trackId: string, clipId: string, start: number) => void
+  /** Clip-Trimmen: Kante live (preview) + persistiert (commit). */
+  onClipTrimPreview: (trackId: string, clipId: string, edge: "start" | "end", value: number) => void
+  onClipTrimCommit: (trackId: string, clipId: string, edge: "start" | "end", value: number) => void
   /** Schnittpunkte: live verschieben (preview) + persistiert (commit) + löschen. */
   onCutPreview: (cutId: string, time: number) => void
   onCutCommit: (cutId: string, time: number) => void
@@ -49,6 +53,7 @@ const GAP = 8
 export function TrackArea({
   timeline, assets, onRemoveClip, currentTime, onSeek, onScrubStart,
   cursorTime, onCursorChange, onClipPreview, onClipCommit,
+  onClipTrimPreview, onClipTrimCommit,
   onCutPreview, onCutCommit, onCutRemove, selectedCutId, onSelectCut,
 }: Props) {
   const assetLabel = useMemo(() => new Map(assets.map((a) => [a.id, a.label])), [assets])
@@ -142,6 +147,8 @@ export function TrackArea({
                       snapTargets={def.kind === "video" ? [...clipEdges, cursorTime] : [0, cursorTime]}
                       onPreview={(start) => onClipPreview(def.id, clip.id, start)}
                       onCommit={(start) => onClipCommit(def.id, clip.id, start)}
+                      onTrimPreview={(edge, value) => onClipTrimPreview(def.id, clip.id, edge, value)}
+                      onTrimCommit={(edge, value) => onClipTrimCommit(def.id, clip.id, edge, value)}
                       onRemove={() => onRemoveClip(def.id, clip.id)}
                     />
                   ))}
@@ -166,31 +173,15 @@ export function TrackArea({
             />
           ))}
 
-          {/* Playhead-Linie (Wiedergabe) — Griff oben ziehbar zum Vor-/Zurückscrollen */}
-          <div
-            className="absolute inset-y-0 z-10 w-px bg-[#ffb86b]"
-            style={{ left: `calc(${LABEL_COL}px + ${GAP}px + ${playheadLeft}px)` }}
-          >
-            <div
-              onPointerDown={onPlayheadPointerDown}
-              title="Abspielposition ziehen"
-              className={["absolute -top-1.5 -left-[6px] h-3.5 w-3.5 cursor-ew-resize touch-none rounded-[2px] bg-[#ffb86b] shadow",
-                playheadDrag.dragging ? "ring-2 ring-[#ffd9a8]" : ""].join(" ")}
-            />
-          </div>
-
-          {/* Roter Cut-Cursor (Justage) — ziehbar */}
-          <div
-            className="absolute inset-y-0 z-20 w-[2px] touch-none bg-rose-500"
-            style={{ left: `calc(${LABEL_COL}px + ${GAP}px + ${cursorLeft}px)` }}
-          >
-            <div
-              onPointerDown={onCursorPointerDown}
-              className={["absolute -top-1 -left-[6px] h-3 w-3.5 cursor-ew-resize rounded-[2px] bg-rose-500 shadow",
-                cursorDrag.dragging ? "ring-2 ring-rose-300" : ""].join(" ")}
-              title="Cut-Cursor ziehen"
-            />
-          </div>
+          <TimelineCursors
+            laneOffsetCss={`${LABEL_COL}px + ${GAP}px`}
+            playheadLeft={playheadLeft}
+            cursorLeft={cursorLeft}
+            onPlayheadPointerDown={onPlayheadPointerDown}
+            onCursorPointerDown={onCursorPointerDown}
+            playheadDragging={playheadDrag.dragging}
+            cursorDragging={cursorDrag.dragging}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/features/cockpit/media/videocut/timelineOps.ts
+++ b/frontend/src/features/cockpit/media/videocut/timelineOps.ts
@@ -88,3 +88,66 @@ export function patchCut(tl: MediaTimeline, cutId: string, patch: Partial<MediaC
 export function removeCut(tl: MediaTimeline, cutId: string): MediaTimeline {
   return { ...tl, cut_points: (tl.cut_points ?? []).filter((cp) => cp.id !== cutId) }
 }
+
+export const MIN_CLIP_DURATION = 0.1
+
+/** Teilt einen Clip an der absoluten Timeline-Sekunde t in zwei Clips.
+ *  Liegt t nicht echt im Clip-Inneren (mit Mindestabstand), bleibt tl unverändert. */
+export function splitClipAt(tl: MediaTimeline, trackId: string, clipId: string, t: number): MediaTimeline {
+  return {
+    ...tl,
+    tracks: tl.tracks.map((track) => {
+      if (track.id !== trackId) return track
+      const clips = track.clips.flatMap((c) => {
+        if (c.id !== clipId) return [c]
+        const offset = t - c.start
+        if (offset < MIN_CLIP_DURATION || offset > c.duration - MIN_CLIP_DURATION) return [c]
+        const left = { ...c, duration: offset }
+        const right = {
+          ...c,
+          id: genId("clip"),
+          start: t,
+          source_in: (c.source_in ?? 0) + offset,
+          duration: c.duration - offset,
+        }
+        return [left, right]
+      })
+      return { ...track, clips }
+    }),
+  }
+}
+
+/** Trimmt eine Clip-Kante. edge="start": linke Kante auf newStart (Timeline-Sek);
+ *  edge="end": rechte Kante auf newEnd. Hält Mindestdauer und source_in ≥ 0 ein. */
+export function trimClipEdge(
+  tl: MediaTimeline,
+  trackId: string,
+  clipId: string,
+  edge: "start" | "end",
+  value: number,
+): MediaTimeline {
+  return {
+    ...tl,
+    tracks: tl.tracks.map((track) => {
+      if (track.id !== trackId) return track
+      return {
+        ...track,
+        clips: track.clips.map((c) => {
+          if (c.id !== clipId) return c
+          if (edge === "end") {
+            const duration = Math.max(MIN_CLIP_DURATION, value - c.start)
+            return { ...c, duration }
+          }
+          // edge === "start": linke Kante verschieben, source_in mitziehen.
+          const sourceIn = c.source_in ?? 0
+          const maxStart = c.start + c.duration - MIN_CLIP_DURATION
+          // delta so begrenzen, dass source_in ≥ 0 bleibt.
+          let newStart = Math.min(value, maxStart)
+          let delta = newStart - c.start
+          if (sourceIn + delta < 0) { delta = -sourceIn; newStart = c.start + delta }
+          return { ...c, start: Math.max(0, newStart), source_in: sourceIn + delta, duration: c.duration - delta }
+        }),
+      }
+    }),
+  }
+}

--- a/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
+++ b/frontend/src/features/cockpit/media/videocut/useCutTimeline.ts
@@ -4,7 +4,8 @@ import type { MediaCutPoint, MediaTimeline } from "../../mediaWorkspaceApi"
 import { ensureAssetRef, ensureCutProject, loadTimelineAndAssets, saveTimeline, type LibraryItem } from "./api"
 import {
   addCut, appendClip, AUDIO_FALLBACK_DURATION, CUT_TRACKS, IMAGE_DEFAULT_DURATION,
-  patchCut, probeDuration, removeClipFrom, removeCut, setClipStart, withDefaultTracks,
+  patchCut, probeDuration, removeClipFrom, removeCut, setClipStart,
+  splitClipAt, trimClipEdge, withDefaultTracks,
 } from "./timelineOps"
 
 // Re-Export für bestehende Importe (TrackArea, ClipLibrary, InputMonitor …).
@@ -79,6 +80,30 @@ export function useCutTimeline(projectId: string) {
     if (timeline) void persist(setClipStart(timeline, trackId, clipId, start))
   }, [timeline, persist])
 
+  /** Trimmt eine Clip-Kante lokal (ohne PUT) — für flüssiges Ziehen. */
+  const previewClipTrim = useCallback((trackId: string, clipId: string, edge: "start" | "end", value: number) => {
+    setTimeline((cur) => (cur ? trimClipEdge(cur, trackId, clipId, edge, value) : cur))
+  }, [])
+
+  const trimClip = useCallback((trackId: string, clipId: string, edge: "start" | "end", value: number) => {
+    if (timeline) void persist(trimClipEdge(timeline, trackId, clipId, edge, value))
+  }, [timeline, persist])
+
+  /** Teilt alle Video-Clips, die an der Zeit t liegen, in zwei. */
+  const splitAt = useCallback((t: number) => {
+    if (!timeline) return
+    let next = timeline
+    for (const track of timeline.tracks) {
+      if (track.kind !== "video") continue
+      for (const clip of track.clips) {
+        if (t > clip.start && t < clip.start + clip.duration) {
+          next = splitClipAt(next, track.id, clip.id, t)
+        }
+      }
+    }
+    if (next !== timeline) void persist(next)
+  }, [timeline, persist])
+
   /** Fügt am Zeitpunkt time einen Schnittpunkt hinzu und gibt dessen ID zurück. */
   const addCutPoint = useCallback((time: number): string | null => {
     if (!timeline) return null
@@ -108,6 +133,7 @@ export function useCutTimeline(projectId: string) {
   return {
     timeline, assets, loading, saving, error,
     addClip, removeClip, previewClipStart, moveClip,
+    previewClipTrim, trimClip, splitAt,
     addCutPoint, previewCutPoint, moveCutPoint, updateCutPoint, removeCutPoint,
   }
 }


### PR DESCRIPTION
## Videoschnitt: Trim & Split (Feinschnitt)

Der letzte fehlende Kernbaustein des Schnittpults: Clips kürzen und teilen. Rein Frontend — das Datenmodell (`start`/`duration`/`source_in`) reicht, **kein Backend-Change**.

### Split
Button **„Am Playhead teilen"** in der Transport-Leiste schneidet alle Video-Clips, die an der Playhead-Position liegen, in zwei — `source_in`/`duration` werden korrekt umgerechnet (Clip B startet mitten in der Quelle weiter).

### Trim
Schmale **Handles an beiden Clip-Kanten** (erscheinen beim Hover):
- linke Kante ziehen → `start` + `source_in` wandern mit, `duration` gegenläufig
- rechte Kante ziehen → nur `duration`
- Mindestdauer 0,1 s; `source_in` wird bei 0 geklemmt (nicht ins Negative)

Der bestehende Body-Drag (Verschieben) bleibt; die Kanten-Handles haben Vorrang.

### Verifikation
- ✅ Reine Ops `splitClipAt` / `trimClipEdge` per **Sanity-Check** verifiziert (18 Assertions: Split-Positionen inkl. Noop außerhalb, Trim beider Kanten, Clamping bei `source_in=0` und Mindestdauer)
- ✅ tsc / eslint / build grün

### Refactor
Playhead + Cut-Cursor nach `TimelineCursors.tsx` ausgelagert → `TrackArea` bleibt unter der 200-Zeilen-Grenze (204 → 189).

Spec: `docs/specs/videocut-trim-split.md`. Damit ist das Schnittpult funktional vollständig: Bibliothek → Spuren → verschieben/überlappen → **trimmen/teilen** → Schnittpunkte → Übergänge → Preview → Export.
