### PR TITLE
feat(admin): Admin-Bereiche als eingerastete Cockpit-Overlays (Users)

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -1,13 +1,20 @@
-import type { ComponentType } from "react"
+import { useState, type ComponentType } from "react"
 import { Boxes, Brain, CircuitBoard, Container, DatabaseBackup, GitBranch, KeyRound, MonitorCog, PlugZap, Server, ShieldAlert, SlidersHorizontal, Users, WandSparkles } from "lucide-react"
 import { CockpitButton } from "./CockpitButton"
 import { CockpitPanel, CockpitSectionLabel } from "./CockpitPanel"
 import { CockpitShell } from "./CockpitShell"
 import { CockpitTopbar } from "./CockpitTopbar"
 import { adminOfflineActions, explicitAiActions, openLocalPath } from "./actionRegistry"
+import { UsersOverlay } from "./admin/UsersOverlay"
+
+/** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
+ *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
+type AdminOverlayId = "users"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
-const adminLinks = adminOfflineActions.map((action, index) => ({ title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
+// action.id "users" wird als Overlay geöffnet, der Rest per Pfad.
+const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -26,6 +33,16 @@ const integrationLinks = [
 ]
 
 export function AdminCockpitPage() {
+  const [overlay, setOverlay] = useState<AdminOverlayId | null>(null)
+
+  // Kachel-Klick: existiert ein Cockpit-Overlay für die Action → einrasten,
+  // sonst (noch) die bestehende Legacy-Seite öffnen.
+  const openArea = (actionId: string, path: string) => {
+    const target = OVERLAY_BY_ACTION[actionId]
+    if (target) setOverlay(target)
+    else openLocalPath(path)
+  }
+
   return (
     <CockpitShell
       eyebrow="Admin"
@@ -45,7 +62,7 @@ export function AdminCockpitPage() {
                 return (
                   <button
                     key={item.path}
-                    onClick={() => openLocalPath(item.path)}
+                    onClick={() => openArea(item.id, item.path)}
                     className="group flex w-full items-start gap-3 rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left transition-colors hover:border-[#46617f] hover:bg-[#172133]"
                   >
                     <Icon size={18} className="mt-0.5 text-[#69d7ff]" />
@@ -145,6 +162,8 @@ export function AdminCockpitPage() {
           </CockpitPanel>
         </aside>
       </div>
+
+      {overlay === "users" && <UsersOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/AdminOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/AdminOverlay.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react"
+import { X } from "lucide-react"
+
+interface Props {
+  eyebrow?: string
+  title: string
+  /** Optionale Aktionen rechts im Header (z. B. "+ Neu"). */
+  headerActions?: ReactNode
+  /** Optionale Leiste unten (z. B. Speichern/Abbrechen). Ohne footer nur "Schließen". */
+  footer?: ReactNode
+  onClose: () => void
+  children: ReactNode
+  /** Maximale Breite; Default max-w-4xl. */
+  maxWidthClass?: string
+}
+
+/**
+ * Einheitlicher Cockpit-Overlay-Rahmen für Admin-Unterbereiche.
+ *
+ * Verhalten wie bei den Projekt-Overlays: bewusst KEIN Schließen bei Klick auf
+ * den Backdrop — der Overlay schließt nur über den X-/Schließen-Button oder
+ * Abbrechen/Speichern des jeweiligen Inhalts. So gehen keine Eingaben durch
+ * einen versehentlichen Außenklick verloren.
+ */
+export function AdminOverlay({ eyebrow, title, headerActions, footer, onClose, children, maxWidthClass = "max-w-4xl" }: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
+      <div className={`flex h-[90dvh] w-full ${maxWidthClass} flex-col overflow-hidden rounded-[6px] border border-[#2a364b] bg-[#0e1420] shadow-2xl`}>
+        <header className="flex shrink-0 items-center gap-3 border-b border-[#2a364b] bg-[#131b2a] px-4 py-3">
+          <div className="min-w-0">
+            {eyebrow && <p className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#69d7ff]">{eyebrow}</p>}
+            <h2 className="truncate text-lg font-black text-[#e8eef8]">{title}</h2>
+          </div>
+          <div className="flex-1" />
+          {headerActions}
+          <button onClick={onClose} className="rounded-[4px] p-2 text-[#8d9ab0] hover:bg-white/[6%] hover:text-[#e8eef8]" aria-label="Schließen">
+            <X size={16} />
+          </button>
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-y-auto p-4">{children}</main>
+
+        {footer && (
+          <footer className="flex shrink-0 items-center gap-2 border-t border-[#2a364b] bg-[#0b111c] px-4 py-3">
+            {footer}
+          </footer>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/admin/UsersOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/UsersOverlay.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react"
+import { Crown, KeyRound, Pencil, Plus, Trash2, User as UserIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { ApiKeysSection } from "@/features/users/ApiKeysSection"
+import { ChangePasswordDialog } from "@/features/users/ChangePasswordDialog"
+import { EditUserDialog } from "@/features/users/EditUserDialog"
+import { NewUserDialog } from "@/features/users/NewUserDialog"
+import { usersApi } from "@/features/users/api"
+import type { User } from "@/features/users/types"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+
+export function UsersOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("users")
+  const currentUsername = useAuthStore((s) => s.username) ?? ""
+  const [users, setUsers] = useState<User[]>([])
+  const [showNew, setShowNew] = useState(false)
+  const [pwTarget, setPwTarget] = useState<string | null>(null)
+  const [editTarget, setEditTarget] = useState<User | null>(null)
+
+  async function load() {
+    try { setUsers(await usersApi.list()) } catch { /* leise */ }
+  }
+  useEffect(() => { load() }, [])
+
+  async function handleDelete(username: string) {
+    if (username === currentUsername) { alert(t("errors.self_delete")); return }
+    if (!confirm(t("actions.delete_confirm", { name: username }))) return
+    try { await usersApi.delete(username); await load() }
+    catch (e) { alert(e instanceof Error ? e.message : "Error") }
+  }
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      headerActions={
+        <CockpitButton tone="primary" onClick={() => setShowNew(true)}>
+          <Plus size={13} className="mr-1 inline" />{t("actions.new")}
+        </CockpitButton>
+      }
+    >
+      <div className="space-y-5">
+        <p className="text-sm text-[#8d9ab0]">{t("subtitle")}</p>
+
+        <div className="space-y-2">
+          {users.length === 0 ? (
+            <p className="py-6 text-center text-sm text-[#8d9ab0]">{t("no_users")}</p>
+          ) : (
+            users.map((u) => {
+              const isSelf = u.username === currentUsername
+              const Icon = u.role === "admin" ? Crown : UserIcon
+              return (
+                <div key={u.username} className="flex items-center gap-3 rounded-[6px] border border-[#2a364b] bg-[#111827] p-3">
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-violet-700 text-sm font-bold text-white">
+                    {u.username[0]?.toUpperCase() ?? "?"}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="flex items-center gap-2 truncate text-sm font-medium text-[#e8eef8]">
+                      {u.username}
+                      {isSelf && <span className="text-[10px] font-normal text-[#8d9ab0]">{t("you_marker")}</span>}
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-1 text-xs text-[#8d9ab0]">
+                      <Icon size={11} className={u.role === "admin" ? "text-violet-400" : "text-[#8d9ab0]"} />
+                      {t(`role.${u.role}`)}
+                    </p>
+                  </div>
+                  <button onClick={() => setEditTarget(u)} title={t("actions.edit")} className="rounded-[4px] p-2 text-[#8d9ab0] transition-colors hover:bg-indigo-500/10 hover:text-indigo-300">
+                    <Pencil size={14} />
+                  </button>
+                  <button onClick={() => setPwTarget(u.username)} title={t("actions.change_password")} className="rounded-[4px] p-2 text-[#8d9ab0] transition-colors hover:bg-violet-500/10 hover:text-violet-300">
+                    <KeyRound size={14} />
+                  </button>
+                  <button onClick={() => handleDelete(u.username)} disabled={isSelf} title={t("actions.delete")} className="rounded-[4px] p-2 text-[#8d9ab0] transition-colors hover:bg-rose-500/10 hover:text-rose-400 disabled:cursor-not-allowed disabled:opacity-30">
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              )
+            })
+          )}
+        </div>
+
+        <div className="border-t border-[#2a364b]" />
+        <ApiKeysSection />
+      </div>
+
+      {showNew && <NewUserDialog onClose={() => setShowNew(false)} onCreated={() => { setShowNew(false); load() }} />}
+      {pwTarget && <ChangePasswordDialog username={pwTarget} onClose={() => setPwTarget(null)} onChanged={() => setPwTarget(null)} />}
+      {editTarget && <EditUserDialog user={editTarget} onClose={() => setEditTarget(null)} onSaved={() => { setEditTarget(null); load() }} />}
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Die Admin-Unterbereiche sollen sich wie im Projekt-Cockpit verhalten: statt per `window.open` in die alten Legacy-Seiten zu springen (altes `box`-Design, Theme-Layout), gehen sie als **eingerastetes Overlay im Cockpit-Design** auf — Inhalt der alten Seite, neu gestylt, schließt **nur über Abbrechen/Schließen**, nicht bei Klick nach außen.

## Dieser PR: Infrastruktur + erster Bereich (Users)
- **`AdminOverlay`** — wiederverwendbarer Cockpit-Overlay-Rahmen (`fixed inset-0`, Header mit Eyebrow/Titel/Header-Actions, optionaler Footer). **Kein Backdrop-Close** (wie die Projekt-Overlays) → keine verlorenen Eingaben durch Außenklick.
- **`UsersOverlay`** — Inhalt der `UsersPage` neu im Cockpit-Design (`box` raus, Cockpit-Farben/Panels). Wiederverwendet die bestehende API und die User-Dialoge (Neu/Bearbeiten/Passwort) + `ApiKeysSection`.
- **`AdminCockpitPage`** — die Users-Kachel öffnet jetzt das Overlay (State) statt zu navigieren. Übrige Bereiche fallen vorerst weiter auf `openLocalPath`, bis sie in Folge-PRs nachgezogen sind (`OVERLAY_BY_ACTION`-Map als Erweiterungspunkt).

## Warum inkrementell
Bewusst klein gehalten (1 Bereich + Muster) nach dem Big-Bang-Risiko der letzten Änderung. Das `AdminOverlay`-Muster steht damit fest; die restlichen ~12 Bereiche (System, Credentials, Modules, Plugins, LLM, MCP, Skills, VMs, Containers, Themes, Settings, Extensions) ziehen in Folge-PRs konsistent nach.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler)
- Browser-Boot-Test gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**, App rendert (Login).
- Backdrop-Close bewusst deaktiviert; die stapelnden User-Dialoge sind eigene `fixed`-Overlays und liegen korrekt darüber.

## Hinweis
Login-geschützter Innenbereich konnte ich in der Preview nicht bis zum offenen Overlay durchklicken (keine Test-Credentials). Bitte nach Deploy einmal: Admin → Kachel „User" → Overlay öffnet im Cockpit-Design, schließt nur über X/Schließen.