### PR TITLE
fix(runner): leerer Turn wird sichtbar statt still zu enden (Cleanup #3)

### DIFF
--- a/core/src/hydrahive/runner/context.py
+++ b/core/src/hydrahive/runner/context.py
@@ -203,3 +203,20 @@ def merge_text_blocks(blocks: list[dict]) -> str:
 def extract_tool_uses(blocks: list[dict]) -> list[dict]:
     """Filter assistant content to just tool_use blocks."""
     return [b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"]
+
+
+def has_visible_content(blocks: list[dict]) -> bool:
+    """Ob die Antwort etwas Sichtbares/Handlungsrelevantes enthält.
+
+    Reine reasoning/thinking-Blöcke ohne Text und ohne tool_use zählen NICHT —
+    ein solcher Turn bringt den User nicht weiter und darf nicht als stiller
+    Leerlauf durchgehen (sonst: Chat wirkt „hängt", ohne Fehlermeldung)."""
+    for b in blocks:
+        if not isinstance(b, dict):
+            continue
+        btype = b.get("type")
+        if btype == "tool_use":
+            return True
+        if btype == "text" and (b.get("text") or "").strip():
+            return True
+    return False

--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -33,7 +33,12 @@ from hydrahive.runner._runner_iter import (
 )
 from hydrahive.runner.system_prompt import compose as compose_system_prompts
 from hydrahive.runner._runner_tools import process_tool_uses
-from hydrahive.runner.context import extract_tool_uses, heal_orphan_tool_uses, to_anthropic_messages
+from hydrahive.runner.context import (
+    extract_tool_uses,
+    has_visible_content,
+    heal_orphan_tool_uses,
+    to_anthropic_messages,
+)
 from hydrahive.runner.events import Done, Error, Event, IterationStart
 from hydrahive.skills.loader import list_for_agent as load_agent_skills
 from hydrahive.tools import ToolContext, schemas_for
@@ -271,6 +276,23 @@ async def run(
                 f"max_tokens ({agent.get('max_tokens', DEFAULT_MAX_TOKENS)}) erreicht — Antwort abgeschnitten. "
                 "Tool-Argumente sind unvollständig. Erhöhe max_tokens oder formuliere die Aufgabe kürzer.",
                 metadata={"stop_reason": result.stop_reason, "message_id": assistant_msg.id},
+            ); return
+
+        # Leerer Turn: LLM lieferte weder Text noch Tool-Use (z.B. nur reasoning-
+        # Blöcke oder eine komplett leere Antwort). Früher endete das still als
+        # "completed" → der Chat wirkte, als hänge er, ohne jede Fehlermeldung.
+        # Jetzt sichtbar als Fehler melden statt stumm zu beenden.
+        if not tool_uses and not has_visible_content(result.blocks):
+            logger.warning(
+                "Leere LLM-Antwort (model=%s, stop=%s, blocks=%d) — Turn ohne sichtbaren Inhalt",
+                result.used_model, result.stop_reason, len(result.blocks),
+            )
+            session_end(agent["id"], session_id, status="abandoned")
+            yield Error(
+                "Das Modell hat eine leere Antwort geliefert (kein Text, kein Tool-Aufruf). "
+                "Bitte erneut senden — ggf. anderes Modell oder Reasoning-Tiefe wählen.",
+                metadata={"stop_reason": result.stop_reason, "model": result.used_model,
+                          "message_id": assistant_msg.id},
             ); return
 
         if not tool_uses:

--- a/core/tests/test_runner_context.py
+++ b/core/tests/test_runner_context.py
@@ -8,6 +8,7 @@ from hydrahive.db.messages import Message
 from hydrahive.runner.context import (
     _sanitize_block,
     extract_tool_uses,
+    has_visible_content,
     heal_orphan_tool_uses,
     merge_text_blocks,
     to_anthropic_messages,
@@ -228,3 +229,36 @@ def test_heal_dedupliziert_doppelte_tool_results():
     results = [b for b in out[1].content if b.get("type") == "tool_result"]
     assert len(results) == 1
     assert results[0]["content"] == "first"
+
+
+def test_has_visible_content_true_for_text():
+    assert has_visible_content([{"type": "text", "text": "Hallo"}]) is True
+
+
+def test_has_visible_content_true_for_tool_use():
+    assert has_visible_content([{"type": "tool_use", "id": "t1", "name": "x", "input": {}}]) is True
+
+
+def test_has_visible_content_false_for_empty():
+    assert has_visible_content([]) is False
+
+
+def test_has_visible_content_false_for_whitespace_only_text():
+    assert has_visible_content([{"type": "text", "text": "   \n  "}]) is False
+
+
+def test_has_visible_content_false_for_reasoning_only():
+    # Nur reasoning/thinking ohne Text/Tool → gilt als leerer Turn.
+    blocks = [
+        {"type": "codex_reasoning", "encrypted_content": "enc", "model": "openai-codex/gpt-5.6-sol"},
+        {"type": "thinking", "thinking": "hmm", "signature": "s"},
+    ]
+    assert has_visible_content(blocks) is False
+
+
+def test_has_visible_content_true_when_text_alongside_reasoning():
+    blocks = [
+        {"type": "codex_reasoning", "encrypted_content": "enc", "model": "m"},
+        {"type": "text", "text": "Antwort"},
+    ]
+    assert has_visible_content(blocks) is True


### PR DESCRIPTION
Dritter Post-Release-Aufräumschritt — der Punkt, der **dich direkt betraf**: „keine Fehlermeldung, aber auch keine Ausgabe".

## Symptom
Lieferte das LLM eine Antwort **ohne Text und ohne Tool-Aufruf** (z.B. nur verschlüsselte reasoning-Blöcke — genau der Codex-`summary`-Fall — oder komplett leer), endete der Turn **still als „completed"**. Der Chat wirkte, als hänge er: keine Fehlermeldung, keine Ausgabe.

## Root-Cause
In `runner.py` prüfte der Code nur `if not tool_uses:` → Session endet „completed", auch wenn `result.blocks` komplett leer ist. Es gab **keinen Check auf eine substanziell leere Antwort**.

## Fix
Neuer Helper `context.has_visible_content(blocks)`: prüft, ob die Antwort mindestens einen **nicht-leeren Text-Block** oder einen **`tool_use`** enthält. Reine `reasoning`/`thinking`-Blöcke zählen **nicht** (die bringen den User nicht weiter).

Im Runner wird ein Turn ohne sichtbaren Inhalt jetzt als **`Error`** gemeldet (`session_end("abandoned")` + `logger.warning` mit model/stop_reason), statt stumm zu beenden.

## Verifikation (gegen alle Szenarien)
| Szenario | Guard feuert? |
|----------|---------------|
| codex-nur-reasoning (realer Bug-Fall) | ✅ ja → User sieht Fehler |
| komplett leer | ✅ ja |
| normaler Text | ❌ nein (kein False Positive) |
| tool_use | ❌ nein |

- 6 neue Unit-Tests für `has_visible_content` · 120 runner-nahe Tests grün · ruff clean

Zusammen mit dem `summary`-Fix (#329) ist damit **beide** Hälften des Codex-Problems abgedeckt: die Ursache behoben **und** falls je wieder etwas Leeres kommt, wird es sichtbar statt still verschluckt.

Deploy: Backend-Änderung → Server-Update nötig.