### PR TITLE
feat(cockpit): Cockpit-Module — Reiter im Top-Menü + bare Chrome

### DIFF
--- a/frontend/src/features/cockpit/CockpitTopbar.tsx
+++ b/frontend/src/features/cockpit/CockpitTopbar.tsx
@@ -2,36 +2,35 @@ import { useEffect, useRef, useState, type ReactNode } from "react"
 import { Menu, MoreHorizontal, X } from "lucide-react"
 import { HelpButton } from "@/i18n/HelpButton"
 import type { HelpTopic } from "@/i18n/help/loader"
+import { navLabel } from "@/shared/nav-label"
+import { useTranslation } from "react-i18next"
+import { COCKPIT_MODULE_ITEMS } from "@/shared/nav-config"
 import { CockpitButton } from "./CockpitButton"
 import { CockpitAppsMenu } from "./CockpitAppsMenu"
 import { CockpitUserMenu } from "./CockpitUserMenu"
 
 interface Props {
-  active: "projects" | "buddy" | "media" | "vault" | "admin"
+  /** Core-Cockpit-Id oder Pfad eines Cockpit-Moduls (z. B. "/mediacenter"). */
+  active: "projects" | "buddy" | "media" | "vault" | "admin" | (string & {})
   context?: string
   action?: { label: string; path: string }
   extraActions?: ReactNode
 }
 
-const nav = [
-  { id: "projects", label: "Projekte", path: "/projects" },
-  { id: "buddy", label: "Buddy", path: "/buddy" },
-  { id: "media", label: "Media", path: "/media" },
-  { id: "vault", label: "Vault", path: "/vault" },
-  { id: "admin", label: "Admin", path: "/admin" },
-  { id: "help", label: "Hilfe", path: "/help" },
-] as const
+interface NavTab { id: string; label: string; path: string; help?: HelpTopic }
+
+const CORE_NAV: NavTab[] = [
+  { id: "projects", label: "Projekte", path: "/projects", help: "projects" },
+  { id: "buddy", label: "Buddy", path: "/buddy", help: "buddy" },
+  { id: "media", label: "Media", path: "/media", help: "atelier" },
+  { id: "vault", label: "Vault", path: "/vault", help: "patientenakte" },
+  { id: "admin", label: "Admin", path: "/admin", help: "system" },
+]
 
 const go = (path: string) => window.open(path, "_self")
-const HELP_TOPICS: Record<Props["active"], HelpTopic> = {
-  projects: "projects",
-  buddy: "buddy",
-  media: "atelier",
-  vault: "patientenakte",
-  admin: "system",
-}
 
 export function CockpitTopbar({ active, context, action, extraActions }: Props) {
+  const { t } = useTranslation("nav")
   const [menuOpen, setMenuOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLElement>(null)
@@ -51,7 +50,17 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
     return () => window.removeEventListener("keydown", onKeyDown)
   }, [menuOpen])
 
