### PR TITLE
feat(admin): Modules als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -6,15 +6,18 @@ import { CockpitShell } from "./CockpitShell"
 import { CockpitTopbar } from "./CockpitTopbar"
 import { adminOfflineActions, explicitAiActions, openLocalPath } from "./actionRegistry"
 import { UsersOverlay } from "./admin/UsersOverlay"
+import { ModulesOverlay } from "./admin/ModulesOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users"
+type AdminOverlayId = "users" | "modules"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
-// action.id "users" wird als Overlay geöffnet, der Rest per Pfad.
+// action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
-const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users" }
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules" }
+// Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -39,6 +42,13 @@ export function AdminCockpitPage() {
   // sonst (noch) die bestehende Legacy-Seite öffnen.
   const openArea = (actionId: string, path: string) => {
     const target = OVERLAY_BY_ACTION[actionId]
+    if (target) setOverlay(target)
+    else openLocalPath(path)
+  }
+
+  // Pfad-basierte Kacheln (Ops/Integrationen): Overlay wenn gemappt, sonst Pfad.
+  const openPath = (path: string) => {
+    const target = OVERLAY_BY_PATH[path]
     if (target) setOverlay(target)
     else openLocalPath(path)
   }
@@ -85,7 +95,7 @@ export function AdminCockpitPage() {
                 return (
                   <button
                     key={item.path}
-                    onClick={() => openLocalPath(item.path)}
+                    onClick={() => openPath(item.path)}
                     className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left hover:border-[#46617f] hover:bg-[#172133]"
                   >
                     <Icon size={18} className="mb-3 text-[#69d7ff]" />
@@ -121,7 +131,7 @@ export function AdminCockpitPage() {
               {integrationLinks.map((item) => {
                 const Icon = item.icon
                 return (
-                  <button key={item.title} onClick={() => openLocalPath(item.path)} className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left hover:border-[#46617f] hover:bg-[#172133]">
+                  <button key={item.title} onClick={() => openPath(item.path)} className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left hover:border-[#46617f] hover:bg-[#172133]">
                     <Icon size={16} className="mb-2 text-[#69d7ff]" />
                     <h3 className="text-sm font-bold text-[#e8eef8]">{item.title}</h3>
                     <p className="mt-1 text-xs leading-4 text-[#8d9ab0]">{item.text}</p>
@@ -164,6 +174,7 @@ export function AdminCockpitPage() {
       </div>
 
       {overlay === "users" && <UsersOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "modules" && <ModulesOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/ModuleCockpitCard.tsx
+++ b/frontend/src/features/cockpit/admin/ModuleCockpitCard.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ArrowUpCircle, Boxes, CheckCircle, RefreshCw, XCircle } from "lucide-react"
+import type { ModuleEntry } from "@/features/modules/types"
+import { installModule, uninstallModule, updateModule } from "@/features/modules/api"
+
+type Phase = "idle" | "running" | "done"
+type Action = "install" | "update" | "uninstall"
+
+interface Props {
+  mod: ModuleEntry
+  onRefresh: () => void
+}
+
+/** Modul-Karte im Cockpit-Design (Pendant zu features/modules/ModuleCard,
+ *  ohne box/zinc — nutzt dieselbe Stream-API). */
+export function ModuleCockpitCard({ mod, onRefresh }: Props) {
+  const { t } = useTranslation("modules")
+  const [phase, setPhase] = useState<Phase>("idle")
+  const [action, setAction] = useState<Action>("install")
+  const [lines, setLines] = useState<string[]>([])
+  const [failed, setFailed] = useState(false)
+  const logRef = useRef<HTMLDivElement>(null)
+  const stopRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => { logRef.current?.scrollTo(0, logRef.current.scrollHeight) }, [lines])
+  useEffect(() => () => stopRef.current?.(), [])
+
+  function run(a: Action) {
+    setAction(a); setPhase("running"); setLines([]); setFailed(false)
+    const fn = a === "install" ? installModule : a === "update" ? updateModule : uninstallModule
+    stopRef.current = fn(
+      mod.id,
+      (line) => setLines((l) => [...l.slice(-500), line]),
+      () => { setPhase("done"); onRefresh() },
+      (msg) => { setLines((l) => [...l, `[FEHLER] ${msg}`]); setFailed(true); setPhase("done") },
+    )
+  }
+
+  const busy = phase === "running"
+
+  return (
+    <div className="flex flex-col gap-3 rounded-[6px] border border-[#2a364b] bg-[#111827] p-4">
+      <div className="flex items-start gap-3">
+        <div className={"shrink-0 rounded-[4px] p-2 " + (mod.installed ? "bg-emerald-500/10 text-emerald-400" : "bg-[#1b2536] text-[#8d9ab0]")}>
+          <Boxes size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-[#e8eef8]">{mod.name}</span>
+            <span className="font-mono text-[10px] text-[#8d9ab0]">{mod.id}</span>
+            {mod.version && (
+              <span className="rounded-full border border-[#2a364b] bg-[#0d1420] px-1.5 py-0.5 text-[10px] text-[#8d9ab0]">v{mod.version}</span>
+            )}
+            {mod.update_available && mod.available_version && (
+              <span title={t("update.available")} className="flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
+                <ArrowUpCircle size={9} />{t("update.badge", { from: mod.version, to: mod.available_version })}
+              </span>
+            )}
+            {mod.installed && (mod.loaded ? (
+              <span className="flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+                <CheckCircle size={9} /> {t("status.loaded")}
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 rounded-full border border-rose-500/30 bg-rose-500/15 px-2 py-0.5 text-[10px] font-medium text-rose-400">
+                <XCircle size={9} /> {t("status.error")}
+              </span>
+            ))}
+          </div>
+          {mod.description && <p className="mt-1 text-[12px] leading-snug text-[#8d9ab0]">{mod.description}</p>}
+          {mod.error && <p className="mt-0.5 font-mono text-[11px] text-rose-400">{mod.error}</p>}
+        </div>
+      </div>
+
+      {phase !== "idle" && (
+        <div ref={logRef} className="max-h-40 overflow-y-auto rounded-[4px] bg-[#0b111c] p-3 font-mono text-[11px] leading-relaxed">
+          {lines.length === 0 && <span className="text-[#5b6675]">{t("log.waiting")}</span>}
+          {lines.map((l, i) => (
+            <div key={i} className={
+              l.startsWith("[OK]") ? "text-emerald-400" :
+              l.startsWith("[FEHLER]") || l.startsWith("[ERROR]") ? "text-rose-400" :
+              l.startsWith("[WARN]") ? "text-amber-400" : "text-[#d7deea]"
+            }>{l}</div>
+          ))}
+          {phase === "done" && (
+            <div className={`mt-1 font-medium ${failed ? "text-rose-400" : "text-emerald-400"}`}>
+              {failed ? t("log.failed") : t("log.success")}
+            </div>
+          )}
+        </div>
+      )}
+
+      {mod.installed ? (
+        <div className="flex gap-2">
+          <button onClick={() => run("update")} disabled={busy}
+            className={"flex flex-1 items-center justify-center gap-1.5 rounded-[4px] border py-1.5 text-xs font-medium transition-colors disabled:opacity-40 " +
+              (mod.update_available ? "border-amber-500/30 bg-amber-500/15 text-amber-300 hover:bg-amber-500/25" : "border-[#2a364b] bg-[#172133] text-[#69d7ff] hover:bg-[#1b2536]")}>
+            <RefreshCw size={11} className={busy && action === "update" ? "animate-spin" : ""} />
+            {busy && action === "update" ? t("actions.updating") : mod.update_available ? t("update.available") : t("actions.update")}
+          </button>
+          <button onClick={() => run("uninstall")} disabled={busy}
+            className="flex-1 rounded-[4px] border border-rose-500/20 bg-rose-500/10 py-1.5 text-xs font-medium text-rose-400 transition-colors hover:bg-rose-500/20 disabled:opacity-40">
+            {busy && action === "uninstall" ? t("actions.uninstalling") : t("actions.uninstall")}
+          </button>
+        </div>
+      ) : (
+        <button onClick={() => run("install")} disabled={busy}
+          className="rounded-[4px] bg-violet-600 py-1.5 text-xs font-medium text-white transition-colors hover:bg-violet-500 disabled:opacity-40">
+          {busy && action === "install" ? t("actions.installing") : t("actions.install")}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/admin/ModulesOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/ModulesOverlay.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { ArrowUpCircle, RefreshCw } from "lucide-react"
+import { listModules, updateModule } from "@/features/modules/api"
+import type { ModulesIndex } from "@/features/modules/types"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+import { ModuleCockpitCard } from "./ModuleCockpitCard"
+
+export function ModulesOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("modules")
+  const [data, setData] = useState<ModulesIndex>({ modules: [] })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [batch, setBatch] = useState<{ done: number; total: number } | null>(null)
+  const stopRef = useRef<(() => void) | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null)
+    try { setData(await listModules()) } catch (e) { setError(String(e)) }
+    setLoading(false)
+  }, [])
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { load() }, [load])
+  useEffect(() => () => stopRef.current?.(), [])
+
+  const outdated = data.modules.filter((m) => m.update_available)
+  const installedCount = data.modules.filter((m) => m.installed).length
+
+  const updateAll = useCallback(async () => {
+    if (outdated.length === 0 || batch) return
+    setBatch({ done: 0, total: outdated.length })
+    for (let i = 0; i < outdated.length; i++) {
+      await new Promise<void>((resolve) => {
+        stopRef.current = updateModule(outdated[i].id, () => {}, () => resolve(), () => resolve())
+      })
+      setBatch({ done: i + 1, total: outdated.length })
+    }
+    stopRef.current = null
+    setBatch(null)
+    await load()
+  }, [outdated, batch, load])
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      maxWidthClass="max-w-5xl"
+      headerActions={
+        <div className="flex items-center gap-2">
+          {outdated.length > 0 && (
+            <CockpitButton onClick={updateAll} disabled={batch !== null}>
+              <RefreshCw size={12} className={`mr-1 inline ${batch ? "animate-spin" : ""}`} />
+              {batch ? t("update.all_running", { done: batch.done, total: batch.total }) : t("update.all")}
+            </CockpitButton>
+          )}
+          <CockpitButton onClick={load} disabled={loading || batch !== null}>
+            <RefreshCw size={13} className={loading ? "animate-spin" : ""} />
+          </CockpitButton>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-[#8d9ab0]">
+          <span>{t("installed_count", { count: installedCount })}</span>
+          {outdated.length > 0 && (
+            <span className="flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
+              <ArrowUpCircle size={9} />{t("update.count", { count: outdated.length })}
+            </span>
+          )}
+        </div>
+
+        {error && <div className="rounded-[6px] border border-rose-500/20 bg-rose-500/10 p-4 text-sm text-rose-400">{error}</div>}
+
+        {loading && data.modules.length === 0 ? (
+          <p className="text-sm text-[#8d9ab0]">{t("loading")}</p>
+        ) : data.modules.length === 0 ? (
+          <p className="text-sm text-[#8d9ab0]">{t("empty")}</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {data.modules.map((mod) => <ModuleCockpitCard key={mod.id} mod={mod} onRefresh={load} />)}
+          </div>
+        )}
+      </div>
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Zweiter Admin-Bereich (nach Users, PR #345) vom Legacy-Sprung auf ein eingerastetes Cockpit-Overlay umgestellt.

## Änderungen
- **ModulesOverlay** — Modul-Liste + "Alle aktualisieren"-Batch im `AdminOverlay`-Rahmen (Cockpit-Design). Nutzt die bestehende `modules`-API (`listModules`/`updateModule`) unverändert; schließt nur über X/Schließen.
- **ModuleCockpitCard** — Modul-Karte im Cockpit-Design (Pendant zu `features/modules/ModuleCard`, ohne `box`/`zinc`/`rgbFor`). Gleiche Stream-basierte Install/Update/Uninstall-Logik.
- **AdminCockpitPage** — `modules` in `OVERLAY_BY_ACTION` + neue `OVERLAY_BY_PATH`-Map (`openPath`), damit auch die pfadbasierten Ops-/Integrations-Kacheln Overlays öffnen können (Fundament für die nächsten Bereiche wie Themes/LLM/MCP). Die "Module"-Integrationskachel öffnet jetzt ebenfalls das Overlay.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler)
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Teil der schrittweisen Admin-Migration (je Bereich ein PR). Nächste: Plugins.