### PR TITLE
fix(codex): reasoning-Items brauchen summary — Buddy verstummte nach 1. Tool-Call

### DIFF
--- a/core/src/hydrahive/runner/_codex_convert.py
+++ b/core/src/hydrahive/runner/_codex_convert.py
@@ -92,7 +92,15 @@ def messages_to_codex(
                 elif btype == "codex_reasoning" and b.get("model") == model:
                     encrypted = b.get("encrypted_content")
                     if encrypted:
-                        items.append({"type": "reasoning", "encrypted_content": encrypted})
+                        # Die Responses-API verlangt bei zurückgesendeten reasoning-
+                        # Items ein `summary`-Feld (400 "Missing required parameter:
+                        # input[..].summary" sonst). Wir führen keine Summaries mit,
+                        # also leere Liste — encrypted_content trägt den State.
+                        items.append({
+                            "type": "reasoning",
+                            "encrypted_content": encrypted,
+                            "summary": [],
+                        })
                 elif btype == "tool_use":
                     tool_uses.append(b)
             joined = "".join(text_parts)

--- a/core/tests/test_codex_context.py
+++ b/core/tests/test_codex_context.py
@@ -27,8 +27,21 @@ def test_encrypted_reasoning_replayed_for_same_model_only():
     ]}]
     _, same = messages_to_codex(messages, model="openai-codex/gpt-5.6-sol")
     _, switched = messages_to_codex(messages, model="openai-codex/gpt-5.5")
-    assert {"type": "reasoning", "encrypted_content": "opaque"} in same
+    assert {"type": "reasoning", "encrypted_content": "opaque", "summary": []} in same
     assert all(item.get("type") != "reasoning" for item in switched)
+
+
+def test_replayed_reasoning_item_carries_summary_field():
+    """Regression: Die Responses-API lehnt zurückgesendete reasoning-Items ohne
+    'summary' mit HTTP 400 ab ("Missing required parameter: input[..].summary").
+    Das ließ Codex-Modelle nach dem ERSTEN Tool-Call stumm abbrechen."""
+    messages = [{"role": "assistant", "content": [
+        {"type": "codex_reasoning", "encrypted_content": "enc", "model": "openai-codex/gpt-5.6-sol"},
+        {"type": "tool_use", "id": "call_1", "name": "load_skill", "input": {"name": "x"}},
+    ]}]
+    _, items = messages_to_codex(messages, model="openai-codex/gpt-5.6-sol")
+    reasoning = [i for i in items if i.get("type") == "reasoning"]
+    assert reasoning and all("summary" in i for i in reasoning)
 
 
 def test_codex_payload_requests_cache_replay_material():


### PR DESCRIPTION
## Symptom
Buddy mit einem **gpt-5.6-Codex-Modell** + Reasoning-Tiefe (xhigh) antwortete ein paar Sätze und **verstummte dann** — keine Fehlermeldung, keine Ausgabe.

## Root-Cause (empirisch verifiziert gegen die echte Codex-API)
Aus der Session-DB rekonstruiert: Der Abbruch passierte **exakt nach dem ersten Tool-Call** (`load_skill`). Beim Folge-Call sendet `messages_to_codex` die encrypted `reasoning`-Items zurück an die OpenAI Responses-API. Die verlangt dabei zwingend ein `summary`-Feld:

```
HTTP 400: "Missing required parameter: 'input[1].summary'"
```

Da vor dem Tool-Call keine Text-Antwort gestreamt wurde, griff auch der Retry-Pfad nicht → der Turn brach **still** ab. Reine Textantworten (ohne Tools) erzeugen keine replay-pflichtigen reasoning-Items — deshalb "gingen ein paar Sätze, dann Schluss".

### Beweis
Ich habe den echten Folge-Call mit dem `encrypted_content` aus der Live-Session nachgebaut:
- **vorher:** `400 Missing required parameter: 'input[1].summary'`
- **mit `summary: []`:** `200`, Codex streamt normal weiter (hier direkt der nächste sinnvolle Tool-Call)

## Fix
`reasoning`-Items werden mit `summary: []` emittiert — wir führen keine Summaries mit, der `encrypted_content` trägt den Reasoning-State.

## Tests
- Regressionstest `test_replayed_reasoning_item_carries_summary_field`
- bestehenden Replay-Test auf den korrekten Contract (`{..., "summary": []}`) angepasst
- 51 Codex/Reasoning-Tests grün · ruff clean · Datei <200 Zeilen

## Betrifft
Alle Codex-OAuth-Modelle (gpt-5.6-sol/terra/luna, gpt-5.5, gpt-5.4 …) in **jedem** Chat/Buddy mit Tool-Nutzung — nicht nur Buddy. Der Bug trat immer beim ersten Tool-Call auf.

Deploy: Backend-Änderung → Server-Update nötig.