### PR TITLE
feat(cockpit): vollständiger Agenten-Editor im Projekt-Cockpit

### DIFF
--- a/core/src/hydrahive/api/routes/_agent_schemas.py
+++ b/core/src/hydrahive/api/routes/_agent_schemas.py
@@ -58,6 +58,7 @@ class AgentUpdate(BaseModel):
     cache_ttl: str | None = None
     require_tool_confirm: bool | None = None
     longterm_memory: bool | None = None
+    disabled_skills: list[str] | None = None
     tool_config: dict | None = None
 
 

--- a/core/tests/test_agents_api.py
+++ b/core/tests/test_agents_api.py
@@ -168,6 +168,20 @@ def test_patch_agent_empty_body_returns_agent(client, admin_headers):
     assert res.json()["id"] == agent["id"]
 
 
+def test_patch_agent_persists_disabled_skills(client, admin_headers):
+    """Der vollständige Agenten-Editor muss Skills pro Agent deaktivieren können."""
+    agent = _create_agent(client, admin_headers, name="Selective Bot")
+
+    res = client.patch(
+        f"/api/agents/{agent['id']}",
+        headers=admin_headers,
+        json={"disabled_skills": ["debugging", "docs"]},
+    )
+
+    assert res.status_code == 200
+    assert res.json()["disabled_skills"] == ["debugging", "docs"]
+
+
 # ---------------------------------------------------------------------------
 # DELETE /api/agents/{id}  — delete
 # ---------------------------------------------------------------------------

--- a/docs/plans/project-cockpit-agent-editor.md
+++ b/docs/plans/project-cockpit-agent-editor.md
@@ -1,0 +1,69 @@
+# Plan: Vollständiger Agenten-Editor im Projekt-Cockpit
+
+## Ziel
+
+Das bisherige reduzierte Agenten-Overlay wird zum vollständigen Cockpit-Editor, ohne Navigation oder Abhängigkeit zur alten Settings-Seite.
+
+## Dateien
+
+- `core/src/hydrahive/api/routes/_agent_schemas.py` — erlaubt die Persistenz von `disabled_skills` im bestehenden Update-Endpunkt
+- `core/tests/test_agents_api.py` — Regressionstest für deaktivierte Skills
+- `frontend/src/features/agents/types.ts` — vollständiger Typ der änderbaren Agentenfelder
+- `frontend/src/features/agents/api.ts` — verwendet den vollständigen Update-Typ
+- `frontend/src/features/cockpit/ProjectCockpitPage.tsx` — remountet das Overlay sauber beim Agentenwechsel
+- `frontend/src/features/cockpit/project/ProjectAgentEditOverlay.tsx` — Laden, Draft, Dirty-State, Speichern und Overlay-Shell
+- `frontend/src/features/cockpit/project/ProjectAgentEditorTabs.tsx` — Cockpit-eigene Reiternavigation und vollständige Einstellungsinhalte
+- `docs/specs/project-cockpit-agent-editor.md` — freigegebene Produktspezifikation
+- `docs/plans/project-cockpit-agent-editor.md` — Implementierungs- und Verifikationsplan
+
+## Bestehende Tests, die nicht brechen dürfen
+
+- Frontend-Typecheck (`npx tsc -b`)
+- ESLint (`npx eslint .`)
+- Produktionsbuild (`npm run build`)
+- Cockpit-Offline-Guard (`npm run check:cockpit-offline`)
+
+Im Frontend ist kein Unit-Test-Runner konfiguriert. Deshalb wird die UI-Integration über Typecheck, Lint, Build und einen Browser-Smoke-Test verifiziert.
+
+## Implementierungsreihenfolge
+
+### Task 1: Vollständige Reiteroberfläche
+
+- [x] `ProjectAgentEditorTabs.tsx` mit Übersicht, Modell, Prompt, Tools, Mail, Skills, Soul und Erweitert anlegen
+- [x] Name/Status in der Cockpit-Übersicht editierbar machen
+- [x] Bestehende Agent-Domänenkomponenten nutzen, aber keine Settings-Seite importieren
+- [x] Typecheck ausführen
+
+### Task 2: Vollständiges Laden und Speichern
+
+- [x] Regressionstest für `disabled_skills` schreiben und rot bestätigen
+- [x] `disabled_skills` in das bestehende Backend-Update-Schema aufnehmen und Test grün bestätigen
+- [x] Overlay lädt Modellkatalog, Tools und MCP-Server zusätzlich zum Agenten und Systemprompt
+- [x] Draft enthält alle Agentenfelder
+- [x] Agentenfelder und Systemprompt werden gespeichert
+- [x] Dirty-State und Verwerfen berücksichtigen alle zentral gespeicherten Felder
+- [x] Parent-Liste erhält die aktualisierte Agent-Zusammenfassung
+
+### Task 3: Verifikation
+
+- [x] TypeScript-Typecheck grün
+- [x] ESLint grün (keine Errors)
+- [x] Frontend-Build grün
+- [x] Cockpit-Offline-Guard grün
+- [x] Browser-Smoke-Test: Overlay öffnet, Reiter sind sichtbar, Iterationen/Tokens und Soul-MD-Dateien sind erreichbar
+- [x] HH2-Strukturreview durchführen
+
+## Akzeptanzkriterien
+
+- [x] Maximale Iterationen, maximale Tokens und Thinking-Budget sind im Projekt-Cockpit editierbar
+- [x] Tools, MCP, Skills, Mail und Langzeitgedächtnis sind erreichbar
+- [x] Systemprompt sowie `identity.md`, `behavior.md`, `background.md` sind erreichbar
+- [x] Erweiterte Komprimierungsparameter sind erreichbar
+- [x] Keine Abhängigkeit zu `features/settings/detail/AgentFormTabs.tsx`
+- [x] Keine neue Backend- oder Berechtigungslogik
+
+## Nicht in diesem Plan
+
+- Alte Settings-Seiten entfernen
+- Agenten löschen
+- Backend-Schema erweitern

