### PR TITLE
fix(chat): Modell-/Tiefe-Umschaltung im Projekt-Chat wirkt jetzt

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -225,8 +225,6 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
 
   const handleSessionChanged = (updated: Session) =>
     setSessions((cur) => cur.map((s) => s.id === updated.id ? updated : s))
-  const handleAgentChanged = (updated: AgentBrief) =>
-    setAgents((cur) => cur.map((a) => a.id === updated.id ? updated : a))
 
   async function createPreferredSession() {
     const agent = activeAgent ?? preferredAgent ?? agents.find((a) => !a.is_buddy) ?? agents[0]
@@ -357,7 +355,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
               knownAgentIds={knownAgentIds} buddyAgentIds={buddyAgentIds} projects={projects}
               onSelect={setActiveId} onDelete={handleDelete} onNew={() => setShowNew(true)}
               activeSession={activeSession} activeAgent={activeAgent}
-              onSessionChanged={handleSessionChanged} onAgentChanged={handleAgentChanged}
+              onSessionChanged={handleSessionChanged}
             />
           }
           center={embeddedCenter}

--- a/frontend/src/features/chat/SessionList.tsx
+++ b/frontend/src/features/chat/SessionList.tsx
@@ -21,10 +21,9 @@ interface Props {
   activeSession?: Session | null
   activeAgent?: AgentBrief | null
   onSessionChanged?: (session: Session) => void
-  onAgentChanged?: (agent: AgentBrief) => void
 }
 
