### PR TITLE
fix(cockpit): Session-Klick öffnet in-place im Cockpit-Chat

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -46,9 +46,13 @@ interface ChatPaneProps {
   projectId?: string | null
   showSidePanels?: boolean
   preferredAgentId?: string | null
+  /** Von außen angeforderte Session in-place öffnen (z. B. Klick im Auswerten-Panel). */
+  openSessionRequest?: string | null
+  /** Wird aufgerufen, sobald openSessionRequest angewendet wurde (Parent kann zurücksetzen). */
+  onSessionRequestHandled?: () => void
 }
 
-export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true, preferredAgentId = null }: ChatPaneProps) {
+export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true, preferredAgentId = null, openSessionRequest = null, onSessionRequestHandled }: ChatPaneProps) {
   const { t } = useTranslation("chat")
   const deepLinkApplied = useRef(false)
 
@@ -101,6 +105,13 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
     const current = sessions.find((s) => s.id === activeId)
     if (current && current.project_id !== projectId) setActiveId(null)
   }, [projectId, activeId, sessions])
+
+  // Externe Anforderung (z. B. Session-Klick im Auswerten-Panel) in-place öffnen.
+  useEffect(() => {
+    if (!openSessionRequest) return
+    setActiveId(openSessionRequest)
+    onSessionRequestHandled?.()
+  }, [openSessionRequest, onSessionRequestHandled])
 
   async function handleNew(agentId: string, title: string, projectId?: string) {
     if (activeSession?.project_id) await chatApi.handover(activeSession.id)

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -45,6 +45,7 @@ export function ProjectCockpitPage() {
   const [serversOpen, setServersOpen] = useState(false)
   const [mountsOpen, setMountsOpen] = useState(false)
   const [insightView, setInsightView] = useState<ProjectInsightView | null>(null)
+  const [openSessionRequest, setOpenSessionRequest] = useState<string | null>(null)
   const [gitOpen, setGitOpen] = useState(false)
   const [graphOpen, setGraphOpen] = useState(false)
   const [gitRevision, setGitRevision] = useState(0)
@@ -200,7 +201,14 @@ export function ProjectCockpitPage() {
 
         <main className="min-h-0 overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#151c2b]">
           {activeProjectId ? (
-            <ChatPane key={`${activeProjectId}:${selectedAgentId}:${selectedAgentModel}`} projectId={activeProjectId} showSidePanels={false} preferredAgentId={selectedAgentId} />
+            <ChatPane
+              key={`${activeProjectId}:${selectedAgentId}:${selectedAgentModel}`}
+              projectId={activeProjectId}
+              showSidePanels={false}
+              preferredAgentId={selectedAgentId}
+              openSessionRequest={openSessionRequest}
+              onSessionRequestHandled={() => setOpenSessionRequest(null)}
+            />
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-zinc-600">Bitte ein Projekt auswählen.</div>
           )}
@@ -217,7 +225,14 @@ export function ProjectCockpitPage() {
       )}
       {integrationsOpen && activeProject && <ProjectIntegrationsOverlay project={activeProject} onClose={() => setIntegrationsOpen(false)} onSaved={(updated) => setProjects((current) => current.map((project) => project.id === updated.id ? updated : project))} />}
       {gitOpen && activeProject && <ProjectGitOverlay project={activeProject} onClose={() => setGitOpen(false)} onChanged={() => setGitRevision((revision) => revision + 1)} />}
-      {insightView && activeProject && <ProjectInsightsOverlay project={activeProject} view={insightView} onClose={() => setInsightView(null)} />}
+      {insightView && activeProject && (
+        <ProjectInsightsOverlay
+          project={activeProject}
+          view={insightView}
+          onClose={() => setInsightView(null)}
+          onOpenSession={(sessionId) => { setOpenSessionRequest(sessionId); setInsightView(null) }}
+        />
+      )}
       {graphOpen && activeProject && <ProjectGraphOverlay project={activeProject} onClose={() => setGraphOpen(false)} />}
       {mountsOpen && activeProject && <ProjectMountsOverlay project={activeProject} onClose={() => setMountsOpen(false)} />}
       {serversOpen && activeProject && <ProjectServersOverlay project={activeProject} onClose={() => setServersOpen(false)} />}

--- a/frontend/src/features/cockpit/project/ProjectInsightsOverlay.tsx
+++ b/frontend/src/features/cockpit/project/ProjectInsightsOverlay.tsx
@@ -16,7 +16,7 @@ const VIEW_COPY: Record<ProjectInsightView, { eyebrow: string; title: string; fo
   sessions: {
     eyebrow: "Projektverlauf",
     title: "Sessions",
-    footer: "Ein Klick auf eine Session öffnet sie direkt in der Werkstatt.",
+    footer: "Ein Klick auf eine Session öffnet sie direkt im Cockpit-Chat.",
   },
   audit: {
     eyebrow: "Nachvollziehbarkeit",
@@ -25,10 +25,11 @@ const VIEW_COPY: Record<ProjectInsightView, { eyebrow: string; title: string; fo
   },
 }
 
-export function ProjectInsightsOverlay({ project, view, onClose }: {
+export function ProjectInsightsOverlay({ project, view, onClose, onOpenSession }: {
   project: Project
   view: ProjectInsightView
   onClose: () => void
+  onOpenSession: (sessionId: string) => void
 }) {
   const copy = VIEW_COPY[view]
   return (
@@ -45,7 +46,7 @@ export function ProjectInsightsOverlay({ project, view, onClose }: {
         <main className="min-h-0 flex-1 overflow-y-auto p-4">
           <div className="rounded-[4px] border border-[#2a364b] bg-[#101724] p-4">
             {view === "stats" && <StatsTab projectId={project.id} />}
-            {view === "sessions" && <SessionsTab projectId={project.id} />}
+            {view === "sessions" && <SessionsTab projectId={project.id} onOpenSession={onOpenSession} />}
             {view === "audit" && <AuditTab projectId={project.id} />}
           </div>
         </main>

--- a/frontend/src/features/projects/_SessionsTab.tsx
+++ b/frontend/src/features/projects/_SessionsTab.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react"
 import { MessageSquare, Loader2, ExternalLink } from "lucide-react"
-import { useNavigate } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 import { projectsApi } from "./api"
 import type { ProjectSession } from "./types"
 
 interface Props {
   projectId: string
+  /** Session in-place im Cockpit-Chat öffnen statt in die Werkstatt zu navigieren. */
+  onOpenSession: (sessionId: string) => void
 }
 
-export function SessionsTab({ projectId }: Props) {
+export function SessionsTab({ projectId, onOpenSession }: Props) {
   const { t, i18n } = useTranslation("projects")
-  const navigate = useNavigate()
   const [sessions, setSessions] = useState<ProjectSession[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -38,7 +38,7 @@ export function SessionsTab({ projectId }: Props) {
       {sessions.map((s) => (
         <button
           key={s.id}
-          onClick={() => navigate(`/werkstatt/${s.id}`)}
+          onClick={() => onOpenSession(s.id)}
           className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg bg-zinc-900 border border-white/[6%] hover:border-violet-500/30 hover:bg-violet-500/[4%] transition-all group text-left"
         >
           <MessageSquare size={14} className="text-zinc-500 group-hover:text-violet-400 flex-shrink-0" />


### PR DESCRIPTION
## Problem
Im Projekt-Cockpit unter **Auswerten → Sessions** navigierte ein Klick auf eine Session per `navigate('/werkstatt/${s.id}')` in die **Legacy-Werkstatt** und verließ damit das Cockpit komplett.

## Fix
Die gewählte Session wird jetzt **in-place** in der bereits eingebetteten `ChatPane` geöffnet — exakt wie das Verhalten von *Neuer Chat* und dem Session-Dropdown im Cockpit-Chat-Header. Kein Routing, kein neuer Screen, keine neue Infrastruktur.

## Änderungen (4 Dateien, +37/-10)
- **ChatPane**: neues Prop `openSessionRequest` + `onSessionRequestHandled`; ein Effect setzt `activeId` auf die angeforderte Session.
- **_SessionsTab**: `useNavigate`/`navigate` entfernt → `onOpenSession(sessionId)`-Callback.
- **ProjectInsightsOverlay**: reicht `onOpenSession` durch; Footer-Text korrigiert ("…direkt im Cockpit-Chat").
- **ProjectCockpitPage**: hält `openSessionRequest`-State, schließt das Overlay beim Öffnen.

## Verifikation
- `tsc --noEmit` grün (exit 0)
- `npm run build` grün (exit 0)
- ESLint grün (exit 0; nur bekannte react-hooks-v7 Warnings, konsistent mit bestehenden Effects im File)

## Scope
Betrifft nur den P0-Bug aus dem Legacy-vs-Cockpit-Audit. Der Analyse-Detailview `/analytics/session/:sid` bleibt unberührt (dient der Auswertung, nicht dem Weiterchatten).