### PR TITLE
fix(code-graph): echte Import-Zyklen statt graphify-Basename-Scheinzyklen

### DIFF
--- a/core/src/hydrahive/code_graph_cycles.py
+++ b/core/src/hydrahive/code_graph_cycles.py
@@ -1,0 +1,121 @@
+"""Echte Import-Zyklen aus graph.json berechnen.
+
+graphify's eigener Zyklus-Report kollabiert jeden Knoten auf seinen Datei-
+Basename — bei Python-Projekten mit vielen `__init__.py` erzeugt das massenhaft
+Scheinzyklen (jedes `__init__.py -> __init__.py`). Hier bauen wir den
+Import-Graphen stattdessen auf Datei-Ebene mit vollen Pfaden auf und finden
+echte stark-zusammenhängende Komponenten (Tarjan, iterativ)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_IMPORT_RELATIONS = {"imports", "imports_from", "re_exports"}
+
+
+def _node_files(data: dict) -> dict[str, str]:
+    """id -> lesbarer Datei-Schlüssel (repo-qualifiziert, damit gleichnamige
+    Dateien aus verschiedenen Repos nicht verschmelzen)."""
+    files: dict[str, str] = {}
+    for n in data.get("nodes", []):
+        if not isinstance(n, dict):
+            continue
+        src = n.get("source_file")
+        if not src:
+            continue
+        repo = n.get("repo")
+        files[n.get("id")] = f"{repo}/{src}" if repo else src
+    return files
+
+
+def _import_graph(data: dict) -> dict[str, set[str]]:
+    """Gerichteter Datei→Datei-Import-Graph (ohne Selbstkanten)."""
+    files = _node_files(data)
+    adj: dict[str, set[str]] = {}
+    for link in data.get("links", []):
+        if not isinstance(link, dict) or link.get("relation") not in _IMPORT_RELATIONS:
+            continue
+        src, dst = files.get(link.get("source")), files.get(link.get("target"))
+        if not src or not dst or src == dst:
+            continue
+        adj.setdefault(src, set()).add(dst)
+        adj.setdefault(dst, set())
+    return adj
+
+
+def _sccs(adj: dict[str, set[str]]) -> list[list[str]]:
+    """Tarjan-SCC, iterativ (keine Rekursionsgrenze bei großen Graphen)."""
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    result: list[list[str]] = []
+    counter = 0
+
+    for root in list(adj):
+        if root in index:
+            continue
+        work: list[tuple[str, int]] = [(root, 0)]
+        while work:
+            node, child_i = work[-1]
+            if child_i == 0:
+                index[node] = low[node] = counter
+                counter += 1
+                stack.append(node)
+                on_stack.add(node)
+            children = sorted(adj.get(node, ()))
+            if child_i < len(children):
+                work[-1] = (node, child_i + 1)
+                nxt = children[child_i]
+                if nxt not in index:
+                    work.append((nxt, 0))
+                elif nxt in on_stack:
+                    low[node] = min(low[node], index[nxt])
+            else:
+                if low[node] == index[node]:
+                    comp: list[str] = []
+                    while True:
+                        w = stack.pop()
+                        on_stack.discard(w)
+                        comp.append(w)
+                        if w == node:
+                            break
+                    if len(comp) > 1:
+                        result.append(comp)
+                work.pop()
+                if work:
+                    parent = work[-1][0]
+                    low[parent] = min(low[parent], low[node])
+    return result
+
+
+def _cycle_path(scc: list[str], adj: dict[str, set[str]]) -> list[str]:
+    """Einen konkreten Zyklus innerhalb einer SCC extrahieren (für die Anzeige)."""
+    members = set(scc)
+    start = min(scc)
+    path: list[str] = []
+    seen: set[str] = set()
+    node = start
+    while node not in seen:
+        seen.add(node)
+        path.append(node)
+        nxt = next((t for t in sorted(adj.get(node, ())) if t in members), None)
+        if nxt is None:
+            break
+        if nxt in seen:
+            path.append(nxt)
+            return path[path.index(nxt):]
+        node = nxt
+    return path + [start]
+
+
+def import_cycles(graph_json: Path, limit: int = 10) -> list[str]:
+    """Liste echter Import-Zyklen als lesbare Pfade ('a.py -> b.py -> a.py')."""
+    try:
+        data = json.loads(graph_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    adj = _import_graph(data)
+    cycles = [_cycle_path(scc, adj) for scc in _sccs(adj)]
+    cycles.sort(key=len, reverse=True)
+    return [" -> ".join(c) for c in cycles[:limit]]

--- a/core/src/hydrahive/code_graph_report.py
+++ b/core/src/hydrahive/code_graph_report.py
@@ -7,6 +7,8 @@ import re
 import shutil
 from pathlib import Path
 
+from hydrahive.code_graph_cycles import import_cycles
+
 
 def collect_output(out: Path) -> None:
     """Zieht graph.html + Report + graph.json aus <out.parent>/graphify-out/ nach out/."""
@@ -42,14 +44,17 @@ def output_paths(out: Path) -> dict:
 
 
 def report_excerpt(out: Path) -> dict:
-    """God-Nodes + Import-Zyklen aus dem Report ziehen (für die UI-Kurzsicht)."""
+    """God-Nodes aus dem Report + echte Import-Zyklen aus graph.json.
+
+    God-Nodes stimmen im graphify-Report; die Zyklus-Liste dort ist wegen
+    Basename-Kollaps unbrauchbar (viele Schein-`__init__.py`-Zyklen), darum
+    berechnen wir sie selbst aus dem Graphen mit vollen Datei-Pfaden."""
     report = out / "GRAPH_REPORT.md"
     if not report.is_file():
         return {}
     text = report.read_text(encoding="utf-8", errors="replace")
     god = re.findall(r"^\d+\.\s+`([^`]+)`\s+-\s+(\d+)\s+edges", text, re.MULTILINE)[:10]
-    cycles = re.findall(r"cycle:\s+`([^`]+)`", text)[:10]
     return {
         "god_nodes": [{"name": n, "edges": int(e)} for n, e in god],
-        "cycles": cycles,
+        "cycles": import_cycles(out / "graph.json"),
     }

--- a/core/tests/test_code_graph_cycles.py
+++ b/core/tests/test_code_graph_cycles.py
@@ -1,0 +1,61 @@
+import json
+
+from hydrahive.code_graph_cycles import import_cycles
+
+
+def _write_graph(tmp_path, nodes, links):
+    p = tmp_path / "graph.json"
+    p.write_text(json.dumps({"nodes": nodes, "links": links}))
+    return p
+
+
+def test_no_cycles_on_acyclic_imports(tmp_path):
+    nodes = [
+        {"id": "1", "source_file": "a.py"},
+        {"id": "2", "source_file": "b.py"},
+    ]
+    links = [{"relation": "imports", "source": "1", "target": "2"}]
+    assert import_cycles(_write_graph(tmp_path, nodes, links)) == []
+
+
+def test_detects_real_cycle_with_full_paths(tmp_path):
+    nodes = [
+        {"id": "1", "source_file": "pkg/a.py"},
+        {"id": "2", "source_file": "pkg/b.py"},
+    ]
+    links = [
+        {"relation": "imports", "source": "1", "target": "2"},
+        {"relation": "imports_from", "source": "2", "target": "1"},
+    ]
+    cycles = import_cycles(_write_graph(tmp_path, nodes, links))
+    assert len(cycles) == 1
+    assert "pkg/a.py" in cycles[0] and "pkg/b.py" in cycles[0]
+
+
+def test_ignores_basename_collapse_across_distinct_init_files(tmp_path):
+    # Zwei verschiedene __init__.py (unterschiedliche Pfade) sind KEIN Zyklus,
+    # auch wenn graphify sie auf denselben Basename kollabieren würde.
+    nodes = [
+        {"id": "1", "source_file": "mod_a/__init__.py"},
+        {"id": "2", "source_file": "mod_b/__init__.py"},
+    ]
+    links = [{"relation": "imports", "source": "1", "target": "2"}]
+    assert import_cycles(_write_graph(tmp_path, nodes, links)) == []
+
+
+def test_self_import_is_not_a_cycle(tmp_path):
+    nodes = [{"id": "1", "source_file": "a.py"}]
+    links = [{"relation": "imports", "source": "1", "target": "1"}]
+    assert import_cycles(_write_graph(tmp_path, nodes, links)) == []
+
+
+def test_non_import_relations_are_ignored(tmp_path):
+    nodes = [
+        {"id": "1", "source_file": "a.py"},
+        {"id": "2", "source_file": "b.py"},
+    ]
+    links = [
+        {"relation": "calls", "source": "1", "target": "2"},
+        {"relation": "calls", "source": "2", "target": "1"},
+    ]
+    assert import_cycles(_write_graph(tmp_path, nodes, links)) == []

--- a/docs/specs/code-graph.md
+++ b/docs/specs/code-graph.md
@@ -45,9 +45,17 @@ anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
 - `ensure_installed()` → legt venv an + pip install (idempotent, mit Timeout).
 - `get_config(project_id)` / `set_config(project_id, scan_dirs)` — scan_dirs gegen
   Path-Traversal validiert (müssen **innerhalb** des Workspace liegen, existieren).
-- `build(project_id)` → für jedes scan_dir `graphify update`; danach die Outputs
-  ins gemeinsame `.graphify/out/` konsolidieren; liefert Kurz-Metriken
-  (nodes/edges/communities) + Report-Auszug (God-Nodes, Zyklen).
+- `build(project_id)` → für jedes scan_dir `graphify update`; danach die
+  Einzelgraphen per `merge-graphs` zu **einem** Gesamtgraphen mergen und via
+  `cluster-only` (`GRAPHIFY_VIZ_NODE_LIMIT` hochgesetzt) `graph.html` + Report
+  für den Gesamtgraphen erzeugen. graphify-out-Reste werden aus den scan_dirs
+  aufgeräumt. Liefert Kurz-Metriken (nodes/edges/communities) + God-Nodes + Zyklen.
+- **Import-Zyklen** kommen NICHT aus graphifys Report (der kollabiert Knoten auf
+  ihren Datei-Basename → massenhaft Schein-`__init__.py`-Zyklen). Stattdessen
+  berechnet `code_graph_cycles.import_cycles()` echte Zyklen aus `graph.json`:
+  Datei-Import-Graph mit vollen Pfaden (repo-qualifiziert) + Tarjan-SCC.
+- `code_graph_report.py` bündelt Output-Konsolidierung, Metriken (aus graph.json)
+  und Report-Auszug; `code_graph_cycles.py` die Zyklus-Erkennung.
 - `status(project_id)` → letzter Build (Zeit, Metriken, ob graph.html existiert).
 - Routen (neuer Router `code_graph.py`, require_auth + _authorize):
   - `GET  /api/projects/{id}/code-graph/status`
@@ -59,7 +67,8 @@ anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
 - `projectsApi`-Erweiterung bzw. `codeGraphApi` (status/config/build).
 - **`ProjectGraphOverlay`**: Verzeichnis-Auswahl (Checkbox-Liste aus Vorschlägen +
   manuell), „Graph bauen" (zeigt Fortschritt), nach Build: Metriken + God-Nodes +
-  Zyklen aus dem Report, und die interaktive `graph.html` als iframe
+  echte Import-Zyklen (rot mit vollen Pfaden; grüne „keine Zyklen"-Bestätigung
+  wenn sauber), und die interaktive `graph.html` als iframe
   (`/api/files?path=…`). Bootstrap-Hinweis, falls venv erst eingerichtet wird.
 - **Button „Graph"** in `ProjectActionGroups`, verdrahtet in `ProjectCockpitPage`.
 

--- a/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
+++ b/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
@@ -120,9 +120,14 @@ export function ProjectGraphOverlay({ project, onClose }: { project: Project; on
             {cycles.length ? (
               <div className="rounded-[4px] border border-rose-500/30 bg-rose-500/5 p-3">
                 <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-rose-300">Import-Zyklen</p>
-                <ul className="space-y-0.5 text-[11px] text-rose-200">
-                  {cycles.map((c) => <li key={c} className="truncate font-mono">{c}</li>)}
+                <ul className="space-y-1 text-[11px] text-rose-200">
+                  {cycles.map((c) => <li key={c} className="break-all font-mono leading-snug">{c}</li>)}
                 </ul>
+              </div>
+            ) : metrics ? (
+              <div className="rounded-[4px] border border-emerald-500/25 bg-emerald-500/5 p-3">
+                <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-emerald-300">Import-Zyklen</p>
+                <p className="mt-1 text-[11px] text-emerald-200/90">Keine echten Zyklen gefunden.</p>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Fix: Die roten „Import-Zyklen" waren alle falsch

Du hast die rote Box mit 20 Zyklen gemeldet — `__init__.py -> __init__.py`, `__init__.py -> tools_write.py -> __init__.py` usw. Ich hab den rohen Graphen gegen deinen Code geprüft:

### Root-Cause
graphify's Zyklus-Report **kollabiert jeden Knoten auf seinen Datei-Basename**. Dein Projekt hat **73 verschiedene `__init__.py`** (eine pro Package) — die werden im Report alle zu *einem* Knoten. Dadurch sieht das normale Python-Package-Muster (`from . import x` = Kante zum Package-`__init__`) wie ein Zyklus aus. **Es sind keine echten Zyklen.**

Empirisch bewiesen: Import-Graph auf **Datei-Ebene mit vollen Pfaden** + Tarjan-SCC → **0 stark-zusammenhängende Komponenten**. Kein einziger echter Modul-zu-Modul-Zyklus.

### Fix — Zyklen selbst berechnen (statt graphifys kaputte Liste filtern)
Neues Modul `code_graph_cycles.py`:
- Baut den Import-Graphen aus `graph.json` auf Datei-Ebene mit **repo-qualifizierten vollen Pfaden** (Relationen `imports`/`imports_from`/`re_exports`, ohne Selbstkanten)
- Findet echte Zyklen per iterativem **Tarjan-SCC** (kein Rekursionslimit bei großen Graphen)
- Extrahiert pro SCC einen konkreten, lesbaren Zyklus-Pfad

`report_excerpt` nutzt das jetzt; God-Nodes bleiben aus dem graphify-Report (die stimmen).

### Verifikation
- Echter Graph (7471 Nodes) → **0 Zyklen** (rote Box verschwindet zu Recht)
- **Sanity-Check:** künstlich injizierter `a <-> b`-Zyklus wird korrekt erkannt und mit vollen Pfaden angezeigt — die Erkennung ist also echt, nicht nur „immer leer"
- 5 neue Tests: leer / echter Zyklus / basename-Kollaps-immun / self-loop / non-import-Relationen ignoriert

### UI
- Zyklen jetzt mit vollen Pfaden lesbar (`break-all` statt `truncate`)
- Bei 0 Zyklen (Graph gebaut): grüne **„Keine echten Zyklen gefunden"**-Bestätigung statt leerem Bereich — Rot ist wieder ein echtes Warnsignal

### Checks
tsc + eslint + build grün · 13 Backend-Tests grün · ruff clean · alle Dateien <200 Zeilen · hh-review sauber

Deploy: Backend-Änderung, Server-Update nötig. Danach Graph im Cockpit einmal neu bauen (oder Status neu laden) — dann ist die rote Box weg.
