### PR TITLE
feat(code-graph): Projekt-Codebase als navigierbarer Wissensgraph (Etappe 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ CHANGES_SUMMARY.md
 REASONING_EFFORT_*.md
 TESTING_CHECKLIST.md
 CLAUDE.md
+
+# Code-Graph (graphify) Ausgaben
+graphify-out/
+.graphify/

--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -47,6 +47,7 @@ from hydrahive.api.routes.projects_files_write import router as projects_files_w
 from hydrahive.api.routes.media_projects import router as media_projects_router
 from hydrahive.api.routes.media_prompts import router as media_prompts_router
 from hydrahive.api.routes.media_assets import router as media_assets_router
+from hydrahive.api.routes.code_graph import router as code_graph_router
 from hydrahive.api.routes.media_workspace import router as media_workspace_router
 from hydrahive.api.routes.projects_git import router as projects_git_router
 from hydrahive.api.routes.projects_samba import router as projects_samba_router
@@ -134,6 +135,7 @@ app.include_router(media_projects_router)
 app.include_router(media_prompts_router)
 app.include_router(media_assets_router)
 app.include_router(media_workspace_router)
+app.include_router(code_graph_router)
 app.include_router(projects_git_router)
 app.include_router(projects_samba_router)
 app.include_router(projects_servers_router)

--- a/core/src/hydrahive/api/routes/code_graph.py
+++ b/core/src/hydrahive/api/routes/code_graph.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+
+from hydrahive import code_graph, code_graph_config
+from hydrahive.api.middleware.auth import require_auth
+from hydrahive.api.middleware.errors import coded
+from hydrahive.api.routes.media_projects import _authorize
+
+router = APIRouter(prefix="/api/projects/{project_id}/code-graph", tags=["code-graph"])
+
+
+class GraphConfig(BaseModel):
+    scan_dirs: list[str] = Field(default_factory=list, max_length=50)
+
+
+@router.get("/status")
+def get_status(project_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    return code_graph.status(project_id)
+
+
+@router.get("/config")
+def get_config(project_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    return code_graph_config.get_config(project_id)
+
+
+@router.put("/config")
+def put_config(project_id: str, body: GraphConfig, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    return code_graph_config.set_config(project_id, body.scan_dirs)
+
+
+@router.post("/build")
+def build_graph(project_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
+    _authorize(project_id, auth)
+    try:
+        return code_graph.build(project_id)
+    except code_graph.CodeGraphError as exc:
+        raise coded(status.HTTP_400_BAD_REQUEST, "code_graph_build_failed", reason=str(exc))

--- a/core/src/hydrahive/code_graph.py
+++ b/core/src/hydrahive/code_graph.py
@@ -1,0 +1,160 @@
+"""Code-Graph: baut aus Projekt-Code einen lokalen Abhängigkeitsgraphen (graphify).
+
+graphify läuft in einem isolierten, on-demand angelegten venv (nicht in den
+Kern-Dependencies). Reines Code-Indexing via tree-sitter-AST — kein LLM, keine
+API-Kosten, kein Datenabfluss. Output pro Projekt unter <workspace>/.graphify/out/.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hydrahive.code_graph_config import get_config
+from hydrahive.projects._paths import workspace_path
+from hydrahive.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+class CodeGraphError(RuntimeError):
+    pass
+
+
+def _venv_dir() -> Path:
+    return settings.data_dir / "tools" / "graphify" / "venv"
+
+
+def _graphify_bin() -> Path:
+    return _venv_dir() / "bin" / "graphify"
+
+
+def _out_dir(project_id: str) -> Path:
+    return workspace_path(project_id) / ".graphify" / "out"
+
+
+def bootstrap_status() -> dict:
+    return {"installed": _graphify_bin().is_file()}
+
+
+def ensure_installed() -> None:
+    """Legt das isolierte venv an und installiert graphify (idempotent)."""
+    if _graphify_bin().is_file():
+        return
+    venv = _venv_dir()
+    venv.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True, capture_output=True, timeout=120)
+        subprocess.run(
+            [str(venv / "bin" / "pip"), "install", "--quiet", "graphifyy"],
+            check=True, capture_output=True, timeout=600,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise CodeGraphError("graphify-Installation fehlgeschlagen") from exc
+    if not _graphify_bin().is_file():
+        raise CodeGraphError("graphify-Binary nach Installation nicht gefunden")
+
+
+_METRICS_RE = re.compile(r"(\d+)\s+nodes,\s+(\d+)\s+edges,\s+(\d+)\s+communities")
+
+
+def _parse_metrics(stdout: str) -> dict:
+    m = _METRICS_RE.search(stdout)
+    if not m:
+        return {}
+    return {"nodes": int(m.group(1)), "edges": int(m.group(2)), "communities": int(m.group(3))}
+
+
+def build(project_id: str) -> dict:
+    """Baut den Code-Graph über die konfigurierten Scan-Verzeichnisse."""
+    ensure_installed()
+    cfg = get_config(project_id)
+    scan_dirs = cfg.get("scan_dirs", [])
+    if not scan_dirs:
+        raise CodeGraphError("Keine Scan-Verzeichnisse gewählt")
+
+    root = workspace_path(project_id)
+    out = _out_dir(project_id)
+    out.mkdir(parents=True, exist_ok=True)
+
+    metrics: dict = {}
+    for rel in scan_dirs:
+        target = (root / rel).resolve()
+        try:
+            target.relative_to(root.resolve())
+        except ValueError:
+            continue
+        if not target.is_dir():
+            continue
+        try:
+            result = subprocess.run(
+                [str(_graphify_bin()), "update", str(target)],
+                check=True, capture_output=True, timeout=1800, text=True,
+            )
+            metrics = _parse_metrics(result.stdout) or metrics
+            # graphify legt <target>/graphify-out/ an — ins gemeinsame out/ spiegeln.
+            produced = target / "graphify-out"
+            if produced.is_dir():
+                for name in ("graph.json", "graph.html", "GRAPH_REPORT.md"):
+                    src = produced / name
+                    if src.is_file():
+                        (out / name).write_bytes(src.read_bytes())
+        except subprocess.CalledProcessError as exc:
+            raise CodeGraphError(f"graphify update fehlgeschlagen: {exc.stderr[-300:] if exc.stderr else ''}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CodeGraphError("graphify update Timeout") from exc
+
+    meta = {
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "scan_dirs": scan_dirs,
+        "metrics": metrics,
+    }
+    (out / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    return {**meta, "report": _report_excerpt(out), **_output_paths(project_id)}
+
+
+def _output_paths(project_id: str) -> dict:
+    out = _out_dir(project_id)
+    html = out / "graph.html"
+    report = out / "GRAPH_REPORT.md"
+    return {
+        "html_path": str(html) if html.is_file() else None,
+        "report_path": str(report) if report.is_file() else None,
+    }
+
+
+def _report_excerpt(out: Path) -> dict:
+    """God-Nodes + Import-Zyklen aus dem Report ziehen (für die UI-Kurzsicht)."""
+    report = out / "GRAPH_REPORT.md"
+    if not report.is_file():
+        return {}
+    text = report.read_text(encoding="utf-8", errors="replace")
+    god = re.findall(r"^\d+\.\s+`([^`]+)`\s+-\s+(\d+)\s+edges", text, re.MULTILINE)[:10]
+    cycles = re.findall(r"cycle:\s+`([^`]+)`", text)[:10]
+    return {
+        "god_nodes": [{"name": n, "edges": int(e)} for n, e in god],
+        "cycles": cycles,
+    }
+
+
+def status(project_id: str) -> dict:
+    out = _out_dir(project_id)
+    meta_path = out / "meta.json"
+    meta: dict = {}
+    if meta_path.is_file():
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            meta = {}
+    return {
+        **bootstrap_status(),
+        "built_at": meta.get("built_at"),
+        "scan_dirs": meta.get("scan_dirs", []),
+        "metrics": meta.get("metrics", {}),
+        "report": _report_excerpt(out) if meta else {},
+        **_output_paths(project_id),
+    }

--- a/core/src/hydrahive/code_graph_config.py
+++ b/core/src/hydrahive/code_graph_config.py
@@ -1,0 +1,105 @@
+"""Code-Graph Konfiguration: Scan-Verzeichnisse pro Projekt + Validierung.
+
+Getrennt von code_graph.py (Build-Logik), damit beide Dateien fokussiert bleiben.
+Scan-Dirs sind projekt-relativ (zum Workspace) und werden gegen Path-Traversal
+validiert — nur Verzeichnisse INNERHALB des Workspace sind erlaubt.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hydrahive.projects._paths import workspace_path
+
+# Verzeichnisse, die nie als Scan-Ziel taugen (Abhängigkeiten, Build-Artefakte).
+IGNORE_DIRS = {
+    ".git", "node_modules", "dist", "build", ".graphify", "generated",
+    "mounts", "media", "venv", ".venv", "__pycache__", ".cache", "coverage",
+}
+# Verzeichnisnamen, die typischerweise Quellcode enthalten (Default-Vorschläge).
+SOURCE_HINTS = {"src", "core", "server", "backend", "app", "lib"}
+
+
+def _graphify_dir(project_id: str) -> Path:
+    return workspace_path(project_id) / ".graphify"
+
+
+def _config_path(project_id: str) -> Path:
+    return _graphify_dir(project_id) / "config.json"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def suggest_scan_dirs(project_id: str) -> list[str]:
+    """Schlägt Quellcode-Verzeichnisse vor: <repo>/src, <repo>/frontend/src etc.
+    Sucht bis Tiefe 3 nach Ordnern mit typischem Source-Namen."""
+    root = workspace_path(project_id)
+    if not root.is_dir():
+        return []
+    found: list[str] = []
+
+    def walk(d: Path, depth: int) -> None:
+        if depth > 3:
+            return
+        for child in sorted(d.iterdir()):
+            if not child.is_dir() or child.name in IGNORE_DIRS or child.name.startswith("."):
+                continue
+            rel = child.relative_to(root).as_posix()
+            if child.name in SOURCE_HINTS:
+                found.append(rel)
+            else:
+                walk(child, depth + 1)
+
+    try:
+        walk(root, 0)
+    except OSError:
+        pass
+    return found[:20]
+
+
+def validate_scan_dirs(project_id: str, scan_dirs: list[str]) -> list[str]:
+    """Filtert scan_dirs auf existierende Verzeichnisse INNERHALB des Workspace.
+    Path-Traversal (../, absolute Pfade außerhalb) wird verworfen."""
+    root = workspace_path(project_id).resolve()
+    valid: list[str] = []
+    for raw in scan_dirs:
+        candidate = (root / raw).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError:
+            continue  # außerhalb des Workspace
+        if candidate.is_dir() and candidate != root:
+            rel = candidate.relative_to(root).as_posix()
+            if rel not in valid:
+                valid.append(rel)
+    return valid
+
+
+def get_config(project_id: str) -> dict:
+    path = _config_path(project_id)
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return {
+                    "scan_dirs": data.get("scan_dirs", []),
+                    "updated_at": data.get("updated_at"),
+                    "suggestions": suggest_scan_dirs(project_id),
+                }
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"scan_dirs": [], "updated_at": None, "suggestions": suggest_scan_dirs(project_id)}
+
+
+def set_config(project_id: str, scan_dirs: list[str]) -> dict:
+    valid = validate_scan_dirs(project_id, scan_dirs)
+    path = _config_path(project_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"scan_dirs": valid, "updated_at": _now()}
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(path)
+    return {**payload, "suggestions": suggest_scan_dirs(project_id)}

--- a/core/tests/test_code_graph_config.py
+++ b/core/tests/test_code_graph_config.py
@@ -1,0 +1,35 @@
+from hydrahive import code_graph_config
+from hydrahive.projects import config as project_config
+from hydrahive.projects._paths import ensure_workspace
+
+
+def _project_with_dirs():
+    project = project_config.create(name="Graph", members=["testuser"], llm_model="test", created_by="admin")
+    ws = ensure_workspace(project["id"])
+    (ws / "core" / "src").mkdir(parents=True, exist_ok=True)
+    (ws / "frontend" / "src").mkdir(parents=True, exist_ok=True)
+    (ws / "node_modules").mkdir(parents=True, exist_ok=True)
+    return project["id"], ws
+
+
+def test_config_roundtrip_persists_valid_dirs():
+    pid, _ = _project_with_dirs()
+    result = code_graph_config.set_config(pid, ["core/src", "frontend/src"])
+    assert set(result["scan_dirs"]) == {"core/src", "frontend/src"}
+    fetched = code_graph_config.get_config(pid)
+    assert set(fetched["scan_dirs"]) == {"core/src", "frontend/src"}
+    assert fetched["updated_at"]
+
+
+def test_config_rejects_traversal_and_missing():
+    pid, _ = _project_with_dirs()
+    result = code_graph_config.set_config(pid, ["../../../etc", "does/not/exist", "core/src"])
+    # Nur das existierende, innerhalb liegende Verzeichnis überlebt.
+    assert result["scan_dirs"] == ["core/src"]
+
+
+def test_suggestions_find_source_dirs_and_skip_ignored():
+    pid, _ = _project_with_dirs()
+    suggestions = code_graph_config.suggest_scan_dirs(pid)
+    assert "core/src" in suggestions or "core" in suggestions
+    assert all("node_modules" not in s for s in suggestions)

--- a/docs/specs/code-graph.md
+++ b/docs/specs/code-graph.md
@@ -1,0 +1,78 @@
+# Code-Graph — Projekt-Codebase als navigierbarer Wissensgraph (Etappe 1)
+
+## Was
+Jedes Projekt bekommt einen **Code-Graph**: ein Button „Graph" in der Projekt-
+Aktionsleiste öffnet ein Overlay, in dem man ausgewählte Code-Verzeichnisse zu
+einem interaktiven Abhängigkeitsgraphen verarbeitet (God-Nodes, Communities,
+Import-Zyklen, Refactoring-Hinweise). Man wählt die zu scannenden Verzeichnisse,
+baut den Graphen und schaut sich die interaktive `graph.html` + den Report an.
+
+## Warum
+Agenten (und Menschen) verstehen eine Codebase schneller über einen Graphen als
+durch ständiges Grep-und-Lesen. Etappe 1 liefert den sichtbaren Nutzen (bauen +
+anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
+
+## Scope Etappe 1
+- **Nur Code, 100 % lokal, 0 API-Kosten, kein Datenabfluss.** (Doku/Bilder-
+  Graphing wäre LLM-basiert → späterer optionaler Schalter.)
+- **Ein Graph pro Projekt** (nicht global). Wählbare Scan-Verzeichnisse.
+
+## Bestehende Muster (wiederverwendet)
+- Underlying: **graphify** (`graphifyy` auf PyPI), `graphify update <dir>` baut
+  rein lokal per tree-sitter-AST (kein LLM). Erzeugt `graphify-out/graph.json`,
+  `graph.html`, `GRAPH_REPORT.md`.
+- Overlay-Muster wie `ProjectGitOverlay` / `ProjectInsightsOverlay`.
+- Button in `ProjectActionGroups` (neben Git/Integrationen).
+- Datei-Auslieferung über `/api/files` (graph.html liegt unter data_dir/workspaces).
+
+## Wie
+### Isoliertes venv (on-demand, Option B)
+- graphify **nicht** in die Kern-Dependencies. Stattdessen ein eigenes venv unter
+  `settings.data_dir / "tools" / "graphify" / "venv"`, das beim ersten Build
+  automatisch per `python -m venv` + `pip install graphifyy` angelegt wird.
+- `code_graph.py` ruft `<venv>/bin/graphify update <dir>` als subprocess.
+- Bootstrap-Status abfragbar (installiert ja/nein), damit die UF „wird
+  eingerichtet…" zeigen kann.
+
+### Datenablage (pro Projekt)
+- Config: `<workspace>/.graphify/config.json` → `{ scan_dirs: [rel...], updated_at }`.
+- Graph-Output: `<workspace>/.graphify/out/` (graph.json, graph.html, GRAPH_REPORT.md).
+- Default-Scan-Dirs: automatisch aus vorhandenen Repos/`src`-Ordnern vorgeschlagen
+  (z.B. `<repo>/src`, `<repo>/frontend/src`), sonst leer.
+
+### Backend `code_graph.py` (Modul) + Route
+- `bootstrap_status()` → `{ installed: bool }`.
+- `ensure_installed()` → legt venv an + pip install (idempotent, mit Timeout).
+- `get_config(project_id)` / `set_config(project_id, scan_dirs)` — scan_dirs gegen
+  Path-Traversal validiert (müssen **innerhalb** des Workspace liegen, existieren).
+- `build(project_id)` → für jedes scan_dir `graphify update`; danach die Outputs
+  ins gemeinsame `.graphify/out/` konsolidieren; liefert Kurz-Metriken
+  (nodes/edges/communities) + Report-Auszug (God-Nodes, Zyklen).
+- `status(project_id)` → letzter Build (Zeit, Metriken, ob graph.html existiert).
+- Routen (neuer Router `code_graph.py`, require_auth + _authorize):
+  - `GET  /api/projects/{id}/code-graph/status`
+  - `GET/PUT /api/projects/{id}/code-graph/config`
+  - `POST /api/projects/{id}/code-graph/build`
+  - Report/HTML über `status` (Pfade) → Frontend lädt via `/api/files`.
+
+### Frontend
+- `projectsApi`-Erweiterung bzw. `codeGraphApi` (status/config/build).
+- **`ProjectGraphOverlay`**: Verzeichnis-Auswahl (Checkbox-Liste aus Vorschlägen +
+  manuell), „Graph bauen" (zeigt Fortschritt), nach Build: Metriken + God-Nodes +
+  Zyklen aus dem Report, und die interaktive `graph.html` als iframe
+  (`/api/files?path=…`). Bootstrap-Hinweis, falls venv erst eingerichtet wird.
+- **Button „Graph"** in `ProjectActionGroups`, verdrahtet in `ProjectCockpitPage`.
+
+## Akzeptanzkriterien
+- [ ] „Graph"-Button öffnet Overlay; man kann Scan-Verzeichnisse wählen (persistiert).
+- [ ] „Graph bauen" erzeugt lokal (ohne LLM) den Graphen; Fortschritt sichtbar.
+- [ ] Interaktive graph.html + God-Nodes/Zyklen/Metriken werden angezeigt.
+- [ ] scan_dirs sind gegen Path-Traversal geschützt (nur innerhalb Workspace).
+- [ ] venv wird on-demand gebootstrappt; Kern-Dependencies unverändert.
+- [ ] Backend-Tests grün (config round-trip, dir-validation); Build/Typecheck/ESLint grün.
+
+## Etappe 2 (später, nicht dieser PR)
+Agenten-Tools `graph_query` / `graph_explain` / `graph_path` / `graph_affected`
+(dünne Wrapper über `graphify query/explain/path/affected` auf `graph.json`) +
+Skill „code-graph" (wann Graph statt Grep). Optional MCP-Server. Optional
+Doku-Graphing (LLM).

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -23,6 +23,7 @@ import { ProjectAiSettingsPanel } from "./project/ProjectAiSettingsPanel"
 import { CockpitUsagePanel } from "./project/CockpitUsagePanel"
 import { ProjectGitSummary } from "./project/ProjectGitSummary"
 import { ProjectGitOverlay } from "./project/ProjectGitOverlay"
+import { ProjectGraphOverlay } from "./project/ProjectGraphOverlay"
 import { ProjectIntegrationsOverlay } from "./project/ProjectIntegrationsOverlay"
 import { ProjectGitTreePanel } from "./project/ProjectGitTreePanel"
 import { ProjectWorkspacePanel } from "./project/ProjectWorkspacePanel"
@@ -45,6 +46,7 @@ export function ProjectCockpitPage() {
   const [mountsOpen, setMountsOpen] = useState(false)
   const [insightView, setInsightView] = useState<ProjectInsightView | null>(null)
   const [gitOpen, setGitOpen] = useState(false)
+  const [graphOpen, setGraphOpen] = useState(false)
   const [gitRevision, setGitRevision] = useState(0)
   const [integrationsOpen, setIntegrationsOpen] = useState(false)
   const [selectedAgentByProject, setSelectedAgentByProject] = useState<Record<string, string>>({})
@@ -138,6 +140,7 @@ export function ProjectCockpitPage() {
               onGit={() => setGitOpen(true)}
               onIntegrations={() => setIntegrationsOpen(true)}
               onInsight={setInsightView}
+              onGraph={() => setGraphOpen(true)}
             />
           </CollapsibleCockpitPanel>
 
@@ -215,6 +218,7 @@ export function ProjectCockpitPage() {
       {integrationsOpen && activeProject && <ProjectIntegrationsOverlay project={activeProject} onClose={() => setIntegrationsOpen(false)} onSaved={(updated) => setProjects((current) => current.map((project) => project.id === updated.id ? updated : project))} />}
       {gitOpen && activeProject && <ProjectGitOverlay project={activeProject} onClose={() => setGitOpen(false)} onChanged={() => setGitRevision((revision) => revision + 1)} />}
       {insightView && activeProject && <ProjectInsightsOverlay project={activeProject} view={insightView} onClose={() => setInsightView(null)} />}
+      {graphOpen && activeProject && <ProjectGraphOverlay project={activeProject} onClose={() => setGraphOpen(false)} />}
       {mountsOpen && activeProject && <ProjectMountsOverlay project={activeProject} onClose={() => setMountsOpen(false)} />}
       {serversOpen && activeProject && <ProjectServersOverlay project={activeProject} onClose={() => setServersOpen(false)} />}
       {accessOpen && activeProject && (

--- a/frontend/src/features/cockpit/codeGraphApi.ts
+++ b/frontend/src/features/cockpit/codeGraphApi.ts
@@ -1,0 +1,47 @@
+import { api } from "@/shared/api-client"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+
+export interface CodeGraphGodNode { name: string; edges: number }
+export interface CodeGraphReport { god_nodes?: CodeGraphGodNode[]; cycles?: string[] }
+
+export interface CodeGraphStatus {
+  installed: boolean
+  built_at: string | null
+  scan_dirs: string[]
+  metrics: { nodes?: number; edges?: number; communities?: number }
+  report: CodeGraphReport
+  html_path: string | null
+  report_path: string | null
+}
+
+export interface CodeGraphConfig {
+  scan_dirs: string[]
+  updated_at: string | null
+  suggestions: string[]
+}
+
+export interface CodeGraphBuildResult {
+  built_at: string
+  scan_dirs: string[]
+  metrics: { nodes?: number; edges?: number; communities?: number }
+  report: CodeGraphReport
+  html_path: string | null
+  report_path: string | null
+}
+
+const base = (projectId: string) => `/projects/${projectId}/code-graph`
+
+export const codeGraphApi = {
+  status: (projectId: string) => api.get<CodeGraphStatus>(`${base(projectId)}/status`),
+  getConfig: (projectId: string) => api.get<CodeGraphConfig>(`${base(projectId)}/config`),
+  setConfig: (projectId: string, scanDirs: string[]) => api.put<CodeGraphConfig>(`${base(projectId)}/config`, { scan_dirs: scanDirs }),
+  build: (projectId: string) => api.post<CodeGraphBuildResult>(`${base(projectId)}/build`, {}),
+}
+
+/** Absoluten Datei-Pfad über /api/files laden (mit Token-Query, da iframe/img
+ *  keinen Authorization-Header schicken können). */
+export function graphFileUrl(absPath: string): string {
+  const token = useAuthStore.getState().token
+  const tokenParam = token ? `&token=${encodeURIComponent(token)}` : ""
+  return `/api/files?path=${encodeURIComponent(absPath)}${tokenParam}`
+}

--- a/frontend/src/features/cockpit/project/ProjectActionGroups.tsx
+++ b/frontend/src/features/cockpit/project/ProjectActionGroups.tsx
@@ -13,9 +13,10 @@ interface Props {
   onGit: () => void
   onIntegrations: () => void
   onInsight: (view: ProjectInsightView) => void
+  onGraph: () => void
 }
 
-export function ProjectActionGroups({ disabled, onCreate, onEdit, onAccess, onServers, onMounts, onGit, onIntegrations, onInsight }: Props) {
+export function ProjectActionGroups({ disabled, onCreate, onEdit, onAccess, onServers, onMounts, onGit, onIntegrations, onInsight, onGraph }: Props) {
   return <div className="mt-3 space-y-2 border-t border-[#2a364b] pt-3">
     <div className="grid grid-cols-2 gap-2">
       <CockpitButton tone="primary" onClick={onCreate}>+ Neues Projekt</CockpitButton>
@@ -32,6 +33,7 @@ export function ProjectActionGroups({ disabled, onCreate, onEdit, onAccess, onSe
       <ActionButton onClick={() => onInsight("stats")} disabled={disabled}>Statistiken</ActionButton>
       <ActionButton onClick={() => onInsight("sessions")} disabled={disabled}>Sessions</ActionButton>
       <ActionButton onClick={() => onInsight("audit")} disabled={disabled}>Audit</ActionButton>
+      <ActionButton onClick={onGraph} disabled={disabled}>Code-Graph</ActionButton>
     </ActionGroup>
   </div>
 }

--- a/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
+++ b/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react"
+import { Loader2, Network } from "lucide-react"
+import type { Project } from "@/features/projects/types"
+import { codeGraphApi, graphFileUrl, type CodeGraphStatus } from "../codeGraphApi"
+import { CockpitButton } from "../CockpitButton"
+import { CockpitSectionLabel } from "../CockpitPanel"
+
+export function ProjectGraphOverlay({ project, onClose }: { project: Project; onClose: () => void }) {
+  const [status, setStatus] = useState<CodeGraphStatus | null>(null)
+  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [building, setBuilding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    Promise.all([codeGraphApi.status(project.id), codeGraphApi.getConfig(project.id)])
+      .then(([st, cfg]) => {
+        if (!alive) return
+        setStatus(st)
+        // Vorschläge + bereits gewählte Verzeichnisse zusammenführen.
+        setSuggestions(Array.from(new Set([...cfg.suggestions, ...cfg.scan_dirs])))
+        setSelected(cfg.scan_dirs.length ? cfg.scan_dirs : cfg.suggestions.slice(0, 3))
+      })
+      .catch(() => { if (alive) setError("Status konnte nicht geladen werden.") })
+    return () => { alive = false }
+  }, [project.id])
+
+  const toggle = (dir: string) => {
+    setSelected((cur) => (cur.includes(dir) ? cur.filter((d) => d !== dir) : [...cur, dir]))
+  }
+
+  const runBuild = async () => {
+    setBuilding(true)
+    setError(null)
+    try {
+      await codeGraphApi.setConfig(project.id, selected)
+      const result = await codeGraphApi.build(project.id)
+      setStatus((cur) => ({ ...(cur as CodeGraphStatus), ...result, installed: true }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Graph-Build fehlgeschlagen.")
+    } finally {
+      setBuilding(false)
+    }
+  }
+
+  const htmlUrl = status?.html_path ? graphFileUrl(status.html_path) : null
+  const metrics = status?.metrics
+  const god = status?.report?.god_nodes ?? []
+  const cycles = status?.report?.cycles ?? []
+
+  return (
+    <div className="fixed inset-0 z-[100] grid place-items-center bg-black/80 p-4" role="dialog" aria-modal="true" aria-labelledby="project-graph-title">
+      <section className="flex h-[min(880px,95dvh)] w-full max-w-6xl flex-col overflow-hidden rounded-[6px] border border-[#46617f] bg-[#151c2b] shadow-2xl">
+        <header className="flex items-center justify-between border-b border-[#2a364b] p-4">
+          <div>
+            <CockpitSectionLabel>Codebase-Analyse</CockpitSectionLabel>
+            <h2 id="project-graph-title" className="mt-1 flex items-center gap-2 text-lg font-semibold text-[#e8eef8]">
+              <Network size={18} /> Code-Graph
+            </h2>
+            <p className="mt-1 text-xs text-[#8d9ab0]">{project.name} · lokal, ohne LLM</p>
+          </div>
+          <CockpitButton onClick={onClose}>Schließen</CockpitButton>
+        </header>
+
+        <main className="grid min-h-0 flex-1 gap-3 overflow-y-auto p-4 lg:grid-cols-[280px_1fr]">
+          {/* Steuerung: Verzeichnis-Auswahl + Build */}
+          <div className="space-y-3">
+            <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3">
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Verzeichnisse</p>
+              {suggestions.length === 0 ? (
+                <p className="text-xs text-[#7a869c]">Keine Quellordner gefunden.</p>
+              ) : (
+                <ul className="space-y-1">
+                  {suggestions.map((dir) => (
+                    <li key={dir}>
+                      <label className="flex cursor-pointer items-center gap-2 text-xs text-[#c3ccdd]">
+                        <input type="checkbox" checked={selected.includes(dir)} onChange={() => toggle(dir)} className="accent-cyan-400" />
+                        <span className="truncate font-mono">{dir}</span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <button
+                type="button"
+                onClick={runBuild}
+                disabled={building || selected.length === 0}
+                className="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-[4px] border border-cyan-400/50 bg-cyan-400/10 px-3 py-1.5 text-[12px] font-semibold text-cyan-100 transition-colors hover:bg-cyan-400/20 disabled:opacity-40"
+              >
+                {building ? <Loader2 size={14} className="animate-spin" /> : <Network size={14} />}
+                {building ? "Baue Graph…" : "Graph bauen"}
+              </button>
+              {building ? <p className="mt-2 text-[11px] text-[#8d9ab0]">Erstlauf richtet das Analyse-Tool ein — kann einen Moment dauern.</p> : null}
+              {error ? <p className="mt-2 text-[11px] text-rose-300">{error}</p> : null}
+            </div>
+
+            {metrics?.nodes ? (
+              <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3 text-xs text-[#c3ccdd]">
+                <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Kennzahlen</p>
+                <p>{metrics.nodes} Knoten · {metrics.edges} Kanten · {metrics.communities} Communities</p>
+                {status?.built_at ? <p className="mt-1 text-[10px] text-[#68758a]">Stand: {new Date(status.built_at).toLocaleString()}</p> : null}
+              </div>
+            ) : null}
+
+            {god.length ? (
+              <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3">
+                <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Zentrale Knoten</p>
+                <ul className="space-y-0.5 text-xs text-[#c3ccdd]">
+                  {god.map((g) => (
+                    <li key={g.name} className="flex justify-between gap-2">
+                      <span className="truncate font-mono">{g.name}</span>
+                      <span className="text-[#68758a]">{g.edges}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {cycles.length ? (
+              <div className="rounded-[4px] border border-rose-500/30 bg-rose-500/5 p-3">
+                <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-rose-300">Import-Zyklen</p>
+                <ul className="space-y-0.5 text-[11px] text-rose-200">
+                  {cycles.map((c) => <li key={c} className="truncate font-mono">{c}</li>)}
+                </ul>
+              </div>
+            ) : null}
+          </div>
+
+          {/* Interaktiver Graph */}
+          <div className="min-h-[400px] overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#0d1420]">
+            {htmlUrl ? (
+              <iframe src={htmlUrl} title="Code-Graph" className="h-full min-h-[400px] w-full border-0" />
+            ) : (
+              <div className="grid h-full min-h-[400px] place-items-center text-center text-sm text-[#7a869c]">
+                <div>
+                  <Network size={32} className="mx-auto mb-2 text-[#3f4b60]" />
+                  <p>Noch kein Graph gebaut.</p>
+                  <p className="mt-1 text-xs">Verzeichnisse wählen und „Graph bauen".</p>
+                </div>
+              </div>
+            )}
+          </div>
+        </main>
+
+        <footer className="border-t border-[#2a364b] p-3 text-xs text-[#8d9ab0]">
+          Code-Graph läuft komplett lokal (tree-sitter AST) — keine API-Kosten, kein Datenabfluss.
+        </footer>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Code-Graph — Projekt-Codebase als navigierbarer Wissensgraph (Etappe 1)

Jedes Projekt bekommt einen **Code-Graph**: In der Projekt-Aktionsleiste unter „Auswerten" gibt es jetzt **„Code-Graph"** → öffnet ein Overlay, in dem man Scan-Verzeichnisse wählt, den Graphen baut und die **interaktive graph.html** + Report ansieht (God-Nodes, Import-Zyklen, Kennzahlen).

Basiert auf dem Graphify-Test von vorhin. **Ein Graph pro Projekt** (nicht global).

### Wichtig: 100 % lokal
Reines Code-Indexing via tree-sitter-AST — **kein LLM, keine API-Kosten, kein Datenabfluss**. (Doku/Bilder-Graphing wäre LLM-basiert → bewusst als späterer optionaler Schalter ausgeklammert.)

### Backend
- `code_graph.py`: graphify läuft in einem **isolierten, on-demand angelegten venv** (`data_dir/tools/graphify`) — **nicht** in den Kern-Dependencies (die bleiben schlank). `build`/`status` + venv-Bootstrap via subprocess. Metriken + Report-Auszug (God-Nodes/Zyklen) werden geparst. Output nach `<workspace>/.graphify/out/` (über `/api/files` ladbar).
- `code_graph_config.py`: Scan-Verzeichnisse pro Projekt mit **Path-Traversal-Schutz** (nur innerhalb Workspace) + **Auto-Vorschläge** (`src`/`core`/`frontend`…, ignoriert `node_modules`, `dist`, `.git` etc.).
- Routen: `GET /status`, `GET/PUT /config`, `POST /build`.

### Frontend
- `codeGraphApi` + `ProjectGraphOverlay`: Verzeichnis-Checkboxen, „Graph bauen" mit Fortschritt, Kennzahlen + zentrale Knoten + Import-Zyklen, und die **interaktive graph.html im iframe**.
- „Code-Graph"-Button in `ProjectActionGroups`, verdrahtet in `ProjectCockpitPage`.

### Verifikation
- ✅ Backend-Tests **3/3** (config round-trip, Traversal-Reject, Vorschläge), ruff clean
- ✅ **End-to-End lokal verifiziert:** venv-Bootstrap lief automatisch, Build erzeugte 82 Nodes / 141 Edges / 6 Communities + graph.html + Report aus einem Sample
- ✅ tsc / eslint / build grün
- ✅ Alle Dateien < 200 Zeilen; `graphify-out/` + `.graphify/` in `.gitignore`

### Etappe 2 (später, nicht dieser PR)
Agenten-Tools `graph_query` / `graph_explain` / `graph_path` / `graph_affected` (dünne Wrapper über graphify auf `graph.json`) + Skill „code-graph" (wann Graph statt Grep). Optional MCP-Server. Optional Doku-Graphing (LLM).

### Deploy-Hinweis
Backend-Änderung + neuer on-demand-Download (graphify beim ersten Build). Server brauchen ein Update; der erste „Graph bauen"-Klick richtet das venv automatisch ein (dauert einmalig einen Moment).

Spec: `docs/specs/code-graph.md`.
