### PR TITLE
feat(code-graph): Etappe 2 — Agenten-Tools + Skill

### DIFF
--- a/core/src/hydrahive/agents/_defaults.py
+++ b/core/src/hydrahive/agents/_defaults.py
@@ -20,6 +20,7 @@ _BASE_TOOLS: dict[str, list[str]] = {
         "list_skills", "load_skill",
         "create_specialist", "configure_specialist", "list_specialists",
         "write_skill", "delete_skill",
+        "graph_query", "graph_explain", "graph_path", "graph_affected",
     ],
     "specialist": [
         "fetch_url", "list_skills", "load_skill",

--- a/core/src/hydrahive/skills/system_defaults/code-graph.md
+++ b/core/src/hydrahive/skills/system_defaults/code-graph.md
@@ -1,0 +1,47 @@
+---
+name: code-graph
+description: Den Code-Graph des Projekts abfragen statt den Quellcode zu durchwühlen
+when_to_use: Wenn du verstehen willst wie Code zusammenhängt — was ruft was auf, was hängt an einem Symbol, was bricht bei einer Änderung, wie hängen zwei Dateien zusammen. Bevor du dich mit grep durch viele Dateien liest.
+tools_required: [graph_query, graph_explain, graph_path, graph_affected]
+---
+
+# Code-Graph nutzen statt Grep-und-Lesen
+
+Das aktive Projekt kann einen **Code-Graph** haben (im Cockpit unter „Code-Graph"
+gebaut) — einen Abhängigkeitsgraphen aus AST-Analyse. Ihn abzufragen ist oft
+schneller und token-günstiger als den Quellcode zu durchsuchen.
+
+## Wann den Graph, wann Grep
+
+**Graph zuerst** bei Struktur-/Zusammenhang-Fragen:
+- „Was hängt an `require_auth`?" → `graph_query`
+- „Wie hängen `mcp.py` und `errors.py` zusammen?" → `graph_path`
+- „Was bricht, wenn ich `db()` ändere?" → `graph_affected`
+- „Was macht `TriggerEvent` und womit ist es verbunden?" → `graph_explain`
+
+**Grep/Read** bleibt richtig für:
+- konkreten Code lesen/ändern (der Graph liefert Datei:Zeile — dann gezielt lesen)
+- Textsuche nach Strings/Konstanten
+- wenn kein Graph existiert
+
+## Ablauf
+
+1. **`graph_query "<frage>"`** — natürlichsprachige Frage, BFS-Traversal. Liefert
+   relevante Knoten mit `datei:zeile`. `budget` begrenzt die Antwortgröße.
+2. Aus dem Ergebnis die **relevanten Dateien:Zeilen** nehmen und gezielt mit
+   `file_read` öffnen — statt blind viele Dateien zu grep-en.
+3. Für „Impact einer Änderung": **`graph_affected "<symbol>"`** vor dem Umbau.
+4. Für „wie erreicht A B": **`graph_path "A" "B"`**.
+
+## Wenn kein Graph da ist
+
+Die Tools antworten dann mit einem Hinweis „erst im Cockpit den Graph bauen".
+Das ist kein Fehler — dann normal mit `grep`/`file_read` weiterarbeiten und
+dem User ggf. vorschlagen, den Code-Graph im Cockpit zu bauen.
+
+## Merke
+- Der Graph zeigt **Struktur**, nicht den aktuellen Datei-Inhalt Zeile für Zeile.
+  Immer die genannten Stellen danach mit `file_read` verifizieren, bevor du
+  Änderungen darauf stützt.
+- Der Graph ist so aktuell wie sein letzter Build. Nach größeren Refactors kann
+  er veraltet sein.

--- a/core/src/hydrahive/tools/__init__.py
+++ b/core/src/hydrahive/tools/__init__.py
@@ -12,6 +12,7 @@ Public API:
 
 from hydrahive.tools import (
     ask_agent,
+    code_graph_tools,
     datamining,
     analyze_image,
     generate_image,
@@ -86,6 +87,10 @@ def _build_registry() -> dict[str, Tool]:
         prompt_archive.TOOL_LIST,
         prompt_archive.TOOL_GET,
         prompt_archive.TOOL_SAVE,
+        code_graph_tools.TOOL_QUERY,
+        code_graph_tools.TOOL_EXPLAIN,
+        code_graph_tools.TOOL_PATH,
+        code_graph_tools.TOOL_AFFECTED,
     ]
     if settings.agentlink_url:
         tools.append(ask_agent.TOOL)

--- a/core/src/hydrahive/tools/code_graph_tools.py
+++ b/core/src/hydrahive/tools/code_graph_tools.py
@@ -1,0 +1,147 @@
+"""Agenten-Tools für den Code-Graph: den lokalen Wissensgraphen abfragen statt
+den Quellcode zu durchwühlen.
+
+Dünne Wrapper über die graphify-CLI (query/explain/path/affected) auf der
+graph.json des aktiven Projekts (<workspace>/.graphify/out/graph.json). Der
+Graph muss vorher im Cockpit ("Code-Graph" → Graph bauen) erstellt worden sein.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from hydrahive.tools.base import Tool, ToolContext, ToolResult
+
+
+def _graph_json(project_id: str | None):
+    """Pfad zur graph.json des Projekts, oder None wenn kein Graph existiert."""
+    if not project_id:
+        return None
+    from hydrahive.code_graph import _out_dir
+    graph = _out_dir(project_id) / "graph.json"
+    return graph if graph.is_file() else None
+
+
+async def _run_graphify(args: list[str], project_id: str | None) -> ToolResult:
+    from hydrahive.code_graph import _graphify_bin
+    graph = _graph_json(project_id)
+    if graph is None:
+        return ToolResult.fail(
+            "Kein Code-Graph vorhanden. Erst im Cockpit unter 'Code-Graph' den Graph bauen."
+        )
+    binary = _graphify_bin()
+    if not binary.is_file():
+        return ToolResult.fail("graphify ist nicht installiert (Code-Graph erst im Cockpit bauen).")
+    cmd = [str(binary), *args, "--graph", str(graph)]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=60)
+    except asyncio.TimeoutError:
+        return ToolResult.fail("Graph-Abfrage Timeout")
+    if proc.returncode != 0:
+        return ToolResult.fail(f"Graph-Abfrage fehlgeschlagen: {err.decode(errors='replace')[-300:]}")
+    return ToolResult.ok(out.decode(errors="replace").strip() or "Keine Treffer.")
+
+
+async def _query(args: dict, ctx: ToolContext) -> ToolResult:
+    question = (args.get("question") or "").strip()
+    if not question:
+        return ToolResult.fail("question fehlt")
+    budget = int(args.get("budget", 2000))
+    return await _run_graphify(["query", question, "--budget", str(budget)], ctx.project_id)
+
+
+async def _explain(args: dict, ctx: ToolContext) -> ToolResult:
+    node = (args.get("node") or "").strip()
+    if not node:
+        return ToolResult.fail("node fehlt")
+    return await _run_graphify(["explain", node], ctx.project_id)
+
+
+async def _path(args: dict, ctx: ToolContext) -> ToolResult:
+    a = (args.get("from_node") or "").strip()
+    b = (args.get("to_node") or "").strip()
+    if not a or not b:
+        return ToolResult.fail("from_node und to_node erforderlich")
+    return await _run_graphify(["path", a, b], ctx.project_id)
+
+
+async def _affected(args: dict, ctx: ToolContext) -> ToolResult:
+    node = (args.get("node") or "").strip()
+    if not node:
+        return ToolResult.fail("node fehlt")
+    depth = int(args.get("depth", 2))
+    return await _run_graphify(["affected", node, "--depth", str(depth)], ctx.project_id)
+
+
+TOOL_QUERY = Tool(
+    name="graph_query",
+    description=(
+        "Fragt den Code-Graph des aktiven Projekts mit einer natürlichsprachigen Frage ab "
+        "(BFS-Traversal). Liefert relevante Knoten mit Datei:Zeile — schneller/günstiger als "
+        "den Quellcode zu durchsuchen. Voraussetzung: Graph wurde im Cockpit gebaut. "
+        "Beispiel: 'was hängt an require_auth und wie läuft der Auth-Flow?'"
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "question": {"type": "string", "description": "Frage in natürlicher Sprache"},
+            "budget": {"type": "integer", "description": "Max. Tokens der Antwort (default 2000)"},
+        },
+        "required": ["question"],
+    },
+    execute=_query,
+    category="code",
+)
+
+TOOL_EXPLAIN = Tool(
+    name="graph_explain",
+    description=(
+        "Erklärt einen Knoten (Funktion/Klasse/Datei) des Code-Graphs und seine Nachbarn "
+        "in einfacher Sprache. Voraussetzung: Graph wurde im Cockpit gebaut."
+    ),
+    schema={
+        "type": "object",
+        "properties": {"node": {"type": "string", "description": "Name des Knotens, z.B. 'require_auth' oder 'auth.py'"}},
+        "required": ["node"],
+    },
+    execute=_explain,
+    category="code",
+)
+
+TOOL_PATH = Tool(
+    name="graph_path",
+    description=(
+        "Findet den kürzesten Pfad zwischen zwei Knoten im Code-Graph — zeigt wie zwei "
+        "Symbole/Dateien zusammenhängen. Voraussetzung: Graph wurde im Cockpit gebaut."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "from_node": {"type": "string", "description": "Start-Knoten"},
+            "to_node": {"type": "string", "description": "Ziel-Knoten"},
+        },
+        "required": ["from_node", "to_node"],
+    },
+    execute=_path,
+    category="code",
+)
+
+TOOL_AFFECTED = Tool(
+    name="graph_affected",
+    description=(
+        "Reverse-Traversal: findet Knoten, die von einer Änderung an X betroffen wären "
+        "('was bricht, wenn ich X ändere?'). Voraussetzung: Graph wurde im Cockpit gebaut."
+    ),
+    schema={
+        "type": "object",
+        "properties": {
+            "node": {"type": "string", "description": "Knoten, dessen Änderung untersucht wird"},
+            "depth": {"type": "integer", "description": "Traversal-Tiefe (default 2)"},
+        },
+        "required": ["node"],
+    },
+    execute=_affected,
+    category="code",
+)

--- a/core/tests/test_code_graph_tools.py
+++ b/core/tests/test_code_graph_tools.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from hydrahive.tools import REGISTRY
+from hydrahive.tools.base import ToolContext
+from hydrahive.tools import code_graph_tools as cgt
+from hydrahive.projects._paths import ensure_workspace
+from hydrahive.projects import config as project_config
+
+
+def test_graph_tools_registered():
+    for name in ("graph_query", "graph_explain", "graph_path", "graph_affected"):
+        assert name in REGISTRY
+        assert REGISTRY[name].category == "code"
+
+
+def _ctx(project_id):
+    ws = ensure_workspace(project_id)
+    return ToolContext(session_id="s", agent_id="a", user_id="u", workspace=ws, project_id=project_id)
+
+
+def test_query_without_graph_returns_hint():
+    project = project_config.create(name="NoGraph", members=["testuser"], llm_model="test", created_by="admin")
+    ctx = _ctx(project["id"])
+    result = asyncio.run(cgt._query({"question": "was hängt an X"}, ctx))
+    assert not result.success
+    assert "Code-Graph" in (result.error or "")
+
+
+def test_query_missing_question():
+    project = project_config.create(name="NoQ", members=["testuser"], llm_model="test", created_by="admin")
+    ctx = _ctx(project["id"])
+    result = asyncio.run(cgt._query({}, ctx))
+    assert not result.success
+    assert "question" in (result.error or "")


### PR DESCRIPTION
## Code-Graph Etappe 2 — Agenten-Tools + Skill

Baut auf Etappe 1 (#324) auf. Jetzt können **Agenten** den Code-Graph abfragen, statt sich mit Grep durch viele Dateien zu lesen — der eigentliche Effizienzgewinn.

### Vier neue Tools (dünne Wrapper über die graphify-CLI auf `graph.json`)
| Tool | Zweck |
|------|-------|
| `graph_query` | natürlichsprachige Frage → relevante Knoten mit `datei:zeile` (BFS, `budget`-begrenzt) |
| `graph_explain` | einen Knoten + seine Nachbarn erklären |
| `graph_path` | kürzester Pfad zwischen zwei Knoten (wie hängen A und B zusammen) |
| `graph_affected` | Reverse-Traversal: „was bricht, wenn ich X ändere?" |

- In `REGISTRY` registriert und zu den **Projekt-Agent-Default-Tools** hinzugefügt (Kategorie `code`).
- Ohne gebauten Graph antworten sie mit **klarem Hinweis** („erst im Cockpit den Graph bauen") — kein harter Fehler, der Agent arbeitet dann normal mit grep weiter.
- Laufen als async subprocess mit 60s-Timeout.

### Skill „code-graph"
Neuer System-Default-Skill erklärt den Agenten **wann** sie den Graph statt Grep nutzen (Struktur-/Zusammenhang-Fragen → Graph; Code lesen/ändern → danach gezielt `file_read` auf die genannten Stellen).

### Verifikation
- ✅ **End-to-End verifiziert:** echten Graph gebaut, dann `graph_query` (findet `build()` + Calls mit `datei:zeile`), `graph_explain` (7 Verbindungen von `export()`), `graph_affected` (Reverse-Traversal) — alle korrekt.
- ✅ Tests **6/6** (Registrierung, No-Graph-Hinweis, fehlende Argumente)
- ✅ Volle Agent/Tool/Skill-Suite **322 grün** — keine Regression durch die Default-Tool-Erweiterung
- ✅ ruff clean

### Damit ist die Code-Graph-Idee vollständig
Etappe 1: bauen + anschauen (UI). Etappe 2: Agenten arbeiten damit. Optional später: MCP-Server (für externe Claude-Code-Agenten), Doku-Graphing (LLM).

### Deploy-Hinweis
Backend-Änderung (neue Tools). Server brauchen ein Update. Bestehende Projekt-Agenten bekommen die Tools automatisch über die Default-Toolliste; der Graph muss pro Projekt einmal im Cockpit gebaut werden.
