### PR TITLE
feat(code-graph): graph_refresh — Agent baut den Graph selbst neu

### DIFF
--- a/core/src/hydrahive/code_graph.py
+++ b/core/src/hydrahive/code_graph.py
@@ -90,11 +90,11 @@ def _extract_one(target: Path) -> Path | None:
 def build(project_id: str) -> dict:
     """Baut den Code-Graph über ALLE konfigurierten Scan-Verzeichnisse und führt
     sie zu EINEM Graphen zusammen (merge-graphs), statt sie zu überschreiben."""
-    ensure_installed()
     cfg = get_config(project_id)
     scan_dirs = cfg.get("scan_dirs", [])
     if not scan_dirs:
         raise CodeGraphError("Keine Scan-Verzeichnisse gewählt")
+    ensure_installed()
 
     root = workspace_path(project_id).resolve()
     out = _out_dir(project_id)

--- a/core/src/hydrahive/skills/system_defaults/code-graph.md
+++ b/core/src/hydrahive/skills/system_defaults/code-graph.md
@@ -2,7 +2,7 @@
 name: code-graph
 description: Den Code-Graph des Projekts abfragen statt den Quellcode zu durchwühlen
 when_to_use: Wenn du verstehen willst wie Code zusammenhängt — was ruft was auf, was hängt an einem Symbol, was bricht bei einer Änderung, wie hängen zwei Dateien zusammen. Bevor du dich mit grep durch viele Dateien liest.
-tools_required: [graph_query, graph_explain, graph_path, graph_affected]
+tools_required: [graph_query, graph_explain, graph_path, graph_affected, graph_refresh]
 ---
 
 # Code-Graph nutzen statt Grep-und-Lesen
@@ -33,15 +33,33 @@ schneller und token-günstiger als den Quellcode zu durchsuchen.
 3. Für „Impact einer Änderung": **`graph_affected "<symbol>"`** vor dem Umbau.
 4. Für „wie erreicht A B": **`graph_path "A" "B"`**.
 
+## Graph aktualisieren nach eigenen Änderungen
+
+Der Graph ist so aktuell wie sein letzter Build. Hast du selbst Code geändert
+(neue Datei, umbenannt, größeres Refactoring) und willst danach wieder
+zuverlässig `graph_query`/`graph_affected` nutzen, baue ihn neu:
+
+- **`graph_refresh`** — baut den Graph lokal neu (ohne LLM/Kosten) über die im
+  Cockpit gewählten Verzeichnisse. Dauert Sekunden bis ~1-2 Minuten. Danach
+  spiegeln die Abfragen den aktuellen Code.
+
+Wann sinnvoll:
+- Vor einer Impact-Analyse (`graph_affected`), wenn du seit dem letzten Build
+  schon Dateien angefasst hast — sonst basiert die Analyse auf altem Stand.
+- Nach dem Abschluss eines Features/Refactors, bevor du den Graph erneut befragst.
+
+Nicht bei jeder Kleinigkeit neu bauen — nur wenn die Struktur sich geändert hat
+und du dich danach wieder auf den Graph stützen willst.
+
 ## Wenn kein Graph da ist
 
-Die Tools antworten dann mit einem Hinweis „erst im Cockpit den Graph bauen".
-Das ist kein Fehler — dann normal mit `grep`/`file_read` weiterarbeiten und
-dem User ggf. vorschlagen, den Code-Graph im Cockpit zu bauen.
+Die Abfrage-Tools antworten dann mit einem Hinweis „erst im Cockpit den Graph
+bauen". Das ist kein Fehler — dann normal mit `grep`/`file_read` weiterarbeiten
+und dem User ggf. vorschlagen, den Code-Graph im Cockpit zu bauen. `graph_refresh`
+funktioniert erst, wenn im Cockpit einmal Scan-Verzeichnisse gewählt wurden.
 
 ## Merke
 - Der Graph zeigt **Struktur**, nicht den aktuellen Datei-Inhalt Zeile für Zeile.
   Immer die genannten Stellen danach mit `file_read` verifizieren, bevor du
   Änderungen darauf stützt.
