### PR TITLE
chore(frontend): ESLint in CI mit gestaffelter Severity (Cleanup #5)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,3 +54,10 @@ jobs:
       - name: Type-check
         working-directory: frontend
         run: npx tsc --noEmit
+
+      - name: ESLint
+        working-directory: frontend
+        # Blockiert nur bei echten Fehlern (severity=error). Warnungen (react-
+        # hooks-v7-Rauschen, exhaustive-deps-Altfälle, explizite any) bleiben
+        # sichtbar, brechen den Build aber nicht.
+        run: npx eslint .

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,10 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // dist = Build-Output; src/modules/* = zur Build-Zeit aus dem separaten
+  // hydrahive2-modules-Repo generiert (gitignored) — kein Quellcode dieses
+  // Repos, daher nicht linten (hält lokalen Lint deckungsgleich mit CI).
+  globalIgnores(['dist', 'src/modules/*/', 'src/modules/index.generated.ts']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -17,6 +20,33 @@ export default defineConfig([
     ],
     languageOptions: {
       globals: globals.browser,
+    },
+    // Severity-Politik (Cleanup #5): eslint läuft ab jetzt in CI. Damit das
+    // sinnvoll ist, ohne main mit Rauschen der neuen react-hooks-v7-Compiler-
+    // Suite rot zu färben, staffeln wir bewusst:
+    //  - error  = echte Fehler, die wir sauber halten (CI blockiert)
+    //  - warn   = wertvoll aber (noch) viele Alt-Treffer ODER zu aggressiv
+    rules: {
+      // Findet echte Stale-Closure-Bugs, aber 38 Alt-Fälle → separater Fix-PR.
+      'react-hooks/exhaustive-deps': 'warn',
+      // Neue, sehr aggressive react-compiler-Regeln (v7) mit vielen
+      // False-Positives auf legitime Muster — sichtbar als warn, nicht blockierend.
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/refs': 'warn',
+      'react-hooks/immutability': 'warn',
+      'react-hooks/purity': 'warn',
+      'react-hooks/static-components': 'warn',
+      // HMR-Hygiene — kein Laufzeitfehler.
+      'react-refresh/only-export-components': 'warn',
+      // Bewusst annotierte any bleiben erlaubt (unter TS-strict abgedeckt),
+      // implizite any fängt bereits der Compiler.
+      '@typescript-eslint/no-explicit-any': 'warn',
+      // Unterstrich-Präfix = bewusst ungenutzt (API-Signaturen, Platzhalter-
+      // Parameter). Etablierte Konvention — nicht als Fehler werten.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
     },
   },
 ])

--- a/frontend/src/features/buddy/BuddyPage.tsx
+++ b/frontend/src/features/buddy/BuddyPage.tsx
@@ -116,7 +116,9 @@ export function BuddyPage() {
         await buddyApi.logCmd(text, result.message)
         await chat.reload()
         setLocalMsgs([])
-      } catch {}
+      } catch {
+        /* Log/Reload best-effort — lokale Anzeige bleibt trotzdem gültig */
+      }
       return
     }
     await chat.send(text, files)

--- a/frontend/src/features/chat/workspace/FileTree.tsx
+++ b/frontend/src/features/chat/workspace/FileTree.tsx
@@ -27,7 +27,7 @@ export function FileTree({ agentId, path, onOpen, depth = 0 }: Props) {
           <div key={e.name}>
             <button
               onClick={() => e.is_dir
-                ? setExpanded((s) => { const n = new Set(s); n.has(e.name) ? n.delete(e.name) : n.add(e.name); return n })
+                ? setExpanded((s) => { const n = new Set(s); if (n.has(e.name)) n.delete(e.name); else n.add(e.name); return n })
                 : onOpen(childPath)}
               className="flex w-full items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-left text-[11px] text-[#cdd7e6] hover:bg-[#172133]"
               style={{ paddingLeft: `${6 + depth * 12}px` }}

--- a/frontend/src/features/datamining/GraphTab.tsx
+++ b/frontend/src/features/datamining/GraphTab.tsx
@@ -71,7 +71,9 @@ export function GraphTab() {
       try {
         const d = await dataminingApi.graph() as TopologyData
         if (d.active_agents) setActiveAgents(new Set(d.active_agents))
-      } catch {}
+      } catch {
+        /* Polling best-effort — nächster Tick versucht es erneut */
+      }
     }, 10000)
     return () => clearInterval(iv)
   }, [!!data])