--- a/docs/specs/project-cockpit-agent-editor.md
+++ b/docs/specs/project-cockpit-agent-editor.md
@@ -1,0 +1,51 @@
+# Vollständiger Agenten-Editor im Projekt-Cockpit
+
+## Was
+
+Der Agenten-Editor im Projekt-Cockpit wird zum vollständigen, eigenständigen Editor ausgebaut. Er bleibt ein Cockpit-Overlay und leitet nicht auf die alten Einstellungsseiten weiter.
+
+Der Editor erhält Reiter für:
+
+1. **Übersicht** — Name, Status, Typ/Domain, Beschreibung, Tool-Bestätigung und Metadaten
+2. **Modell** — Hauptmodell, Temperatur, maximale Output-Tokens, maximale Iterationen, Fallback-Modelle, Thinking-Budget und Thinking-Tiefe/Reasoning-Effort
+3. **Prompt** — Systemprompt
+4. **Tools** — Langzeitgedächtnis, Tools und MCP-Server
+5. **Mail** — erscheint bei aktivierten Mail-Tools
+6. **Skills** — Skills anlegen, bearbeiten und pro Agent aktivieren/deaktivieren
+7. **Seele / MD-Dateien** — `identity.md`, `behavior.md` und `background.md`
+8. **Erweitert** — Komprimierungsmodell, Tool-Result-Limit, Token-Reserve, Turn-Limit, Schwelle, Live-Truncation und Cache-TTL
+
+## Warum
+
+Das bisherige Overlay ist ein separat gebauter Mini-Editor und kann nur Name, Status, Beschreibung, Hauptmodell und Systemprompt ändern. Dadurch sind wesentliche Agentenparameter im Projekt-Cockpit nicht erreichbar. Die alten Einstellungsseiten sollen perspektivisch entfallen; das Projekt-Cockpit muss deshalb selbst vollständig sein.
+
+## Wie
+
+- `ProjectAgentEditOverlay` bleibt Eigentümer des Lade-, Draft-, Dirty- und Save-Zustands.
+- Der Editor lädt Agent, Systemprompt, Modellkatalog, Tool-Metadaten und MCP-Server.
+- Die Reiter werden als Cockpit-eigene Oberfläche aufgebaut.
+- Vorhandene domänenspezifische Eingabekomponenten aus `features/agents` werden wiederverwendet; es gibt keine Abhängigkeit von `features/settings` oder `AgentFormTabs`.
+- Agentenfelder werden über `PATCH /agents/{id}` gespeichert.
+- Der Systemprompt wird über `PUT /agents/{id}/system_prompt` gespeichert.
+- Skills und Soul-MD-Dateien behalten ihre bestehenden spezialisierten Endpunkte und eigenen Speichervorgänge.
+- Backend-Berechtigungen bleiben unverändert maßgeblich; das Frontend erweitert keine Rechte.
+- `disabled_skills` wird in das bestehende Agent-Update-Schema aufgenommen, damit die bereits vorgesehene Skill-Aktivierung tatsächlich persistiert.
+- Löschen bleibt außerhalb dieses Umbaus, da das bisherige Cockpit-Overlay nur Bearbeiten angeboten hat.
+
+## Akzeptanzkriterien
+
+- Im Projekt-Cockpit sind maximale Iterationen und maximale Tokens editierbar.
+- Alle oben aufgelisteten Reiter sind erreichbar.
+- `identity.md`, `behavior.md` und `background.md` können geladen und gespeichert werden.
+- Systemprompt und Agentenfelder werden korrekt gespeichert.
+- Mail erscheint nur, wenn der Agent `send_mail` oder `read_mail` besitzt.
+- Änderungen können verworfen werden; die Schließen-Aktion verändert nichts ungespeichert.
+- Das Overlay hängt nicht von der alten Settings-Seite oder `AgentFormTabs` ab.
+- TypeScript-Typecheck, ESLint und Frontend-Build sind grün.
+
+## Nicht enthalten
+
+- Entfernen der alten Settings-Seiten
+- Neue API-Endpunkte
+- Änderungen am Berechtigungsmodell
+- Löschen von Agenten aus dem Projekt-Cockpit