-- Der Graph ist so aktuell wie sein letzter Build. Nach größeren Refactors kann
-  er veraltet sein.
+- Nach größeren Refactors mit `graph_refresh` neu bauen, sonst ist er veraltet.

--- a/core/src/hydrahive/tools/__init__.py
+++ b/core/src/hydrahive/tools/__init__.py
@@ -91,6 +91,7 @@ def _build_registry() -> dict[str, Tool]:
         code_graph_tools.TOOL_EXPLAIN,
         code_graph_tools.TOOL_PATH,
         code_graph_tools.TOOL_AFFECTED,
+        code_graph_tools.TOOL_REFRESH,
     ]
     if settings.agentlink_url:
         tools.append(ask_agent.TOOL)

--- a/core/src/hydrahive/tools/code_graph_tools.py
+++ b/core/src/hydrahive/tools/code_graph_tools.py
@@ -44,6 +44,34 @@ async def _run_graphify(args: list[str], project_id: str | None) -> ToolResult:
     return ToolResult.ok(out.decode(errors="replace").strip() or "Keine Treffer.")
 
 
+async def _refresh(args: dict, ctx: ToolContext) -> ToolResult:
+    """Baut den Code-Graph neu — nach eigenen Code-Änderungen, damit die
+    Graph-Abfragen wieder den aktuellen Stand zeigen (statt veraltetem Build)."""
+    if not ctx.project_id:
+        return ToolResult.fail("Kein aktives Projekt.")
+    from hydrahive.code_graph import CodeGraphError, build
+    try:
+        result = await asyncio.to_thread(build, ctx.project_id)
+    except CodeGraphError as exc:
+        msg = str(exc)
+        if "Scan-Verzeichnisse" in msg:
+            return ToolResult.fail(
+                "Kein Scan-Verzeichnis konfiguriert. Erst im Cockpit unter 'Code-Graph' "
+                "die zu scannenden Verzeichnisse wählen und einmal bauen."
+            )
+        return ToolResult.fail(f"Graph-Neuaufbau fehlgeschlagen: {msg}")
+    metrics = result.get("metrics", {})
+    cycles = result.get("report", {}).get("cycles", [])
+    lines = [
+        "Code-Graph neu gebaut.",
+        f"Verzeichnisse: {', '.join(result.get('scan_dirs', [])) or '—'}",
+        f"Knoten: {metrics.get('nodes', 0)} · Kanten: {metrics.get('edges', 0)} · "
+        f"Communities: {metrics.get('communities', 0)}",
+        f"Import-Zyklen: {len(cycles)}" + (f" ({cycles[0]} …)" if cycles else " (keine)"),
+    ]
+    return ToolResult.ok("\n".join(lines))
+
+
 async def _query(args: dict, ctx: ToolContext) -> ToolResult:
     question = (args.get("question") or "").strip()
     if not question:
@@ -74,6 +102,20 @@ async def _affected(args: dict, ctx: ToolContext) -> ToolResult:
     depth = int(args.get("depth", 2))
     return await _run_graphify(["affected", node, "--depth", str(depth)], ctx.project_id)
 