--- a/frontend/src/features/extensions/ExtensionsPage.tsx
+++ b/frontend/src/features/extensions/ExtensionsPage.tsx
@@ -26,7 +26,7 @@ export function ExtensionsPage() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    try { setExtensions(await fetchExtensions()) } catch {}
+    try { setExtensions(await fetchExtensions()) } catch { /* Liste bleibt leer bei Fehler */ }
     setLoading(false)
   }, [])
 
@@ -74,7 +74,7 @@ export function ExtensionsPage() {
             const obj = JSON.parse(dataLine.slice(5).trim())
             if (obj.line !== undefined) setDockerInstallLog((l) => [...(l ?? []), obj.line])
             if (obj.done) { load(); break }
-          } catch {}
+          } catch { /* unvollständige SSE-Zeile überspringen */ }
         }
       }
     } catch (e) {

--- a/frontend/src/features/extensions/api.ts
+++ b/frontend/src/features/extensions/api.ts
@@ -48,7 +48,7 @@ export function streamAction(
           const obj = JSON.parse(dataLine.slice(5).trim())
           if (obj.done) { onDone(); return }
           if (obj.line !== undefined) onLine(obj.line)
-        } catch {}
+        } catch { /* unvollständige SSE-Zeile überspringen */ }
       }
     }
   }).catch((e) => {

--- a/frontend/src/features/streaming/StreamingPage.tsx
+++ b/frontend/src/features/streaming/StreamingPage.tsx
@@ -53,7 +53,8 @@ export function StreamingPage() {
   function toggleEp(key: string) {
     setSelected(prev => {
       const next = new Set(prev)
-      next.has(key) ? next.delete(key) : next.add(key)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
       return next
     })
   }


### PR DESCRIPTION
Antwort auf „was bringt die eslint-Scope-Diskrepanz" — in Tat umgesetzt.

## Befund
eslint lief **nirgends automatisch** — die CI machte beim Frontend nur `tsc --noEmit`. Das eslint-Script existierte, wurde aber nie ausgeführt. 268 Meldungen lagen brach.

**Aufschlüsselung** zeigte: der Großteil ist Rauschen der neuen `eslint-plugin-react-hooks@7` (React-Compiler-Suite: `set-state-in-effect` 125×, `refs` 40× …) mit vielen False-Positives auf legitime Muster. **Aber** 38× `exhaustive-deps` = echte Stale-Closure-Bug-Quelle (genau die Klasse, die uns beim Modell-Switch-Bug fast erwischt hätte).

## Lösung: eslint in CI, aber mit Köpfchen
Statt 227 Errors auf einen Schlag zu erzwingen (main sofort rot) — **gestaffelte Severity**:

| Severity | Regeln | Effekt |
|----------|--------|--------|
| **error** (blockiert CI) | echte Fehler (`no-empty`, `no-unused-*` …) | sauber gehalten |
| **warn** (sichtbar, nicht blockierend) | react-hooks-v7-Rauschen, `exhaustive-deps` (38 Altfälle), `no-explicit-any` | Backlog bleibt sichtbar |

### 14 echte Errors gefixt (getrackte Dateien)
- **4× `no-unused-expressions`**: ternäre Seiteneffekt-Statements (`x.has(k) ? x.delete(k) : x.add(k)`) → klares `if/else`
- **5× `no-empty`**: leere `catch {}` mit erklärendem Kommentar (Frontend-Pendant zu den Backend-`except: pass` aus #333)
- **5× `no-unused-vars`**: via `^_`-Ignore-Pattern gelöst (bewusste Platzhalter-Parameter — Konvention, kein Bug)

### Config
- `src/modules/*` + `index.generated.ts` ignoriert (zur Build-Zeit aus separatem Repo generiert, gitignored → lokaler Lint deckungsgleich mit CI)
- ESLint-Schritt in `pytest.yml` nach dem Type-Check

## Ergebnis
`eslint .` → **0 errors, 164 warnings** (exit 0, CI-grün). Ab jetzt röten **neue echte Fehler** die CI; die Hook-Warnungen bleiben als Backlog sichtbar für den geplanten `exhaustive-deps`-Fix-PR.

tsc + build unverändert grün.

## Hinweis
Ein paar `exhaustive-deps`-Treffer liegen in `src/modules/*` (separates `hydrahive2-modules`-Repo) — deren echte Fixes gehören dorthin, nicht hierher.

Deploy: CI-/Config-/Frontend-Änderung → Server-Update baut neu.