### PR TITLE
fix(cockpit): zirkulären Import behoben — schwarzer Screen beim Boot

### DIFF
--- a/frontend/src/features/cockpit/CockpitTopbar.tsx
+++ b/frontend/src/features/cockpit/CockpitTopbar.tsx
@@ -4,7 +4,7 @@ import { HelpButton } from "@/i18n/HelpButton"
 import type { HelpTopic } from "@/i18n/help/loader"
 import { navLabel } from "@/shared/nav-label"
 import { useTranslation } from "react-i18next"
-import { COCKPIT_MODULE_ITEMS } from "@/shared/nav-config"
+import { cockpitModuleItems } from "@/shared/nav-config"
 import { CockpitButton } from "./CockpitButton"
 import { CockpitAppsMenu } from "./CockpitAppsMenu"
 import { CockpitUserMenu } from "./CockpitUserMenu"
@@ -52,7 +52,7 @@ export function CockpitTopbar({ active, context, action, extraActions }: Props) 
 
   // Cockpit-Module (nav mit cockpit:true) als zusätzliche Reiter; Label aus dem
   // jeweiligen Modul-i18n (<key>:title) via navLabel. Hilfe-Reiter bleibt am Ende.
-  const moduleTabs: NavTab[] = COCKPIT_MODULE_ITEMS.map((i) => ({
+  const moduleTabs: NavTab[] = cockpitModuleItems().map((i) => ({
     id: i.path, label: navLabel(t, i.labelKey), path: i.path,
   }))
   const nav: NavTab[] = [...CORE_NAV, ...moduleTabs, { id: "help", label: "Hilfe", path: "/help" }]

--- a/frontend/src/shared/Layout.tsx
+++ b/frontend/src/shared/Layout.tsx
@@ -6,7 +6,7 @@ import { UpdateModal } from "@/shared/UpdateModal"
 import { AppFooter } from "@/shared/AppFooter"
 import { useLayoutUpdate } from "./useLayoutUpdate"
 import { BentoMenu } from "./BentoMenu"
-import { COCKPIT_MODULE_ITEMS, NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
+import { cockpitModuleItems, NAV_ITEMS, QUICK_LINK_PATHS, visibleItems } from "./nav-config"
 import { getStoredThemeId, getTheme } from "./themes/registry"
 import type { LayoutChrome } from "./layouts/types"
 
@@ -37,7 +37,7 @@ export function Layout() {
   // Core-Cockpits + installierte Cockpit-Module (nav mit cockpit:true) laufen
   // im bare Cockpit-Chrome statt im Theme-Layout.
   const cockpitPaths = ["/projects", "/buddy", "/media", "/vault", "/admin",
-    ...COCKPIT_MODULE_ITEMS.map((i) => i.path)]
+    ...cockpitModuleItems().map((i) => i.path)]
   const isCockpitRoute = cockpitPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`))
 
   // Theme-CSS-Variablen auf <html> anwenden (überschreibt --hh-*).

--- a/frontend/src/shared/nav-config.ts
+++ b/frontend/src/shared/nav-config.ts
@@ -77,21 +77,29 @@ export const NAV_ITEMS: NavItem[] = [
 
 export const QUICK_LINK_PATHS = ["/projects", "/buddy", "/media", "/vault", "/admin"]
 
-const MODULE_NAV_ITEMS: NavItem[] = (moduleNav as ModuleNavEntry[]).map((n) => ({
-  path: n.path,
-  icon: moduleIcon(n.icon),
-  labelKey: n.labelKey,
-  group: n.group ?? "working",
-  roles: n.roles,
-  cockpit: n.cockpit,
-}))
+// LAZY auswerten (Funktion statt top-level const): moduleNav stammt aus
+// index.generated, das über CockpitTopbar → nav-config einen Import-Zyklus bildet.
+// Eine eager map() beim Modul-Import liefe, bevor moduleNav initialisiert ist
+// (undefined.map → Boot-Crash). Zur Render-Zeit ist das Live-Binding gefüllt.
+function moduleNavItems(): NavItem[] {
+  return (moduleNav as ModuleNavEntry[]).map((n) => ({
+    path: n.path,
+    icon: moduleIcon(n.icon),
+    labelKey: n.labelKey,
+    group: n.group ?? "working",
+    roles: n.roles,
+    cockpit: n.cockpit,
+  }))
+}
 
 /** Cockpit-Module (nav mit cockpit:true). Basis für dynamische Cockpit-Reiter
- *  im Top-Menü und für die bare-Chrome-Erkennung in Layout.tsx. */
-export const COCKPIT_MODULE_ITEMS: NavItem[] = MODULE_NAV_ITEMS.filter((i) => i.cockpit)
+ *  im Top-Menü und für die bare-Chrome-Erkennung in Layout.tsx. Lazy — siehe oben. */
+export function cockpitModuleItems(): NavItem[] {
+  return moduleNavItems().filter((i) => i.cockpit)
+}
 
 export function visibleItems(role: string | null): NavItem[] {
-  const all = [...NAV_ITEMS, ...MODULE_NAV_ITEMS]
+  const all = [...NAV_ITEMS, ...moduleNavItems()]
   return all.filter((i) =>
     !i.roles || i.roles.length === 0 || (role !== null && i.roles.includes(role as "admin" | "user"))
   )


### PR DESCRIPTION
## Kritischer Boot-Crash (Regression aus #343)
Nach dem Cockpit-Modul-Feature (#343) blieb die App auf **allen** Seiten schwarz.

## Ursache: zirkulärer Import + eager Auswertung
Import-Zyklus:
```
index.generated → mediacenter → MediacenterPage → CockpitTopbar → nav-config → index.generated ↩
```
`nav-config.ts` wertete `MODULE_NAV_ITEMS`/`COCKPIT_MODULE_ITEMS` **eager beim Import** aus (`moduleNav.map(...)`). Über den Zyklus war `moduleNav` zu diesem Zeitpunkt noch `undefined` → `Cannot read properties of undefined (reading 'map')` → App crasht beim Boot → schwarzer Screen.

## Fix: lazy statt eager
- `MODULE_NAV_ITEMS` (const) → `moduleNavItems()` (interne Funktion)
- `COCKPIT_MODULE_ITEMS` (const) → `cockpitModuleItems()` (exportierte Funktion)
- `Layout.tsx` + `CockpitTopbar` rufen die Funktion auf statt die const zu lesen

`moduleNav` wird jetzt **nur zur Render-Zeit** gelesen — nie beim Modul-Import. Der Zyklus ist damit entschärft.

## Verifikation
- Crash-Mechanik per Node-Repro bestätigt (`undefined.map` vs. lazy = kein Crash)
- Statisch verifiziert: `moduleNav` wird nur noch **innerhalb Funktionen** referenziert, keine top-level-Auswertung mehr
- `tsc --noEmit` grün · `npm run build` grün

## Dringlichkeit
Behebt einen Totalausfall des Frontends → sollte schnell gemergt + deployed werden.