### PR TITLE
chore(release): Frontend-Version auf 2.0.0 für Produktiv-Release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-markdown": "^0.12.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "gen:emotes": "node scripts/gen-emotes.mjs",


### PR DESCRIPTION
Angleich der Frontend-Version (0.0.0 → 2.0.0) an core/pyproject.toml (bereits 2.0.0) vor dem ersten Produktiv-Release **v2.0.0**.

Verifikation des Release-Stands (main d0f2e400 + dieser Angleich):
- 1721 Backend-Tests grün
- tsc + Frontend-Build grün
- ruff clean (82k Zeilen)
- Working tree sauber, CI auf main grün

Nach Merge → Tag `v2.0.0` + GitHub-Release.