--- a/frontend/src/features/agents/api.ts
+++ b/frontend/src/features/agents/api.ts
@@ -1,11 +1,11 @@
 import { api } from "@/shared/api-client"
-import type { Agent, AgentCreate, AgentDefaults, AgentTemplate, AgentToolConfig, ToolMeta } from "./types"
+import type { Agent, AgentCreate, AgentDefaults, AgentTemplate, AgentToolConfig, AgentUpdate, ToolMeta } from "./types"
 
 export const agentsApi = {
   list: () => api.get<Agent[]>("/agents"),
   get: (id: string) => api.get<Agent>(`/agents/${id}`),
   create: (req: AgentCreate) => api.post<Agent>("/agents", req),
-  update: (id: string, fields: Partial<AgentCreate & { status: string }>) =>
+  update: (id: string, fields: AgentUpdate) =>
     api.patch<Agent>(`/agents/${id}`, fields),
   delete: (id: string) => api.delete<void>(`/agents/${id}`),
   getSystemPrompt: (id: string) =>

--- a/frontend/src/features/agents/types.ts
+++ b/frontend/src/features/agents/types.ts
@@ -38,6 +38,34 @@ export interface Agent {
   tool_config?: AgentToolConfig
 }
 
+export type AgentUpdate = Partial<Pick<Agent,
+  | "name"
+  | "owner"
+  | "llm_model"
+  | "fallback_models"
+  | "tools"
+  | "mcp_servers"
+  | "description"
+  | "temperature"
+  | "max_tokens"
+  | "thinking_budget"
+  | "reasoning_effort"
+  | "status"
+  | "domain"
+  | "compact_model"
+  | "compact_tool_result_limit"
+  | "compact_reserve_tokens"
+  | "compact_threshold_pct"
+  | "compact_max_turns"
+  | "tool_result_max_chars"
+  | "cache_ttl"
+  | "max_iterations"
+  | "disabled_skills"
+  | "require_tool_confirm"
+  | "longterm_memory"
+  | "tool_config"
+>>
+
 export interface MailAccountConfig {
   host?: string
   port?: number

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -254,6 +254,7 @@ export function ProjectCockpitPage() {
       )}
       {editingAgentId && (
         <ProjectAgentEditOverlay
+          key={editingAgentId}
           agentId={editingAgentId}
           onClose={() => setEditingAgentId(null)}
           onSaved={(updated) => setAgents((cur) => cur.map((agent) => agent.id === updated.id ? { ...agent, ...updated } : agent))}

--- a/frontend/src/features/cockpit/project/ProjectAgentEditOverlay.tsx
+++ b/frontend/src/features/cockpit/project/ProjectAgentEditOverlay.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react"
 import { Check, RefreshCw, X } from "lucide-react"
-import { agentsApi } from "@/features/agents/api"
-import type { Agent } from "@/features/agents/types"
+import { agentsApi, mcpInfoApi, type McpServerBrief } from "@/features/agents/api"
+import type { Agent, ToolMeta } from "@/features/agents/types"
 import type { AgentBrief } from "@/features/chat/types"
-import { llmModelsApi } from "@/features/llm/api"
+import { llmModelsApi, type RegistryModel } from "@/features/llm/api"
 import { CockpitButton } from "../CockpitButton"
+import { ProjectAgentEditorTabs } from "./ProjectAgentEditorTabs"
 
 interface Props {
   agentId: string
@@ -14,13 +15,13 @@ interface Props {
 
 export function ProjectAgentEditOverlay({ agentId, onClose, onSaved }: Props) {
   const [agent, setAgent] = useState<Agent | null>(null)
+  const [draft, setDraft] = useState<Agent | null>(null)
+  const [prompt, setPrompt] = useState("")
+  const [savedPrompt, setSavedPrompt] = useState("")
   const [models, setModels] = useState<string[]>([])
-  const [name, setName] = useState("")
-  const [description, setDescription] = useState("")
-  const [model, setModel] = useState("")
-  const [status, setStatus] = useState<"active" | "disabled">("active")
-  const [systemPrompt, setSystemPrompt] = useState("")
-  const [originalSystemPrompt, setOriginalSystemPrompt] = useState("")
+  const [catalog, setCatalog] = useState<RegistryModel[]>([])
+  const [tools, setTools] = useState<ToolMeta[]>([])
+  const [mcpServers, setMcpServers] = useState<McpServerBrief[]>([])
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -28,75 +29,82 @@ export function ProjectAgentEditOverlay({ agentId, onClose, onSaved }: Props) {
 
   useEffect(() => {
     let alive = true
-    setLoading(true)
-    setError(null)
-    setMessage(null)
     Promise.all([
       agentsApi.get(agentId),
       agentsApi.getSystemPrompt(agentId),
-      llmModelsApi.byModality("chat").catch(() => ({ models: [] })),
+      llmModelsApi.byModality("chat").catch(() => ({ models: [], default: "" })),
+      agentsApi.listTools().catch(() => []),
+      mcpInfoApi.list().catch(() => []),
     ])
-      .then(([agentData, promptData, modelData]) => {
+      .then(([agentData, promptData, modelData, toolData, mcpData]) => {
         if (!alive) return
         setAgent(agentData)
-        setName(agentData.name)
-        setDescription(agentData.description ?? "")
-        setModel(agentData.llm_model)
-        setStatus(agentData.status)
-        setSystemPrompt(promptData.prompt ?? "")
-        setOriginalSystemPrompt(promptData.prompt ?? "")
+        setDraft(agentData)
+        setPrompt(promptData.prompt ?? "")
+        setSavedPrompt(promptData.prompt ?? "")
+        setCatalog(modelData.models)
         setModels(modelData.models.map((item) => item.id))
+        setTools(toolData)
+        setMcpServers(mcpData)
       })
       .catch(() => { if (alive) setError("Agent konnte nicht geladen werden.") })
       .finally(() => { if (alive) setLoading(false) })
     return () => { alive = false }
   }, [agentId])
 
-  const availableModels = useMemo(() => {
-    const seen = new Set<string>()
-    const out: string[] = []
-    for (const item of [agent?.llm_model, model, ...models]) {
-      if (!item || seen.has(item)) continue
-      seen.add(item)
-      out.push(item)
-    }
-    return out
-  }, [agent?.llm_model, model, models])
+  const agentDirty = useMemo(
+    () => Boolean(agent && draft && JSON.stringify(draft) !== JSON.stringify(agent)),
+    [agent, draft],
+  )
+  const promptDirty = prompt !== savedPrompt
+  const dirty = agentDirty || promptDirty
 
-  const dirty = Boolean(agent && (
-    name.trim() !== agent.name ||
-    description !== (agent.description ?? "") ||
-    model.trim() !== agent.llm_model ||
-    status !== agent.status ||
-    systemPrompt !== originalSystemPrompt
-  ))
+  function patch(fields: Partial<Agent>) {
+    setDraft((current) => current ? { ...current, ...fields } : current)
+    setMessage(null)
+  }
+
+  function discard() {
+    setDraft(agent)
+    setPrompt(savedPrompt)
+    setError(null)
+    setMessage(null)
+  }
 
   async function save() {
-    if (!agent || !name.trim() || !model.trim()) return
+    if (!agent || !draft || !draft.name.trim() || !draft.llm_model.trim()) return
+    if (promptDirty && !prompt.trim()) {
+      setError("Der Systemprompt darf nicht leer sein.")
+      return
+    }
     setSaving(true)
     setError(null)
     setMessage(null)
     try {
-      const updated = await agentsApi.update(agent.id, {
-        name: name.trim(),
-        description,
-        llm_model: model.trim(),
-        status,
-      })
-      await agentsApi.setSystemPrompt(agent.id, systemPrompt)
+      let updated = agent
+      if (agentDirty) {
+        const {
+          id: _id,
+          type: _type,
+          created_at: _createdAt,
+          updated_at: _updatedAt,
+          created_by: _createdBy,
+          workspace: _workspace,
+          project_id: _projectId,
+          ...fields
+        } = draft
+        void _id; void _type; void _createdAt; void _updatedAt; void _createdBy
+        void _workspace; void _projectId
+        updated = await agentsApi.update(agent.id, fields)
+      }
+      if (promptDirty) await agentsApi.setSystemPrompt(agent.id, prompt)
       setAgent(updated)
-      setOriginalSystemPrompt(systemPrompt)
-      onSaved({
-        id: updated.id,
-        name: updated.name,
-        type: updated.type,
-        llm_model: updated.llm_model,
-        status: updated.status,
-        is_buddy: false,
-      })
+      setDraft(updated)
+      setSavedPrompt(prompt)
+      onSaved(toBrief(updated))
       setMessage("Agent gespeichert.")
-    } catch {
-      setError("Agent konnte nicht gespeichert werden. Admin-Rechte erforderlich?")
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Agent konnte nicht gespeichert werden.")
     } finally {
       setSaving(false)
     }
@@ -104,11 +112,11 @@ export function ProjectAgentEditOverlay({ agentId, onClose, onSaved }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="flex max-h-[86dvh] w-full max-w-3xl flex-col overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#0e1420] shadow-2xl">
+      <div className="flex h-[90dvh] w-full max-w-6xl flex-col overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#0e1420] shadow-2xl">
         <header className="flex shrink-0 items-center gap-3 border-b border-[#2a364b] bg-[#131b2a] px-4 py-3">
           <div>
             <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#69d7ff]">Projekt-Agent</p>
-            <h2 className="text-lg font-black text-[#e8eef8]">Agent bearbeiten</h2>
+            <h2 className="text-lg font-black text-[#e8eef8]">Vollständige Agenten-Einstellungen</h2>
           </div>
           <div className="flex-1" />
           <button onClick={onClose} className="rounded-[4px] p-2 text-[#8d9ab0] hover:bg-white/[6%] hover:text-[#e8eef8]" aria-label="Schließen">
@@ -116,69 +124,29 @@ export function ProjectAgentEditOverlay({ agentId, onClose, onSaved }: Props) {
           </button>
         </header>
 
-        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
-          {loading ? <p className="text-sm text-[#8d9ab0]">Lade Agent…</p> : null}
-          {error ? <p className="rounded-[4px] border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{error}</p> : null}
-          {message ? <p className="rounded-[4px] border border-emerald-400/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">{message}</p> : null}
-
-          {agent ? (
-            <>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Field label="Name">
-                  <input
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                    className="w-full rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 text-sm text-[#e8eef8] outline-none focus:border-[#69d7ff]/60"
-                  />
-                </Field>
-                <Field label="Status">
-                  <select
-                    value={status}
-                    onChange={(event) => setStatus(event.target.value as "active" | "disabled")}
-                    className="w-full rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 text-sm text-[#e8eef8] outline-none focus:border-[#69d7ff]/60"
-                  >
-                    <option value="active">aktiv</option>
-                    <option value="disabled">deaktiviert</option>
-                  </select>
-                </Field>
-              </div>
-
-              <Field label="Beschreibung">
-                <textarea
-                  value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                  rows={2}
-                  className="w-full resize-none rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 text-sm text-[#e8eef8] outline-none focus:border-[#69d7ff]/60"
-                />
-              </Field>
-
-              <Field label="Modell">
-                <select
-                  value={model}
-                  onChange={(event) => setModel(event.target.value)}
-                  className="w-full rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 text-sm text-[#e8eef8] outline-none focus:border-[#69d7ff]/60"
-                >
-                  {availableModels.map((item) => <option key={item} value={item}>{item}</option>)}
-                </select>
-              </Field>
-
-              <Field label="Systemprompt" hint="Wird direkt am Agenten gespeichert. Tools/Rechte bleiben aus Sicherheitsgründen in den Agent-Einstellungen.">
-                <textarea
-                  value={systemPrompt}
-                  onChange={(event) => setSystemPrompt(event.target.value)}
-                  rows={12}
-                  className="w-full resize-y rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 font-mono text-xs leading-5 text-[#e8eef8] outline-none focus:border-[#69d7ff]/60"
-                />
-              </Field>
-            </>
-          ) : null}
-        </div>
+        {error ? <p className="mx-4 mt-3 rounded-[4px] border border-rose-400/25 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{error}</p> : null}
+        {message ? <p className="mx-4 mt-3 rounded-[4px] border border-emerald-400/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">{message}</p> : null}
+        {loading ? <p className="p-5 text-sm text-[#8d9ab0]">Lade Agent und Einstellungen…</p> : null}
+        {agent && draft ? (
+          <ProjectAgentEditorTabs
+            agent={agent}
+            draft={draft}
+            prompt={prompt}
+            models={models}
+            catalog={catalog}
+            tools={tools}
+            mcpServers={mcpServers}
+            onChange={patch}
+            onPromptChange={(value) => { setPrompt(value); setMessage(null) }}
+          />
+        ) : null}
 
         <footer className="flex shrink-0 items-center gap-2 border-t border-[#2a364b] bg-[#0b111c] px-4 py-3">
-          <p className="text-xs text-[#8d9ab0]">Agent-ID: <span className="font-mono">{agentId}</span></p>
+          <p className="truncate text-xs text-[#8d9ab0]">Agent-ID: <span className="font-mono">{agentId}</span></p>
           <div className="flex-1" />
+          {dirty ? <CockpitButton disabled={saving} onClick={discard}>Verwerfen</CockpitButton> : null}
           <CockpitButton disabled={saving} onClick={onClose}>Schließen</CockpitButton>
-          <CockpitButton tone="primary" disabled={!dirty || saving || !agent || !name.trim() || !model.trim()} onClick={() => void save()}>
+          <CockpitButton tone="primary" disabled={!dirty || saving || !draft?.name.trim() || !draft?.llm_model.trim() || (promptDirty && !prompt.trim())} onClick={() => void save()}>
             {saving ? <RefreshCw size={12} className="mr-1 inline animate-spin" /> : <Check size={12} className="mr-1 inline" />}
             Speichern
           </CockpitButton>
@@ -188,12 +156,13 @@ export function ProjectAgentEditOverlay({ agentId, onClose, onSaved }: Props) {
   )
 }
 
-function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <label className="mb-1 block text-xs font-semibold text-[#8d9ab0]">{label}</label>
-      {children}
-      {hint ? <p className="mt-1 text-[11px] text-[#8d9ab0]">{hint}</p> : null}
-    </div>
-  )
+function toBrief(agent: Agent): AgentBrief {
+  return {
+    id: agent.id,
+    name: agent.name,
+    type: agent.type,
+    llm_model: agent.llm_model,
+    status: agent.status,
+    is_buddy: false,
+  }
 }

--- a/frontend/src/features/cockpit/project/ProjectAgentEditorTabs.tsx
+++ b/frontend/src/features/cockpit/project/ProjectAgentEditorTabs.tsx
@@ -1,0 +1,167 @@
+import { useState, type ComponentType } from "react"
+import {
+  BrainCircuit,
+  Cpu,
+  FileText,
+  LayoutGrid,
+  Mail,
+  SlidersHorizontal,
+  Sparkles,
+  Wrench,
+} from "lucide-react"
+import { CompactionSection } from "@/features/agents/CompactionSection"
+import { MailTab } from "@/features/agents/_MailTab"
+import { ModelTab } from "@/features/agents/_ModelTab"
+import { OverviewTab } from "@/features/agents/_OverviewTab"
+import { PromptTab } from "@/features/agents/_PromptTab"
+import { SkillsTab } from "@/features/agents/_SkillsTab"
+import { SoulTab } from "@/features/agents/_SoulTab"
+import { ToolsTab } from "@/features/agents/_ToolsTab"
+import type { McpServerBrief } from "@/features/agents/api"
+import type { Agent, ToolMeta } from "@/features/agents/types"
+import type { RegistryModel } from "@/features/llm/api"
+import { useEffortLevels } from "@/features/llm/effort"
+
+interface Props {
+  agent: Agent
+  draft: Agent
+  prompt: string
+  models: string[]
+  catalog: RegistryModel[]
+  tools: ToolMeta[]
+  mcpServers: McpServerBrief[]
+  onChange: (patch: Partial<Agent>) => void
+  onPromptChange: (prompt: string) => void
+}
+
+interface TabDefinition {
+  id: string
+  label: string
+  icon: ComponentType<{ size?: number }>
+}
+
+export function ProjectAgentEditorTabs({
+  agent,
+  draft,
+  prompt,
+  models,
+  catalog,
+  tools,
+  mcpServers,
+  onChange,
+  onPromptChange,
+}: Props) {
+  const [tab, setTab] = useState("overview")
+  const effortLevels = useEffortLevels(draft.llm_model)
+  const hasMail = draft.tools.includes("send_mail") || draft.tools.includes("read_mail")
+  const tabs: TabDefinition[] = [
+    { id: "overview", label: "Übersicht", icon: LayoutGrid },
+    { id: "model", label: "Modell", icon: Cpu },
+    { id: "prompt", label: "Prompt", icon: FileText },
+    { id: "tools", label: "Tools", icon: Wrench },
+    ...(hasMail ? [{ id: "mail", label: "Mail", icon: Mail }] : []),
+    { id: "skills", label: "Skills", icon: Sparkles },
+    { id: "soul", label: "MD-Dateien", icon: BrainCircuit },
+    { id: "advanced", label: "Erweitert", icon: SlidersHorizontal },
+  ]
+
+  const activeTab = !hasMail && tab === "mail" ? "overview" : tab
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <nav className="flex shrink-0 flex-wrap gap-1 border-b border-[#2a364b] bg-[#0b111c] px-4 pt-2">
+        {tabs.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTab(id)}
+            className={`flex items-center gap-1.5 rounded-t-[4px] border-b-2 px-3 py-2 text-xs font-semibold transition-colors ${
+              activeTab === id
+                ? "border-[#69d7ff] bg-[#69d7ff]/10 text-[#c8f2ff]"
+                : "border-transparent text-[#8d9ab0] hover:bg-white/[4%] hover:text-[#e8eef8]"
+            }`}
+          >
+            <Icon size={13} />
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-5">
+        <div className="mx-auto max-w-4xl">
+          {activeTab === "overview" && (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field label="Name">
+                  <input
+                    value={draft.name}
+                    onChange={(event) => onChange({ name: event.target.value })}
+                    className={controlClass}
+                  />
+                </Field>
+                <Field label="Status">
+                  <select
+                    value={draft.status}
+                    onChange={(event) => onChange({ status: event.target.value as Agent["status"] })}
+                    className={controlClass}
+                  >
+                    <option value="active">aktiv</option>
+                    <option value="disabled">deaktiviert</option>
+                  </select>
+                </Field>
+              </div>
+              <OverviewTab draft={draft} onChange={onChange} />
+            </div>
+          )}
+          {activeTab === "model" && (
+            <div className="space-y-4">
+              <ModelTab
+                draft={draft}
+                models={models}
+                catalog={catalog}
+                onChange={(patch) => onChange(patch.llm_model ? { ...patch, reasoning_effort: "" } : patch)}
+              />
+              <Field label="Thinking-Tiefe">
+                <select
+                  value={draft.reasoning_effort ?? ""}
+                  disabled={effortLevels.length === 0}
+                  onChange={(event) => onChange({ reasoning_effort: event.target.value })}
+                  className={controlClass}
+                >
+                  <option value="">Modellstandard</option>
+                  {effortLevels.map((level) => <option key={level} value={level}>{effortLabel(level)}</option>)}
+                </select>
+                <p className="mt-1 text-[11px] text-[#8d9ab0]">Standard für den Agenten; eine Session-Auswahl hat Vorrang.</p>
+              </Field>
+            </div>
+          )}
+          {activeTab === "prompt" && <PromptTab prompt={prompt} onChange={onPromptChange} />}
+          {activeTab === "tools" && (
+            <ToolsTab draft={draft} tools={tools} mcpServers={mcpServers} onChange={onChange} />
+          )}
+          {activeTab === "mail" && hasMail && <MailTab draft={draft} onChange={onChange} />}
+          {activeTab === "skills" && <SkillsTab agent={agent} draft={draft} onChange={onChange} />}
+          {activeTab === "soul" && <SoulTab agent={agent} />}
+          {activeTab === "advanced" && (
+            <CompactionSection agent={draft} models={models} onChange={onChange} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const controlClass = "w-full rounded-[4px] border border-[#2a364b] bg-[#0b111c] px-3 py-2 text-sm text-[#e8eef8] outline-none focus:border-[#69d7ff]/60 disabled:opacity-50"
+
+function effortLabel(level: string) {
+  return ({ low: "Low", medium: "Medium", high: "High", xhigh: "Extra High", max: "Max", ultra: "Ultra" } as Record<string, string>)[level] ?? level
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-semibold text-[#8d9ab0]">{label}</label>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem
Der Agenten-Editor links im Projekt-Cockpit war ein separater Mini-Editor. Er zeigte nur Name, Status, Beschreibung, Hauptmodell und Systemprompt. Iterations-/Tokenlimits, Tools, Skills und die Soul-MD-Dateien waren dort nicht erreichbar.

## Lösung
Das Cockpit-Overlay ist jetzt ein vollständiger, eigenständiger Editor mit Reitern für:

- **Übersicht:** Name, Status, Typ/Domain, Beschreibung, Tool-Bestätigung, Metadaten
- **Modell:** Modell, Temperatur, Max Tokens, Max Iterationen, Fallbacks, Thinking-Budget, Thinking-Tiefe
- **Prompt:** Systemprompt
- **Tools:** Langzeitgedächtnis, Tools, MCP-Server
- **Mail:** bedingt bei Mail-Tools
- **Skills:** Anlegen/Bearbeiten sowie pro Agent aktivieren/deaktivieren
- **MD-Dateien:** `identity.md`, `behavior.md`, `background.md`
- **Erweitert:** Komprimierungsmodell, Token-Reserve, Turn-/Result-Limits, Schwelle, Cache-TTL

Das Overlay hat eine eigene Cockpit-Navigation und hängt **nicht** an `features/settings` oder `AgentFormTabs`; die alten Settings-Seiten können später unabhängig entfernt werden. Wiederverwendet werden nur domänenspezifische Agent-Eingabekomponenten.

## Zusätzlicher Root-Cause-Fix
Beim Ausbau fiel auf, dass `disabled_skills` zwar im Agent-Modell und im Runner existierte, aber im Pydantic-Update-Schema fehlte. Die UI konnte Skills daher scheinbar deaktivieren, das Backend verwarf das Feld jedoch. Das Schema akzeptiert und persistiert es jetzt; ein Regressionstest deckt dies ab.

## Verifikation
- `PYTHONPATH=src pytest tests/test_agents_api.py -q` → **21 passed**
- `ruff check ...` → **All checks passed**
- `npx tsc -b` → grün
- `npx eslint .` → **0 Errors** (nur bestehende Warnungen)
- `npm run check:cockpit-offline` → grün
- `npm run build` → grün
- Headless-Chromium-Smoke-Harness: alle 8 Reiter gerendert; Max Tokens/Iterationen/Thinking-Felder, MD-Dateien und erweiterte Parameter erreichbar; kein Runtime-Fehler

## Scope
Kein neuer Endpoint und keine Erweiterung von Rechten. Die bestehende Admin-/Owner-Prüfung bleibt maßgeblich. Agent löschen ist bewusst nicht Teil dieses PRs.