### PR TITLE
chore(frontend): TypeScript strict mode aktivieren (Cleanup #4)

### DIFF
--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["node"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Der **größte Hebel** aus dem Code-Quality-Deep-Dive — und angenehm undramatisch im Ergebnis.

## Problem
`tsconfig.app.json`/`tsconfig.node.json` hatten **kein `strict`** gesetzt (nur `noUnusedLocals`/`noUnusedParameters`). Damit lief TypeScript ohne `strictNullChecks`, `noImplicitAny`, `strictFunctionTypes` etc. → Null-/Undefined-Bugs und implizite `any` konnten unbemerkt durchrutschen.

## Messung zuerst (statt Hauruck)
Ich habe `strict` erst temporär aktiviert und gemessen, wie groß der Berg ist — mit der Erwartung von zig bis hunderten Fehlern (v.a. `strictNullChecks`).

**Ergebnis: 0 Fehler.** Die Codebase ist bereits strict-kompatibel geschrieben. Die vorhandenen `any` sind durchweg *explizit* annotiert (unter strict erlaubt), es gibt keine impliziten.

## Änderung
`"strict": true` in beiden Projekt-Configs:
- `tsconfig.app.json` → deckt `src/` ab
- `tsconfig.node.json` → deckt `vite.config.ts` ab

Kein einziger Code-Fix nötig, kein Big-Bang-Refactor — ein 2-Zeilen-Diff.

## Verifikation
- `tsc -b --force` mit strict in **beiden** Configs: **0 Fehler**
- **Sanity-Probe**: absichtlicher `null`-Zugriff wird jetzt korrekt gefangen (`TS18047: possibly null`) → strict greift wirklich
- `npm run build` grün
- eslint-Stand **unverändert** (die vorbestehenden 234 Meldungen sind unabhängig von strict — mit/ohne Änderung identisch)

## Wirkung
Ab jetzt fängt der Compiler `strictNullChecks`/`noImplicitAny`/… **projektweit** — neue Null-/`any`-Bugs werden zur **Build-Zeit** sichtbar statt zur Laufzeit. Und `strict: true` zieht künftige TS-strict-Flags automatisch mit.

Deploy: reine Config/Frontend-Änderung → Server-Update baut das Frontend neu.