### PR TITLE
fix(code-graph): Grafik fehlte — Build mergt jetzt alle Verzeichnisse

### DIFF
--- a/core/src/hydrahive/code_graph.py
+++ b/core/src/hydrahive/code_graph.py
@@ -8,17 +8,23 @@ from __future__ import annotations
 
 import json
 import logging
-import re
+import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 from hydrahive.code_graph_config import get_config
+from hydrahive.code_graph_report import collect_output, graph_metrics, output_paths, report_excerpt
 from hydrahive.projects._paths import workspace_path
 from hydrahive.settings import settings
 
 logger = logging.getLogger(__name__)
+
+# graphify erzeugt standardmäßig KEINE interaktive graph.html über 5000 Knoten.
+# Wir heben das Limit an, damit auch große Codebases eine Grafik bekommen.
+VIZ_NODE_LIMIT = 20000
 
 
 class CodeGraphError(RuntimeError):
@@ -59,86 +65,92 @@ def ensure_installed() -> None:
         raise CodeGraphError("graphify-Binary nach Installation nicht gefunden")
 
 
-_METRICS_RE = re.compile(r"(\d+)\s+nodes,\s+(\d+)\s+edges,\s+(\d+)\s+communities")
+def _run_graphify(args: list[str], timeout: int = 1800) -> subprocess.CompletedProcess:
+    """graphify-Aufruf mit erhöhtem Viz-Node-Limit (große Codebases → graph.html)."""
+    env = {**os.environ, "GRAPHIFY_VIZ_NODE_LIMIT": str(VIZ_NODE_LIMIT)}
+    return subprocess.run(
+        [str(_graphify_bin()), *args],
+        check=True, capture_output=True, timeout=timeout, text=True, env=env,
+    )
 
 
-def _parse_metrics(stdout: str) -> dict:
-    m = _METRICS_RE.search(stdout)
-    if not m:
-        return {}
-    return {"nodes": int(m.group(1)), "edges": int(m.group(2)), "communities": int(m.group(3))}
+def _extract_one(target: Path) -> Path | None:
+    """Baut den Graphen für EIN Verzeichnis und gibt den graph.json-Pfad zurück.
+    graphify schreibt nach <target>/graphify-out/ — das räumen wir danach weg."""
+    try:
+        _run_graphify(["update", str(target)])
+    except subprocess.CalledProcessError as exc:
+        raise CodeGraphError(f"graphify update fehlgeschlagen: {(exc.stderr or '')[-300:]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CodeGraphError("graphify update Timeout") from exc
+    produced = target / "graphify-out" / "graph.json"
+    return produced if produced.is_file() else None
 
 
 def build(project_id: str) -> dict:
-    """Baut den Code-Graph über die konfigurierten Scan-Verzeichnisse."""
+    """Baut den Code-Graph über ALLE konfigurierten Scan-Verzeichnisse und führt
+    sie zu EINEM Graphen zusammen (merge-graphs), statt sie zu überschreiben."""
     ensure_installed()
     cfg = get_config(project_id)
     scan_dirs = cfg.get("scan_dirs", [])
     if not scan_dirs:
         raise CodeGraphError("Keine Scan-Verzeichnisse gewählt")
 
-    root = workspace_path(project_id)
+    root = workspace_path(project_id).resolve()
     out = _out_dir(project_id)
     out.mkdir(parents=True, exist_ok=True)
 
-    metrics: dict = {}
+    # 1. Jeden Ordner einzeln extrahieren, graph.json-Pfade sammeln.
+    graphs: list[Path] = []
+    scanned: list[Path] = []
     for rel in scan_dirs:
         target = (root / rel).resolve()
         try:
-            target.relative_to(root.resolve())
+            target.relative_to(root)
         except ValueError:
             continue
         if not target.is_dir():
             continue
-        try:
-            result = subprocess.run(
-                [str(_graphify_bin()), "update", str(target)],
-                check=True, capture_output=True, timeout=1800, text=True,
-            )
-            metrics = _parse_metrics(result.stdout) or metrics
-            # graphify legt <target>/graphify-out/ an — ins gemeinsame out/ spiegeln.
-            produced = target / "graphify-out"
-            if produced.is_dir():
-                for name in ("graph.json", "graph.html", "GRAPH_REPORT.md"):
-                    src = produced / name
-                    if src.is_file():
-                        (out / name).write_bytes(src.read_bytes())
-        except subprocess.CalledProcessError as exc:
-            raise CodeGraphError(f"graphify update fehlgeschlagen: {exc.stderr[-300:] if exc.stderr else ''}") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise CodeGraphError("graphify update Timeout") from exc
+        scanned.append(target)
+        g = _extract_one(target)
+        if g is not None:
+            graphs.append(g)
+
+    if not graphs:
+        _cleanup(scanned)
+        raise CodeGraphError("Keine Quelldateien in den gewählten Verzeichnissen gefunden")
+
+    graph_json = out / "graph.json"
+    try:
+        if len(graphs) == 1:
+            shutil.copy(graphs[0], graph_json)
+        else:
+            _run_graphify(["merge-graphs", *map(str, graphs), "--out", str(graph_json)])
+        # 2. Clustering + graph.html + Report für den Gesamtgraphen erzeugen.
+        _run_graphify(["cluster-only", str(out.parent), "--graph", str(graph_json)])
+    except subprocess.CalledProcessError as exc:
+        raise CodeGraphError(f"Graph-Zusammenführung fehlgeschlagen: {(exc.stderr or '')[-300:]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CodeGraphError("Graph-Zusammenführung Timeout") from exc
+    finally:
+        _cleanup(scanned)
+
+    # cluster-only schreibt nach <out.parent>/graphify-out/ — ins out/ ziehen.
+    collect_output(out)
 
     meta = {
         "built_at": datetime.now(timezone.utc).isoformat(),
         "scan_dirs": scan_dirs,
-        "metrics": metrics,
+        "metrics": graph_metrics(graph_json),
     }
     (out / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
-    return {**meta, "report": _report_excerpt(out), **_output_paths(project_id)}
+    return {**meta, "report": report_excerpt(out), **output_paths(out)}
 
 
-def _output_paths(project_id: str) -> dict:
-    out = _out_dir(project_id)
-    html = out / "graph.html"
-    report = out / "GRAPH_REPORT.md"
-    return {
-        "html_path": str(html) if html.is_file() else None,
-        "report_path": str(report) if report.is_file() else None,
-    }
-
-
-def _report_excerpt(out: Path) -> dict:
-    """God-Nodes + Import-Zyklen aus dem Report ziehen (für die UI-Kurzsicht)."""
-    report = out / "GRAPH_REPORT.md"
-    if not report.is_file():
-        return {}
-    text = report.read_text(encoding="utf-8", errors="replace")
-    god = re.findall(r"^\d+\.\s+`([^`]+)`\s+-\s+(\d+)\s+edges", text, re.MULTILINE)[:10]
-    cycles = re.findall(r"cycle:\s+`([^`]+)`", text)[:10]
-    return {
-        "god_nodes": [{"name": n, "edges": int(e)} for n, e in god],
-        "cycles": cycles,
-    }
+def _cleanup(dirs: list[Path]) -> None:
+    """Entfernt die von graphify in den Scan-Ordnern angelegten graphify-out/."""
+    for d in dirs:
+        shutil.rmtree(d / "graphify-out", ignore_errors=True)
 
 
 def status(project_id: str) -> dict:
@@ -155,6 +167,6 @@ def status(project_id: str) -> dict:
         "built_at": meta.get("built_at"),
         "scan_dirs": meta.get("scan_dirs", []),
         "metrics": meta.get("metrics", {}),
-        "report": _report_excerpt(out) if meta else {},
-        **_output_paths(project_id),
+        "report": report_excerpt(out) if meta else {},
+        **output_paths(out),
     }

--- a/core/src/hydrahive/code_graph_report.py
+++ b/core/src/hydrahive/code_graph_report.py
@@ -1,0 +1,55 @@
+"""Code-Graph: Output-Konsolidierung + Report-Parsing (getrennt von der
+Build-Orchestrierung in code_graph.py, damit beide Dateien fokussiert bleiben)."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+
+
+def collect_output(out: Path) -> None:
+    """Zieht graph.html + Report + graph.json aus <out.parent>/graphify-out/ nach out/."""
+    produced = out.parent / "graphify-out"
+    if not produced.is_dir():
+        return
+    for name in ("graph.html", "GRAPH_REPORT.md", "graph.json"):
+        src = produced / name
+        if src.is_file():
+            (out / name).write_bytes(src.read_bytes())
+    shutil.rmtree(produced, ignore_errors=True)
+
+
+def graph_metrics(graph_json: Path) -> dict:
+    """Node-/Edge-/Community-Zahlen direkt aus graph.json."""
+    try:
+        data = json.loads(graph_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    nodes = data.get("nodes", [])
+    links = data.get("links", [])
+    communities = {n.get("community") for n in nodes if isinstance(n, dict) and n.get("community") is not None}
+    return {"nodes": len(nodes), "edges": len(links), "communities": len(communities)}
+
+
+def output_paths(out: Path) -> dict:
+    html = out / "graph.html"
+    report = out / "GRAPH_REPORT.md"
+    return {
+        "html_path": str(html) if html.is_file() else None,
+        "report_path": str(report) if report.is_file() else None,
+    }
+
+
+def report_excerpt(out: Path) -> dict:
+    """God-Nodes + Import-Zyklen aus dem Report ziehen (für die UI-Kurzsicht)."""
+    report = out / "GRAPH_REPORT.md"
+    if not report.is_file():
+        return {}
+    text = report.read_text(encoding="utf-8", errors="replace")
+    god = re.findall(r"^\d+\.\s+`([^`]+)`\s+-\s+(\d+)\s+edges", text, re.MULTILINE)[:10]
+    cycles = re.findall(r"cycle:\s+`([^`]+)`", text)[:10]
+    return {
+        "god_nodes": [{"name": n, "edges": int(e)} for n, e in god],
+        "cycles": cycles,
+    }

--- a/core/tests/test_code_graph_config.py
+++ b/core/tests/test_code_graph_config.py
@@ -1,4 +1,6 @@
-from hydrahive import code_graph_config
+import json
+
+from hydrahive import code_graph_config, code_graph_report
 from hydrahive.projects import config as project_config
 from hydrahive.projects._paths import ensure_workspace
 
@@ -33,3 +35,19 @@ def test_suggestions_find_source_dirs_and_skip_ignored():
     suggestions = code_graph_config.suggest_scan_dirs(pid)
     assert "core/src" in suggestions or "core" in suggestions
     assert all("node_modules" not in s for s in suggestions)
+
+
+def test_graph_metrics_counts_nodes_edges_communities(tmp_path):
+    graph = tmp_path / "graph.json"
+    graph.write_text(json.dumps({
+        "nodes": [{"id": "a", "community": 0}, {"id": "b", "community": 1}, {"id": "c", "community": 0}],
+        "links": [{"source": "a", "target": "b"}, {"source": "b", "target": "c"}],
+    }))
+    metrics = code_graph_report.graph_metrics(graph)
+    assert metrics == {"nodes": 3, "edges": 2, "communities": 2}
+
+
+def test_output_paths_reports_existing_files(tmp_path):
+    (tmp_path / "graph.html").write_text("<html></html>")
+    paths = code_graph_report.output_paths(tmp_path)
+    assert paths["html_path"] and paths["report_path"] is None


### PR DESCRIPTION
## Fix: Code-Graph zeigte Auswertung, aber keine Grafik

Du hattest gemeldet: der Graph wertet aus (Report/Kennzahlen kommen), aber es erscheint keine Grafik. Zwei Root-Causes gefunden:

### Bug 1 — Der Build hat überschrieben statt gemergt
`build()` lief über alle Scan-Verzeichnisse und hat bei **jedem** die `out/graph.html` mit dem Ergebnis *dieses einen* Ordners überschrieben. Bei deinen 19 Verzeichnissen blieb am Ende nur der letzte (winzige `tasks/backend`) übrig → **43 Nodes** statt der ganzen Codebase. Die 40-KB-Grafik war praktisch leer.

### Bug 2 — HTML-Viz-Limit
Selbst mit korrektem Merge (7471 Nodes) erzeugt graphify **standardmäßig keine graph.html über 5000 Knoten**.

### Fix
`build()` neu:
1. Jeden Ordner einzeln extrahieren (`graphify update`)
2. Die Einzelgraphen per **`merge-graphs`** zu **einem** Gesamtgraphen zusammenführen
3. **`cluster-only`** mit erhöhtem `GRAPHIFY_VIZ_NODE_LIMIT=20000` erzeugt graph.html + Report für den Gesamtgraphen
4. `graphify-out`-Reste werden aus den Scan-Ordnern aufgeräumt
- Metriken jetzt direkt aus `graph.json` gezählt (nicht mehr per stdout-Regex).

### Verifikation (E2E, echter Build)
- `core/src` + `frontend/src` → **7471 Nodes, 15538 Edges, 416 Communities**, graph.html (7,1 MB) erzeugt, God-Nodes `require_auth`/`coded`/`db` korrekt
- `core/src` allein nach Refactor → 4786 Nodes, graph.html ✅
- Scan-Ordner-Reste sauber aufgeräumt

### Tests
- 8/8 grün (config round-trip, Traversal, Vorschläge, **graph_metrics**, **output_paths**), ruff clean
- Refactor: Output/Report-Helfer nach `code_graph_report.py` (code_graph.py 221→172 Zeilen)

### Ehrlicher Hinweis
Die graph.html wird bei großen Codebases mehrere MB groß (7 MB bei ~7500 Nodes) und lädt im iframe entsprechend langsam. Die **Kernfunktion (Grafik wird erzeugt) ist gefixt**; eine Performance-Optimierung für sehr große Graphen (Sampling/Lazy-Load) wäre ein sinnvolles Folge-Thema, falls es dir zu träge ist.

Deploy: Backend-Änderung, Server-Update nötig. Danach den Graph im Cockpit **neu bauen** (der alte 43-Node-Graph wird überschrieben).
