### PR TITLE
feat(code-graph): granulare Verzeichnis-Auswahl mit Ordner-Browser

### DIFF
--- a/core/src/hydrahive/api/routes/code_graph.py
+++ b/core/src/hydrahive/api/routes/code_graph.py
@@ -29,6 +29,17 @@ def get_config(project_id: str, auth: Annotated[tuple[str, str], Depends(require
     return code_graph_config.get_config(project_id)
 
 
+@router.get("/config/browse")
+def browse_config(
+    project_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+    path: str = "",
+) -> dict:
+    """Unterverzeichnisse einer Ebene für die granulare Ordner-Auswahl."""
+    _authorize(project_id, auth)
+    return code_graph_config.browse_dirs(project_id, path)
+
+
 @router.put("/config")
 def put_config(project_id: str, body: GraphConfig, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
     _authorize(project_id, auth)

--- a/core/src/hydrahive/code_graph_config.py
+++ b/core/src/hydrahive/code_graph_config.py
@@ -60,6 +60,57 @@ def suggest_scan_dirs(project_id: str) -> list[str]:
     return found[:20]
 
 
+def _has_scannable_child(d: Path) -> bool:
+    """Ob ein Ordner mindestens einen nicht-ignorierten Unterordner hat
+    (für das Aufklapp-Chevron im Verzeichnis-Browser)."""
+    try:
+        for child in d.iterdir():
+            if child.is_dir() and child.name not in IGNORE_DIRS and not child.name.startswith("."):
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def browse_dirs(project_id: str, rel_path: str = "") -> dict:
+    """Direkte Unterverzeichnisse EINER Ebene für den Verzeichnis-Browser.
+
+    Erlaubt granulare Auswahl beliebiger Ordner (z.B. `sdk/` tief im Baum),
+    nicht nur die Namens-Heuristik aus suggest_scan_dirs. Traversal-geschützt:
+    nur Verzeichnisse innerhalb des Workspace werden aufgelistet.
+    Returns: {path, parent, dirs:[{rel, name, has_children}]}.
+    """
+    root = workspace_path(project_id).resolve()
+    if not root.is_dir():
+        return {"path": "", "parent": None, "dirs": []}
+    target = (root / rel_path).resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        target = root  # Traversal-Versuch → auf Workspace-Wurzel zurückfallen
+    if not target.is_dir():
+        target = root
+
+    dirs: list[dict] = []
+    try:
+        for child in sorted(target.iterdir(), key=lambda c: c.name.lower()):
+            if not child.is_dir() or child.name in IGNORE_DIRS or child.name.startswith("."):
+                continue
+            dirs.append({
+                "rel": child.relative_to(root).as_posix(),
+                "name": child.name,
+                "has_children": _has_scannable_child(child),
+            })
+    except OSError:
+        pass
+
+    cur_rel = target.relative_to(root).as_posix() if target != root else ""
+    parent = None if target == root else (
+        target.parent.relative_to(root).as_posix() if target.parent != root else ""
+    )
+    return {"path": cur_rel, "parent": parent, "dirs": dirs}
+
+
 def validate_scan_dirs(project_id: str, scan_dirs: list[str]) -> list[str]:
     """Filtert scan_dirs auf existierende Verzeichnisse INNERHALB des Workspace.
     Path-Traversal (../, absolute Pfade außerhalb) wird verworfen."""

--- a/core/tests/test_code_graph_config.py
+++ b/core/tests/test_code_graph_config.py
@@ -37,6 +37,41 @@ def test_suggestions_find_source_dirs_and_skip_ignored():
     assert all("node_modules" not in s for s in suggestions)
 
 
+def test_browse_lists_direct_subdirs_and_skips_ignored():
+    pid, ws = _project_with_dirs()
+    (ws / "sdk").mkdir(exist_ok=True)
+    result = code_graph_config.browse_dirs(pid, "")
+    names = {d["name"] for d in result["dirs"]}
+    assert "core" in names and "frontend" in names and "sdk" in names
+    assert "node_modules" not in names  # IGNORE_DIRS
+    assert result["parent"] is None  # an der Wurzel
+
+
+def test_browse_navigates_into_nested_dir():
+    pid, ws = _project_with_dirs()
+    (ws / "sdk" / "client" / "net").mkdir(parents=True, exist_ok=True)
+    result = code_graph_config.browse_dirs(pid, "sdk/client")
+    rels = {d["rel"] for d in result["dirs"]}
+    assert "sdk/client/net" in rels
+    assert result["path"] == "sdk/client"
+    assert result["parent"] == "sdk"
+
+
+def test_browse_flags_has_children():
+    pid, ws = _project_with_dirs()
+    (ws / "sdk" / "inner").mkdir(parents=True, exist_ok=True)
+    result = code_graph_config.browse_dirs(pid, "")
+    sdk = next(d for d in result["dirs"] if d["name"] == "sdk")
+    assert sdk["has_children"] is True
+
+
+def test_browse_traversal_falls_back_to_root():
+    pid, _ = _project_with_dirs()
+    result = code_graph_config.browse_dirs(pid, "../../../etc")
+    assert result["path"] == ""  # Traversal → Wurzel
+    assert result["parent"] is None
+
+
 def test_graph_metrics_counts_nodes_edges_communities(tmp_path):
     graph = tmp_path / "graph.json"
     graph.write_text(json.dumps({

--- a/docs/specs/code-graph.md
+++ b/docs/specs/code-graph.md
@@ -45,6 +45,9 @@ anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
 - `ensure_installed()` → legt venv an + pip install (idempotent, mit Timeout).
 - `get_config(project_id)` / `set_config(project_id, scan_dirs)` — scan_dirs gegen
   Path-Traversal validiert (müssen **innerhalb** des Workspace liegen, existieren).
+- `browse_dirs(project_id, rel_path)` → direkte Unterordner EINER Ebene
+  ({path, parent, dirs:[{rel, name, has_children}]}) für granulare Auswahl
+  beliebiger Verzeichnisse (z.B. `sdk/` tief im Baum), Traversal-geschützt.
 - `build(project_id)` → für jedes scan_dir `graphify update`; danach die
   Einzelgraphen per `merge-graphs` zu **einem** Gesamtgraphen mergen und via
   `cluster-only` (`GRAPHIFY_VIZ_NODE_LIMIT` hochgesetzt) `graph.html` + Report
@@ -60,13 +63,16 @@ anschauen). Agenten-Tools (query/explain/path) folgen in Etappe 2.
 - Routen (neuer Router `code_graph.py`, require_auth + _authorize):
   - `GET  /api/projects/{id}/code-graph/status`
   - `GET/PUT /api/projects/{id}/code-graph/config`
+  - `GET  /api/projects/{id}/code-graph/config/browse?path=<rel>`
   - `POST /api/projects/{id}/code-graph/build`
   - Report/HTML über `status` (Pfade) → Frontend lädt via `/api/files`.
 
 ### Frontend
 - `projectsApi`-Erweiterung bzw. `codeGraphApi` (status/config/build).
-- **`ProjectGraphOverlay`**: Verzeichnis-Auswahl (Checkbox-Liste aus Vorschlägen +
-  manuell), „Graph bauen" (zeigt Fortschritt), nach Build: Metriken + God-Nodes +
+- **`ProjectGraphOverlay`**: Verzeichnis-Auswahl (gewählte Ordner als entfernbare
+  Chips + Vorschlags-Quick-Picks + navigierbarer `GraphDirBrowser` mit Breadcrumb
+  für beliebige Unterordner), „Graph bauen" (zeigt Fortschritt), nach Build:
+  Metriken + God-Nodes +
   echte Import-Zyklen (rot mit vollen Pfaden; grüne „keine Zyklen"-Bestätigung
   wenn sauber), und die interaktive `graph.html` als iframe
   (`/api/files?path=…`). Bootstrap-Hinweis, falls venv erst eingerichtet wird.

--- a/frontend/src/features/cockpit/codeGraphApi.ts
+++ b/frontend/src/features/cockpit/codeGraphApi.ts
@@ -20,6 +20,13 @@ export interface CodeGraphConfig {
   suggestions: string[]
 }
 
+export interface CodeGraphDirEntry { rel: string; name: string; has_children: boolean }
+export interface CodeGraphBrowse {
+  path: string
+  parent: string | null
+  dirs: CodeGraphDirEntry[]
+}
+
 export interface CodeGraphBuildResult {
   built_at: string
   scan_dirs: string[]
@@ -34,6 +41,7 @@ const base = (projectId: string) => `/projects/${projectId}/code-graph`
 export const codeGraphApi = {
   status: (projectId: string) => api.get<CodeGraphStatus>(`${base(projectId)}/status`),
   getConfig: (projectId: string) => api.get<CodeGraphConfig>(`${base(projectId)}/config`),
+  browse: (projectId: string, path = "") => api.get<CodeGraphBrowse>(`${base(projectId)}/config/browse?path=${encodeURIComponent(path)}`),
   setConfig: (projectId: string, scanDirs: string[]) => api.put<CodeGraphConfig>(`${base(projectId)}/config`, { scan_dirs: scanDirs }),
   build: (projectId: string) => api.post<CodeGraphBuildResult>(`${base(projectId)}/build`, {}),
 }

--- a/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
+++ b/frontend/src/features/cockpit/project/ProjectGraphOverlay.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react"
-import { Loader2, Network } from "lucide-react"
+import { Loader2, Network, X } from "lucide-react"
 import type { Project } from "@/features/projects/types"
 import { codeGraphApi, graphFileUrl, type CodeGraphStatus } from "../codeGraphApi"
 import { CockpitButton } from "../CockpitButton"
 import { CockpitSectionLabel } from "../CockpitPanel"
+import { GraphDirBrowser } from "./_GraphDirBrowser"
 
 export function ProjectGraphOverlay({ project, onClose }: { project: Project; onClose: () => void }) {
   const [status, setStatus] = useState<CodeGraphStatus | null>(null)
@@ -67,20 +68,42 @@ export function ProjectGraphOverlay({ project, onClose }: { project: Project; on
           {/* Steuerung: Verzeichnis-Auswahl + Build */}
           <div className="space-y-3">
             <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3">
-              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Verzeichnisse</p>
-              {suggestions.length === 0 ? (
-                <p className="text-xs text-[#7a869c]">Keine Quellordner gefunden.</p>
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">
+                Zu scannen{selected.length ? ` (${selected.length})` : ""}
+              </p>
+              {selected.length === 0 ? (
+                <p className="text-xs text-[#7a869c]">Noch nichts gewählt — unten Ordner hinzufügen.</p>
               ) : (
-                <ul className="space-y-1">
-                  {suggestions.map((dir) => (
+                <ul className="flex flex-wrap gap-1.5">
+                  {selected.map((dir) => (
                     <li key={dir}>
-                      <label className="flex cursor-pointer items-center gap-2 text-xs text-[#c3ccdd]">
-                        <input type="checkbox" checked={selected.includes(dir)} onChange={() => toggle(dir)} className="accent-cyan-400" />
-                        <span className="truncate font-mono">{dir}</span>
-                      </label>
+                      <button
+                        onClick={() => toggle(dir)}
+                        title="Entfernen"
+                        className="flex items-center gap-1 rounded-full border border-cyan-400/40 bg-cyan-400/10 py-0.5 pl-2 pr-1 text-[11px] font-mono text-cyan-100 hover:border-rose-400/50 hover:bg-rose-400/10"
+                      >
+                        <span className="max-w-[180px] truncate">{dir}</span>
+                        <X size={11} className="shrink-0" />
+                      </button>
                     </li>
                   ))}
                 </ul>
+              )}
+              {suggestions.length > 0 && (
+                <div className="mt-3">
+                  <p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-[#68758a]">Vorschläge</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {suggestions.filter((d) => !selected.includes(d)).map((dir) => (
+                      <button
+                        key={dir}
+                        onClick={() => toggle(dir)}
+                        className="rounded-full border border-[#2a364b] bg-[#0d1420] px-2 py-0.5 text-[11px] font-mono text-[#8d9ab0] hover:border-cyan-400/40 hover:text-cyan-100"
+                      >
+                        + {dir}
+                      </button>
+                    ))}
+                  </div>
+                </div>
               )}
               <button
                 type="button"
@@ -94,6 +117,8 @@ export function ProjectGraphOverlay({ project, onClose }: { project: Project; on
               {building ? <p className="mt-2 text-[11px] text-[#8d9ab0]">Erstlauf richtet das Analyse-Tool ein — kann einen Moment dauern.</p> : null}
               {error ? <p className="mt-2 text-[11px] text-rose-300">{error}</p> : null}
             </div>
+
+            <GraphDirBrowser projectId={project.id} selected={selected} onToggle={toggle} />
 
             {metrics?.nodes ? (
               <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3 text-xs text-[#c3ccdd]">

--- a/frontend/src/features/cockpit/project/_GraphDirBrowser.tsx
+++ b/frontend/src/features/cockpit/project/_GraphDirBrowser.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react"
+import { ChevronRight, FolderPlus, Folder, CornerLeftUp, Check } from "lucide-react"
+import { codeGraphApi, type CodeGraphBrowse } from "../codeGraphApi"
+
+/** Navigierbarer Verzeichnis-Browser: erlaubt granulare Auswahl beliebiger
+ *  Unterordner (z.B. `sdk/` tief im Baum), nicht nur die Namens-Vorschläge. */
+export function GraphDirBrowser({
+  projectId, selected, onToggle,
+}: {
+  projectId: string
+  selected: string[]
+  onToggle: (rel: string) => void
+}) {
+  const [browse, setBrowse] = useState<CodeGraphBrowse | null>(null)
+  const [path, setPath] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    const load = async () => {
+      setLoading(true)
+      try {
+        const b = await codeGraphApi.browse(projectId, path)
+        if (alive) setBrowse(b)
+      } catch {
+        if (alive) setBrowse({ path, parent: null, dirs: [] })
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+    void load()
+    return () => { alive = false }
+  }, [projectId, path])
+
+  const crumbs = path ? path.split("/") : []
+
+  return (
+    <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-3">
+      <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.14em] text-[#68758a]">Ordner durchsuchen</p>
+
+      {/* Breadcrumb */}
+      <div className="mb-2 flex flex-wrap items-center gap-1 text-[11px] text-[#8d9ab0]">
+        <button onClick={() => setPath("")} className="rounded px-1 font-mono hover:text-cyan-200 hover:underline">/</button>
+        {crumbs.map((seg, i) => {
+          const target = crumbs.slice(0, i + 1).join("/")
+          return (
+            <span key={target} className="flex items-center gap-1">
+              <ChevronRight size={11} className="text-[#46617f]" />
+              <button onClick={() => setPath(target)} className="rounded px-0.5 font-mono hover:text-cyan-200 hover:underline">{seg}</button>
+            </span>
+          )
+        })}
+      </div>
+
+      {/* Hoch-Navigation */}
+      {browse?.parent != null && (
+        <button
+          onClick={() => setPath(browse.parent ?? "")}
+          className="mb-1 flex w-full items-center gap-2 rounded-[3px] px-2 py-1 text-left text-xs text-[#8d9ab0] hover:bg-[#182234]"
+        >
+          <CornerLeftUp size={13} /> <span className="font-mono">..</span>
+        </button>
+      )}
+
+      {loading ? (
+        <p className="px-2 py-1 text-xs text-[#7a869c]">Lädt…</p>
+      ) : browse && browse.dirs.length === 0 ? (
+        <p className="px-2 py-1 text-xs text-[#7a869c]">Keine Unterordner.</p>
+      ) : (
+        <ul className="max-h-[220px] space-y-0.5 overflow-y-auto">
+          {browse?.dirs.map((d) => {
+            const isSel = selected.includes(d.rel)
+            return (
+              <li key={d.rel} className="flex items-center gap-1">
+                <button
+                  onClick={() => onToggle(d.rel)}
+                  title={isSel ? "Aus Auswahl entfernen" : "Zum Scan hinzufügen"}
+                  className={`grid h-5 w-5 shrink-0 place-items-center rounded-[3px] border ${isSel ? "border-cyan-400/60 bg-cyan-400/20 text-cyan-200" : "border-[#2a364b] text-[#46617f] hover:border-cyan-400/40"}`}
+                >
+                  {isSel ? <Check size={12} /> : <FolderPlus size={12} />}
+                </button>
+                <button
+                  onClick={() => d.has_children && setPath(d.rel)}
+                  disabled={!d.has_children}
+                  className={`flex min-w-0 flex-1 items-center gap-1.5 rounded-[3px] px-1.5 py-1 text-left text-xs ${d.has_children ? "text-[#c3ccdd] hover:bg-[#182234]" : "cursor-default text-[#8d9ab0]"}`}
+                >
+                  <Folder size={13} className="shrink-0 text-[#5f7a94]" />
+                  <span className="truncate font-mono">{d.name}</span>
+                  {d.has_children && <ChevronRight size={12} className="ml-auto shrink-0 text-[#46617f]" />}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Granulare Scan-Verzeichnis-Auswahl

Bisher konnte man im Graph-Overlay nur die **Namens-Heuristik-Vorschläge** (`src`, `core`, `server`, …) per Checkbox wählen. Bei verschachtelten Projekten wie **Runes of Magic** will man aber gezielt ein tiefes Unterverzeichnis scannen — z.B. nur `sdk/` — und das ging über die UI nicht.

(Das Backend akzeptierte via `validate_scan_dirs` beliebige gültige Pfade längst — es fehlte schlicht die Auswahl-UI.)

## Neu: navigierbarer Verzeichnis-Browser

**Backend**
- `code_graph_config.browse_dirs(project_id, rel_path)` → direkte Unterordner einer Ebene: `{path, parent, dirs:[{rel, name, has_children}]}`. Traversal-geschützt (Ausbruchsversuch → Fallback auf Workspace-Wurzel), `IGNORE_DIRS` gefiltert (`node_modules`, `.git`, `.graphify` …).
- Route `GET .../code-graph/config/browse?path=<rel>`

**Frontend**
- `GraphDirBrowser.tsx` (neu, ausgelagert): Breadcrumb-Navigation, in Ordner mit Unterordnern reinklicken, jeden Ordner per Icon zum Scan hinzufügen/entfernen.
- `ProjectGraphOverlay`: gewählte Ordner als **entfernbare Chips** + Vorschläge als **Quick-Picks** + Browser darunter.
- `codeGraphApi.browse()` + Typen.

## Verifikation
- 4 neue `browse_dirs`-Tests: subdirs+ignore, nested-navigation, `has_children`-Flag, traversal-fallback
- E2E gegen echtes Projekt: Wurzel → `hydrahive2/` → `core` → `src` (aufklappbar), Breadcrumb-Parents korrekt, `media`/`.graphify` etc. korrekt ausgefiltert
- 9 Config-Tests grün · ruff clean · tsc/eslint/build grün · alle Dateien <200 Zeilen

Deploy: Backend + Frontend → Server-Update nötig.