-  const activeLabel = nav.find((item) => item.id === active)?.label ?? "Cockpit"
+  // Cockpit-Module (nav mit cockpit:true) als zusätzliche Reiter; Label aus dem
+  // jeweiligen Modul-i18n (<key>:title) via navLabel. Hilfe-Reiter bleibt am Ende.
+  const moduleTabs: NavTab[] = COCKPIT_MODULE_ITEMS.map((i) => ({
+    id: i.path, label: navLabel(t, i.labelKey), path: i.path,
+  }))
+  const nav: NavTab[] = [...CORE_NAV, ...moduleTabs, { id: "help", label: "Hilfe", path: "/help" }]
+
+  const activeItem = nav.find((item) => item.id === active)
+  const activeLabel = activeItem?.label ?? "Cockpit"
+  // Cockpit-Module bringen kein Core-Help-Topic mit → Onboarding als sicherer Default.
+  const helpTopic: HelpTopic = activeItem?.help ?? "onboarding"
 
   return (
     <header className="relative flex h-[58px] shrink-0 items-center gap-3 border-b border-[#2a364b] bg-gradient-to-b from-[#131b2a] to-[#0e1420] px-3 sm:px-[18px]">
@@ -66,7 +75,7 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
         {extraActions}
         {action ? <CockpitButton onClick={() => go(action.path)}>{action.label}</CockpitButton> : null}
         <CockpitAppsMenu />
-        <HelpButton topic={HELP_TOPICS[active]} />
+        <HelpButton topic={helpTopic} />
         <CockpitUserMenu />
       </div>
       <button
@@ -93,7 +102,7 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
             <div className="contents [&>button]:w-full">{extraActions}</div>
             {action ? <CockpitButton onClick={() => go(action.path)}>{action.label}</CockpitButton> : null}
             <CockpitAppsMenu compact />
-            <HelpButton topic={HELP_TOPICS[active]} className="w-full justify-center" />
+            <HelpButton topic={helpTopic} className="w-full justify-center" />
             <CockpitUserMenu compact />
           </div>
         </section>
@@ -103,7 +112,7 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
 }
 
 function NavButton({ item, active, onNavigate }: {
-  item: (typeof nav)[number]
+  item: NavTab
   active: boolean
   onNavigate?: () => void
 }) {

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -6,7 +6,7 @@ import { UpdateModal } from "@/shared/UpdateModal"
 import { AppFooter } from "@/shared/AppFooter"
 import { useLayoutUpdate } from "./useLayoutUpdate"
 import { BentoMenu } from "./BentoMenu"
-import { NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
+import { COCKPIT_MODULE_ITEMS, NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
 import { getStoredThemeId, getTheme } from "./themes/registry"
 import type { LayoutChrome } from "./layouts/types"
 
@@ -34,7 +34,10 @@ export function Layout() {
   }, [])
 
   const theme = getTheme(themeId)
-  const cockpitPaths = ["/projects", "/buddy", "/media", "/vault", "/admin"]
+  // Core-Cockpits + installierte Cockpit-Module (nav mit cockpit:true) laufen
+  // im bare Cockpit-Chrome statt im Theme-Layout.
+  const cockpitPaths = ["/projects", "/buddy", "/media", "/vault", "/admin",
+    ...COCKPIT_MODULE_ITEMS.map((i) => i.path)]
   const isCockpitRoute = cockpitPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`))
 
   // Theme-CSS-Variablen auf <html> anwenden (überschreibt --hh-*).

--- a/frontend/src/shared/nav-config.ts
+++ b/frontend/src/shared/nav-config.ts
@@ -17,6 +17,9 @@ interface ModuleNavEntry {
   labelKey: string
   group?: string
   roles?: ("admin" | "user")[]
+  /** true = Modul ist ein Cockpit-Modul: eigener Reiter im Cockpit-Top-Menü,
+   *  Seite läuft im bare Cockpit-Chrome statt im Theme-Layout. */
+  cockpit?: boolean
 }
 
 export interface NavItem {
@@ -25,6 +28,7 @@ export interface NavItem {
   labelKey: string
   group: string
   roles?: ("admin" | "user")[]
+  cockpit?: boolean
 }
 
 export const NAV_GROUPS: NavGroup[] = [
@@ -79,7 +83,12 @@ const MODULE_NAV_ITEMS: NavItem[] = (moduleNav as ModuleNavEntry[]).map((n) => (
   labelKey: n.labelKey,
   group: n.group ?? "working",
   roles: n.roles,
+  cockpit: n.cockpit,
 }))
+
+/** Cockpit-Module (nav mit cockpit:true). Basis für dynamische Cockpit-Reiter
+ *  im Top-Menü und für die bare-Chrome-Erkennung in Layout.tsx. */
+export const COCKPIT_MODULE_ITEMS: NavItem[] = MODULE_NAV_ITEMS.filter((i) => i.cockpit)
 
 export function visibleItems(role: string | null): NavItem[] {
   const all = [...NAV_ITEMS, ...MODULE_NAV_ITEMS]


### PR DESCRIPTION
## Warum
Bisher war das Cockpit **Core-only**: die Reiter in `CockpitTopbar` und die bare-Chrome-Erkennung in `Layout.tsx` waren hart auf `projects/buddy/media/vault/admin` kodiert. Installierte Module konnten **nur** ins alte Theme-Layout und tauchten im Bento-/Sidebar-**Untermenü** auf — nie als Reiter im Cockpit-**Top-Menü** und nie im Cockpit-Design.

## Was
Ein Modul-Nav-Eintrag mit **`cockpit: true`** macht das Modul zum Cockpit-Modul:
- **`nav-config.ts`**: `ModuleNavEntry`/`NavItem` um `cockpit`-Flag erweitert; neuer Export `COCKPIT_MODULE_ITEMS` (alle installierten Cockpit-Module).
- **`Layout.tsx`**: `cockpitPaths` um die Cockpit-Modul-Pfade erweitert → Seite läuft im **bare Cockpit-Chrome** statt im Theme-Layout.
- **`CockpitTopbar`**: `active` von Literal-Union auf `string` geöffnet; Reiter-Liste **dynamisch** (Core + Cockpit-Module + Hilfe). Modul-Label kommt via `navLabel` aus dem Modul-i18n; `HelpTopic`-Fallback `onboarding`.

Ergebnis: Jedes installierte Cockpit-Modul erscheint automatisch als Reiter oben und rendert im Cockpit-Design. Kein Core-Edit pro Modul nötig.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler)
- Bestehende Core-Cockpits (projects/buddy/media/vault/admin) unverändert — nur additive Erweiterung.

## Zusammenhang
Gegenstück im Modul-Repo: `hydrahive2-modules` PR (Mediacenter auf `cockpit: true` + `CockpitShell`/`CockpitTopbar`). Beide zusammen deployen.