+
+TOOL_REFRESH = Tool(
+    name="graph_refresh",
+    description=(
+        "Baut den Code-Graph des aktiven Projekts neu (lokal, ohne LLM/Kosten) — nutze das "
+        "nachdem du selbst Code geändert hast, damit graph_query/explain/path/affected wieder "
+        "den aktuellen Stand zeigen statt eines veralteten Builds. Scannt die im Cockpit "
+        "gewählten Verzeichnisse. Dauert je nach Projektgröße Sekunden bis ~1-2 Minuten. "
+        "Voraussetzung: der Graph wurde mind. einmal im Cockpit konfiguriert/gebaut."
+    ),
+    schema={"type": "object", "properties": {}},
+    execute=_refresh,
+    category="code",
+)
 
 TOOL_QUERY = Tool(
     name="graph_query",

--- a/core/tests/test_code_graph_tools.py
+++ b/core/tests/test_code_graph_tools.py
@@ -8,9 +8,26 @@ from hydrahive.projects import config as project_config
 
 
 def test_graph_tools_registered():
-    for name in ("graph_query", "graph_explain", "graph_path", "graph_affected"):
+    for name in ("graph_query", "graph_explain", "graph_path", "graph_affected", "graph_refresh"):
         assert name in REGISTRY
         assert REGISTRY[name].category == "code"
+
+
+def test_refresh_without_scan_dirs_returns_hint():
+    project = project_config.create(name="NoScan", members=["testuser"], llm_model="test", created_by="admin")
+    ctx = _ctx(project["id"])
+    result = asyncio.run(cgt._refresh({}, ctx))
+    assert not result.success
+    assert "Scan-Verzeichnis" in (result.error or "")
+
+
+def test_refresh_without_project():
+    ctx = ToolContext(session_id="s", agent_id="a", user_id="u", workspace=ensure_workspace(
+        project_config.create(name="P", members=["testuser"], llm_model="test", created_by="admin")["id"]
+    ), project_id=None)
+    result = asyncio.run(cgt._refresh({}, ctx))
+    assert not result.success
+    assert "Projekt" in (result.error or "")
 
 
 def _ctx(project_id):

--- a/docs/specs/code-graph.md
+++ b/docs/specs/code-graph.md
@@ -80,8 +80,10 @@ anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
 - [ ] venv wird on-demand gebootstrappt; Kern-Dependencies unverändert.
 - [ ] Backend-Tests grün (config round-trip, dir-validation); Build/Typecheck/ESLint grün.
 
-## Etappe 2 (später, nicht dieser PR)
+## Etappe 2 (umgesetzt)
 Agenten-Tools `graph_query` / `graph_explain` / `graph_path` / `graph_affected`
 (dünne Wrapper über `graphify query/explain/path/affected` auf `graph.json`) +
-Skill „code-graph" (wann Graph statt Grep). Optional MCP-Server. Optional
-Doku-Graphing (LLM).
+`graph_refresh` (baut den Graph via `code_graph.build()` neu, damit der Agent nach
+eigenen Code-Änderungen wieder aktuelle Abfragen bekommt — läuft in `asyncio.to_thread`,
+Scan-Dir-Prüfung vor der graphify-Installation) + Skill „code-graph" (wann Graph
+statt Grep, wann neu bauen). Optional MCP-Server. Optional Doku-Graphing (LLM).


### PR DESCRIPTION
## graph_refresh: der Agent aktualisiert den Code-Graph selbst

Bisher konnte der Agent den Code-Graph nur **abfragen** (`graph_query`/`explain`/`path`/`affected`) — gebaut wurde er ausschließlich manuell im Cockpit. Nach eigenen Code-Änderungen arbeitete der Agent damit auf einem **veralteten** Graphen.

Neues Tool **`graph_refresh`**: baut den Graph lokal neu (ohne LLM/Kosten) über die im Cockpit gewählten Scan-Verzeichnisse. Danach spiegeln alle Graph-Abfragen wieder den aktuellen Code.

### Details
- Läuft in `asyncio.to_thread` → blockiert den Event-Loop nicht, auch wenn der Build ein bis zwei Minuten dauert
- Kompakte Rückmeldung: gescannte Verzeichnisse, nodes/edges/communities, Anzahl echter Import-Zyklen
- Saubere Fehlermeldungen: kein aktives Projekt / keine Scan-Verzeichnisse konfiguriert → Hinweis auf Cockpit
- `build()`: die Scan-Dir-Prüfung wandert **vor** `ensure_installed()` — kein graphify-Install, wenn ohnehin nichts zu bauen ist (macht den Test schnell & netzfrei)

### Skill
`code-graph` um `graph_refresh` + Abschnitt **„Graph aktualisieren nach eigenen Änderungen"** erweitert: *wann* neu bauen (vor Impact-Analyse nach eigenen Edits, nach Feature/Refactor) und *wann nicht* (nicht bei jeder Kleinigkeit).

### Checks
15 Backend-Tests grün (3 neue) · ruff clean · alle Dateien <200 Zeilen · Spec Etappe 2 aktualisiert

Deploy: Backend-Änderung → Server-Update nötig, damit das neue Tool bei den Agenten ankommt.