-export function SessionList({ sessions, activeId, knownAgentIds, buddyAgentIds, projects, onSelect, onDelete, onNew, activeSession, activeAgent, onSessionChanged, onAgentChanged }: Props) {
+export function SessionList({ sessions, activeId, knownAgentIds, buddyAgentIds, projects, onSelect, onDelete, onNew, activeSession, activeAgent, onSessionChanged }: Props) {
   const { t } = useTranslation("chat")
   const { t: tCommon } = useTranslation("common")
   const [tab, setTab] = useState<Tab>("direct")
@@ -107,7 +106,6 @@ export function SessionList({ sessions, activeId, knownAgentIds, buddyAgentIds, 
           session={activeSession}
           agent={activeAgent}
           onSessionChanged={onSessionChanged}
-          onAgentChanged={onAgentChanged}
         />
       )}
     </div>

--- a/frontend/src/features/chat/SessionModelControls.tsx
+++ b/frontend/src/features/chat/SessionModelControls.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next"
 import { ModelPicker } from "./ModelPicker"
 import { ReasoningEffortPill } from "./ReasoningEffortPill"
 import { chatApi } from "./api"
-import { agentsApi } from "@/features/agents/api"
 import { useEffortLevels } from "@/features/llm/effort"
 import type { AgentBrief, Session } from "./types"
 
@@ -10,15 +9,17 @@ interface Props {
   session: Session
   agent: AgentBrief
   onSessionChanged: (session: Session) => void
-  onAgentChanged?: (agent: AgentBrief) => void
 }
 
 /** Modell-Picker + Reasoning-Effort für die aktive Session/Agent.
- *  Kapselt die Override-Logik (Agent-Default vs. Session-Override) und die
- *  modellabhängige Effort-Unterstützung an einer Stelle. */
-export function SessionModelControls({ session, agent, onSessionChanged, onAgentChanged }: Props) {
+ *  Das Modell wird als SESSION-Override (session.metadata.model_override)
+ *  gesetzt — session-lokal, ohne Admin-Rechte, und der Runner liest es pro
+ *  Iteration frisch (greift also ab dem nächsten Turn/Schritt). Der Agent-
+ *  Default bleibt unangetastet; „Reset" nimmt den Override wieder zurück. */
+export function SessionModelControls({ session, agent, onSessionChanged }: Props) {
   const { t } = useTranslation("chat")
-  const activeModel = (session.metadata as { model_override?: string })?.model_override || agent.llm_model || ""
+  const override = (session.metadata as { model_override?: string })?.model_override
+  const activeModel = override || agent.llm_model || ""
   const effortLevels = useEffortLevels(activeModel)
   const supportsReasoningEffort = effortLevels.length > 0
 
@@ -28,16 +29,17 @@ export function SessionModelControls({ session, agent, onSessionChanged, onAgent
         <span className="text-[9px] uppercase tracking-wider text-zinc-600 w-9 shrink-0">{t("model")}</span>
         <div className="flex-1 min-w-0">
           <ModelPicker
-            current={agent.llm_model}
-            hint={t("model_hint")}
+            current={activeModel}
+            hint={override ? t("model_hint") : `${t("model_hint")} · ${agent.llm_model}`}
             fullWidth
+            showReset={!!override}
+            onReset={async () => {
+              const updated = await chatApi.updateSession(session.id, { model_override: "" })
+              onSessionChanged(updated)
+            }}
             onPick={async (m) => {
-              const updatedAgent = await agentsApi.update(agent.id, { llm_model: m })
-              onAgentChanged?.({ ...agent, llm_model: updatedAgent.llm_model })
-              if ((session.metadata as { model_override?: string })?.model_override) {
-                const updated = await chatApi.updateSession(session.id, { model_override: "" })
-                onSessionChanged(updated)
-              }
+              const updated = await chatApi.updateSession(session.id, { model_override: m })
+              onSessionChanged(updated)
             }}
           />
         </div>


### PR DESCRIPTION
## Symptom
Im Projekt-Chat links das **Modell** (oder die **Reasoning-Tiefe**) umgeschaltet — der Agent blieb aber auf dem alten Modell / der alten Tiefe.

## Root-Cause (empirisch aus DB + Code belegt)
Der `ModelPicker` in `SessionModelControls` rief `agentsApi.update(agent.id, {llm_model})` und änderte damit den **Agent global**, statt — wie es der eigene `ModelPicker`-Docstring ausdrücklich vorschreibt (*"session.metadata.model_override im Chat"*) — das Session-Override zu setzen. Zwei Konsequenzen:

1. **`PATCH /agents/{id}` ist `require_admin`** → für Nicht-Admins schlägt der Modellwechsel mit **403** fehl, passiert also gar nicht.
2. `runner.run()` lädt den Agent nur **einmal** vor der Iterations-Schleife; ein globaler Agent-Change greift im laufenden Turn ohnehin nicht.

**DB-Beleg:** Über *alle* Sessions wurde `model_override` nur **1×** je gesetzt. Die aktive Projekt-Session hatte leere `metadata` und lief durchgängig auf `claude-opus-4-8` — trotz Umschaltung.

## Fix
Der Picker setzt jetzt `session.metadata.model_override` via `chatApi.updateSession` (session-lokal, **kein Admin nötig**). Der Runner liest `model_override` **und** `reasoning_effort` **pro Iteration frisch** (`runner.py:154-158`) — die Umschaltung greift ab dem nächsten Schritt.

- Agent-Default bleibt unangetastet; **„Reset auf Agent-Default"** nimmt den Override zurück.
- Toten `onAgentChanged`-Prop-Pfad (`SessionModelControls` → `SessionList` → `ChatPane`) mit entfernt.

## Verifikation
End-to-end der Runner-Resolve-Pfad gegen die echte DB:
- ohne Override → `(claude-opus-4-8, high)` (Agent-Default — das alte, hängende Verhalten)
- **mit** Session-Override (wie der Fix ihn setzt) → `(claude-sonnet-4-5, low)` ✅ greift sofort
- nach Reset → zurück auf Default

tsc/build grün · geänderte Dateien eslint-clean (ChatPane-Restfehler waren bereits auf main).

Die Reasoning-Tiefe nutzte `chatApi.updateSession` schon vorher korrekt — der Modell-Picker war der Ausreißer. Beide teilen sich jetzt denselben session-lokalen Pfad.

Deploy: reine Frontend-Änderung → Server-Update nötig.