### PR TITLE
fix(quality): blinde except-Exception-pass beseitigen (Cleanup #2)

### DIFF
--- a/core/src/hydrahive/api/middleware/api_keys.py
+++ b/core/src/hydrahive/api/middleware/api_keys.py
@@ -91,8 +91,10 @@ def verify(plain: str) -> dict | None:
         try:
             if bcrypt.checkpw(encoded, entry["key_hash"].encode()):
                 return {"username": entry["username"], "role": entry["role"]}
-        except Exception:
-            pass
+        except (ValueError, KeyError) as exc:
+            # Defekter/fehlender Hash-Eintrag — Key gilt als ungültig, aber der
+            # Grund darf nicht still verschwinden (Auth-Debugging).
+            logger.warning("API-Key-Prüfung fehlgeschlagen (key_id=%s): %s", key_id, exc)
         return None
 
     # Altformat-Fallback: lineare Schleife mit key_prefix-Filter

--- a/core/src/hydrahive/api/routes/_extensions_docker.py
+++ b/core/src/hydrahive/api/routes/_extensions_docker.py
@@ -72,8 +72,8 @@ async def install_docker_engine_stream():
         rc2, _ = await _run(_sudo(["usermod", "-aG", "docker", current_user]))
         if rc2 == 0:
             yield f"data: {json.dumps({'line': f'Benutzer {current_user} zur docker-Gruppe hinzugefügt'})}\n\n"
-    except Exception:
-        pass
+    except (OSError, KeyError):
+        pass  # Gruppe-Setzen optional (kein usermod/pwd-Eintrag) — Setup läuft weiter
 
     reset_docker_cache()
     yield f"data: {json.dumps({'line': '[OK] Docker ist bereit'})}\n\n"

--- a/core/src/hydrahive/api/routes/_extensions_helpers.py
+++ b/core/src/hydrahive/api/routes/_extensions_helpers.py
@@ -77,5 +77,5 @@ def write_docker_credentials(manifest: dict, params: dict[str, str]) -> None:
     cred_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
     try:
         os.chmod(cred_file, 0o640)
-    except Exception:
-        pass
+    except OSError:
+        pass  # Permission-Härtung best-effort (z.B. auf FS ohne chmod)

--- a/core/src/hydrahive/api/routes/_extensions_status.py
+++ b/core/src/hydrahive/api/routes/_extensions_status.py
@@ -137,8 +137,8 @@ async def extension_status(manifest: dict) -> dict:
             p = Path(url_file)
             if p.exists():
                 open_url = p.read_text().strip()
-        except Exception:
-            pass
+        except OSError:
+            pass  # optionale URL-Datei nicht lesbar — open_url bleibt leer
 
     return {
         **manifest,

--- a/core/src/hydrahive/api/routes/_extensions_stream.py
+++ b/core/src/hydrahive/api/routes/_extensions_stream.py
@@ -88,8 +88,8 @@ async def stream_docker(
                 if os.getuid() != 0:
                     sysctl_cmd = ["sudo", "-n"] + sysctl_cmd
                 subprocess.run(sysctl_cmd, capture_output=True, timeout=5)
-            except Exception:
-                pass
+            except (OSError, subprocess.SubprocessError):
+                pass  # sysctl best-effort (fehlende Rechte/kein sudo) — unkritisch
         elif action == "down":
             # Leere .env damit compose keine Warnings über fehlende Variablen wirft
             tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False, dir="/tmp")

--- a/core/src/hydrahive/api/routes/agents.py
+++ b/core/src/hydrahive/api/routes/agents.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Annotated
 
@@ -19,6 +20,8 @@ from hydrahive.api.routes._agent_schemas import (
 )
 from hydrahive.plugins import tool_bridge as plugin_bridge
 from hydrahive.tools import REGISTRY as TOOL_REGISTRY
+
+logger = logging.getLogger(__name__)
 
 _TEMPLATE_DIR = Path(__file__).parent.parent.parent / "agents" / "soul_templates"
 _EXAMPLE_AGENT_DIR = Path(__file__).parents[5] / "examples" / "agents"
@@ -54,8 +57,8 @@ def list_agent_templates(_: Annotated[tuple[str, str], Depends(require_auth)]) -
     for f in sorted(_EXAMPLE_AGENT_DIR.glob("*.json")):
         try:
             result.append(json.loads(f.read_text()))
-        except Exception:
-            pass
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Beispiel-Agent-Template %s übersprungen: %s", f.name, exc)
     return result
 
 

--- a/core/src/hydrahive/api/routes/extensions.py
+++ b/core/src/hydrahive/api/routes/extensions.py
@@ -100,8 +100,8 @@ async def install_extension(ext_id: str, request: Request) -> StreamingResponse:
         body = await request.json()
         user_params = body.get("params", {})
         mode = body.get("mode", "native")
-    except Exception:
-        pass
+    except (ValueError, TypeError):
+        pass  # leerer/kein JSON-Body — Defaults (native, keine Params) gelten
 
     errors = validate_manifest(manifest, mode)
     if errors:
@@ -154,8 +154,8 @@ async def uninstall_extension(ext_id: str, request: Request) -> StreamingRespons
     try:
         body = await request.json()
         mode = body.get("mode", "native")
-    except Exception:
-        pass
+    except (ValueError, TypeError):
+        pass  # leerer/kein JSON-Body — Default-Mode "native" gilt
 
     if mode == "docker":
         docker = manifest.get("docker")
@@ -172,8 +172,8 @@ async def uninstall_extension(ext_id: str, request: Request) -> StreamingRespons
             ]:
                 try:
                     cleanup.unlink(missing_ok=True)
-                except Exception:
-                    pass
+                except OSError:
+                    pass  # Cleanup best-effort — Datei bleibt liegen, unkritisch
             yield "data: {\"done\": true}\n\n"
 
         return StreamingResponse(_generate_docker_down(), media_type="text/event-stream", headers=_SSE_HEADERS)

--- a/core/src/hydrahive/api/routes/federation.py
+++ b/core/src/hydrahive/api/routes/federation.py
@@ -1,6 +1,7 @@
 """Federation API — Workstation-Registry + A2A-Card-Refresh + Client-Config-Generator."""
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Annotated
 
@@ -12,6 +13,8 @@ from hydrahive.api.middleware import api_keys as ak
 from hydrahive.api.middleware.auth import require_admin, require_auth
 from hydrahive.db import federation as fed_db
 from hydrahive.federation.registry import fetch_card
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/federation", tags=["federation"])
 
@@ -173,8 +176,10 @@ async def create_client(
         try:
             invite = await create_invite()
             authkey = invite.get("auth_key") or None
-        except Exception:
-            pass
+        except Exception as exc:
+            # Invite ist optional (Tailscale evtl. ohne Auth-Key-Rechte) — der
+            # Rest der Antwort bleibt gültig, aber der Grund soll auffindbar sein.
+            logger.warning("Tailscale-Invite konnte nicht erstellt werden: %s", exc)
         tailscale_section = {
             "ip": ts.get("ip"),
             "hostname": ts.get("hostname"),

--- a/core/src/hydrahive/communication/mail/imap_poll.py
+++ b/core/src/hydrahive/communication/mail/imap_poll.py
@@ -112,8 +112,8 @@ def fetch(cfg: dict, folder: str, *, criterion: str = "ALL",
         if conn is not None:
             try:
                 conn.logout()
-            except Exception:
-                pass
+            except (OSError, imaplib.IMAP4.error):
+                pass  # Verbindung wird ohnehin verworfen — Logout-Fehler egal
     return out
 
 

--- a/core/src/hydrahive/credentials/redaction.py
+++ b/core/src/hydrahive/credentials/redaction.py
@@ -13,11 +13,14 @@ Keine dritte hartcodierte Liste — neue Provider sind automatisch abgedeckt.
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 from typing import Any, Iterable
 
 from hydrahive.tools.base import ToolResult
+
+logger = logging.getLogger(__name__)
 
 # Werte kürzer als das werden NICHT geschwärzt: ein kurzer Secret-Wert (oder ein
 # leerer) würde sonst als Substring überall im Output matchen und ihn zerstören.
@@ -74,8 +77,10 @@ def agent_secret_values(agent_id: str) -> set[str]:
             pw = (tc.get(block) or {}).get("password", "")
             if len(pw) >= MIN_SECRET_LEN:
                 out.add(pw)
-    except Exception:
-        pass
+    except Exception as exc:
+        # Sicherheitsrelevant: schlägt das Laden fehl, werden diese Secrets NICHT
+        # geschwärzt. Nicht still verschlucken — sonst leakt es unbemerkt.
+        logger.warning("Mail-Secrets für Redaction (agent=%s) nicht ladbar: %s", agent_id, exc)
     return out
 
 

--- a/core/src/hydrahive/db/mirror_import_sqlite.py
+++ b/core/src/hydrahive/db/mirror_import_sqlite.py
@@ -87,7 +87,9 @@ def _explode_row(m: dict, s: dict) -> list[dict]:
     content = m.get("content", "")
     try:
         content = json.loads(content)
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
+        # content ist legitim auch als Roh-String gültig (Plaintext-Message) —
+        # dann bleibt es unverändert. Nur echte Parse-Fehler abfangen.
         pass
 
     msg = Message(

--- a/core/src/hydrahive/oauth/anthropic.py
+++ b/core/src/hydrahive/oauth/anthropic.py
@@ -80,8 +80,8 @@ def parse_callback_input(value: str) -> dict[str, str]:
                 out["state"] = qs["state"][0]
             if out:
                 return out
-    except Exception:
-        pass
+    except ValueError:
+        pass  # kein parsebarer URL — Fallback-Parsing unten versuchen
     # 'code#state'-Format wie pi-ai
     if "#" in value:
         code, state = value.split("#", 1)

--- a/core/src/hydrahive/oauth/openai_codex.py
+++ b/core/src/hydrahive/oauth/openai_codex.py
@@ -78,8 +78,8 @@ def parse_callback_input(value: str) -> dict[str, str]:
                 out["state"] = qs["state"][0]
             if out:
                 return out
-    except Exception:
-        pass
+    except ValueError:
+        pass  # kein parsebarer URL — Fallback-Parsing unten versuchen
     if "#" in value and "code=" not in value:
         c, s = value.split("#", 1)
         return {"code": c, "state": s}


### PR DESCRIPTION
Zweiter Post-Release-Aufräumschritt aus dem Code-Quality-Deep-Dive.

## Problem
15 Stellen mit `except Exception: pass` verschluckten Fehler **blind** — exakt die Bug-Klasse, die uns beim Codex-`summary`-Problem gebissen hat: Der Fehler passiert, aber niemand sieht ihn. Leerer Zustand statt Fehlermeldung.

## Vorgehen
Jede Stelle **einzeln bewertet** — nicht pauschal ersetzt.

### Fehler jetzt sichtbar (Logging ergänzt)
| Datei | Grund |
|-------|-------|
| `api_keys.py` | bcrypt-Prüfung bei defektem Hash → `logger.warning` (Auth-Debugging) |
| `credentials/redaction.py` | **Sicherheit**: schlägt das Laden der Mail-Secrets fehl, werden sie unbemerkt **nicht geschwärzt** → `logger.warning` |
| `api/routes/agents.py` | defektes Beispiel-Agent-Template still übersprungen → `logger.warning` |
| `api/routes/federation.py` | Tailscale-Invite fehlgeschlagen → `logger.warning` |

### Exception-Typ verengt (best-effort, `pass` korrekt — aber `except Exception` zu breit)
`_extensions_status.py` (OSError) · `extensions.py` 3× (ValueError/TypeError, OSError) · `_extensions_helpers.py` chmod (OSError) · `_extensions_docker.py` usermod (OSError/KeyError) · `_extensions_stream.py` sysctl (OSError/SubprocessError) · `imap_poll.py` logout (OSError/IMAP4.error) · `mirror_import_sqlite.py` json (JSONDecodeError/TypeError) · `oauth/openai_codex.py` + `oauth/anthropic.py` url-parse (ValueError)

Jede verbleibende `pass`-Stelle hat jetzt einen **erklärenden Kommentar**, warum sie bewusst leer ist.

## Ergebnis
**0** blinde `except Exception: pass` mehr im gesamten Produktivcode.

- 260 betroffene Tests grün · ruff clean · alle 13 Module laden fehlerfrei

Deploy: Backend-Änderung → Server-Update nötig.