### PR TITLE
feat(admin): Plugins als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -7,17 +7,18 @@ import { CockpitTopbar } from "./CockpitTopbar"
 import { adminOfflineActions, explicitAiActions, openLocalPath } from "./actionRegistry"
 import { UsersOverlay } from "./admin/UsersOverlay"
 import { ModulesOverlay } from "./admin/ModulesOverlay"
+import { PluginsOverlay } from "./admin/PluginsOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users" | "modules"
+type AdminOverlayId = "users" | "modules" | "plugins"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
 // action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
-const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules" }
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins" }
 // Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
-const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules" }
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -175,6 +176,7 @@ export function AdminCockpitPage() {
 
       {overlay === "users" && <UsersOverlay onClose={() => setOverlay(null)} />}
       {overlay === "modules" && <ModulesOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "plugins" && <PluginsOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/PluginCockpitCards.tsx
+++ b/frontend/src/features/cockpit/admin/PluginCockpitCards.tsx
@@ -1,0 +1,79 @@
+import { useTranslation } from "react-i18next"
+import { AlertTriangle, CheckCircle2, Download, Loader2, RefreshCw, Trash2 } from "lucide-react"
+import type { HubPlugin, InstalledPlugin } from "@/features/plugins/types"
+
+/** Hub-Plugin-Karte im Cockpit-Design (Pendant zu features/plugins/PluginCard HubCard). */
+export function HubCockpitCard({ plugin, installed, busy, onInstall }: {
+  plugin: HubPlugin; installed: boolean; busy: boolean; onInstall: () => void
+}) {
+  const { t } = useTranslation("plugins")
+  return (
+    <div className="flex flex-col gap-2 rounded-[6px] border border-[#2a364b] bg-[#111827] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-[#e8eef8]">{plugin.name}</h3>
+          <p className="font-mono text-xs text-[#8d9ab0]">v{plugin.version}{plugin.author && <> · {plugin.author}</>}</p>
+        </div>
+        {installed && (
+          <span className="shrink-0 rounded border border-emerald-500/30 bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">{t("installed_badge")}</span>
+        )}
+      </div>
+      <p className="text-xs text-[#8d9ab0]">{plugin.description}</p>
+      {plugin.tags && plugin.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {plugin.tags.map((tag) => <span key={tag} className="rounded bg-white/[6%] px-1.5 py-0.5 text-[10px] text-[#8d9ab0]">{tag}</span>)}
+        </div>
+      )}
+      <button onClick={onInstall} disabled={busy || installed}
+        className="mt-1 flex items-center gap-1.5 self-start rounded-[4px] border border-violet-500/30 bg-violet-600/20 px-3 py-1.5 text-xs font-medium text-violet-200 transition-colors hover:bg-violet-600/30 disabled:cursor-not-allowed disabled:opacity-50">
+        {busy ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+        {installed ? t("reinstall") : t("install")}
+      </button>
+    </div>
+  )
+}
+
+/** Installierte-Plugin-Karte im Cockpit-Design (Pendant zu InstalledCard). */
+export function InstalledCockpitCard({ plugin, busy, onUpdate, onUninstall }: {
+  plugin: InstalledPlugin; busy: boolean; onUpdate: () => void; onUninstall: () => void
+}) {
+  const { t } = useTranslation("plugins")
+  return (
+    <div className="flex flex-col gap-2 rounded-[6px] border border-[#2a364b] bg-[#111827] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-[#e8eef8]">{plugin.name}</h3>
+          <p className="font-mono text-xs text-[#8d9ab0]">{plugin.version ? `v${plugin.version}` : "—"}</p>
+        </div>
+        {plugin.loaded ? (
+          <span className="flex shrink-0 items-center gap-1 rounded border border-emerald-500/30 bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">
+            <CheckCircle2 size={11} /> {t("loaded")}
+          </span>
+        ) : (
+          <span className="flex shrink-0 items-center gap-1 rounded border border-rose-500/30 bg-rose-500/15 px-2 py-0.5 text-xs text-rose-300">
+            <AlertTriangle size={11} /> {t("not_loaded")}
+          </span>
+        )}
+      </div>
+      {plugin.description && <p className="text-xs text-[#8d9ab0]">{plugin.description}</p>}
+      {plugin.error && <p className="break-all font-mono text-xs text-rose-300/80">{plugin.error}</p>}
+      {plugin.tools.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {plugin.tools.map((toolName) => (
+            <span key={toolName} className="rounded border border-violet-500/20 bg-violet-500/10 px-1.5 py-0.5 font-mono text-[10px] text-violet-300">{toolName}</span>
+          ))}
+        </div>
+      )}
+      <div className="mt-1 flex gap-2">
+        <button onClick={onUpdate} disabled={busy}
+          className="flex items-center gap-1.5 rounded-[4px] border border-[#2a364b] bg-[#172133] px-3 py-1.5 text-xs font-medium text-[#d7deea] transition-colors hover:bg-[#1b2536] disabled:opacity-50">
+          {busy ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}{t("update")}
+        </button>
+        <button onClick={onUninstall} disabled={busy}
+          className="flex items-center gap-1.5 rounded-[4px] border border-rose-500/20 bg-rose-500/10 px-3 py-1.5 text-xs font-medium text-rose-300 transition-colors hover:bg-rose-500/20 disabled:opacity-50">
+          <Trash2 size={12} />{t("uninstall")}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/cockpit/admin/PluginsOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/PluginsOverlay.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { RotateCw } from "lucide-react"
+import { usePlugins } from "@/features/plugins/usePlugins"
+import { RestartModal } from "@/shared/RestartModal"
+import { useRestart } from "@/shared/useRestart"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+import { HubCockpitCard, InstalledCockpitCard } from "./PluginCockpitCards"
+
+type Tab = "hub" | "installed"
+
+export function PluginsOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("plugins")
+  const { t: tNav } = useTranslation("nav")
+  const restart = useRestart()
+  const [tab, setTab] = useState<Tab>("hub")
+  const { hub, installed, hubError, busyName, restartHint, installedNames,
+          handleInstall, handleUninstall, handleUpdate } = usePlugins()
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      maxWidthClass="max-w-4xl"
+      headerActions={
+        <CockpitButton onClick={restart.open}>
+          <RotateCw size={12} className="mr-1 inline" />{tNav("restart.button")}
+        </CockpitButton>
+      }
+    >
+      <div className="space-y-4">
+        <div className="flex gap-2 border-b border-[#2a364b]">
+          {(["hub", "installed"] as Tab[]).map((tid) => (
+            <button key={tid} onClick={() => setTab(tid)}
+              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === tid ? "border-violet-500 text-violet-300" : "border-transparent text-[#8d9ab0] hover:text-[#e8eef8]"
+              }`}>
+              {tid === "hub" ? t("tab_hub") : `${t("tab_installed")} (${installed.length})`}
+            </button>
+          ))}
+        </div>
+
+        {restartHint && (
+          <div className="flex items-center justify-between gap-3 rounded-[4px] border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+            <span>{restartHint}</span>
+            <button onClick={restart.open}
+              className="flex shrink-0 items-center gap-1.5 rounded-[4px] border border-amber-500/40 bg-amber-500/20 px-2.5 py-1 text-[11px] font-medium text-amber-100 transition-colors hover:bg-amber-500/30">
+              <RotateCw size={11} /> {tNav("restart.now")}
+            </button>
+          </div>
+        )}
+
+        {tab === "hub" && (
+          <div>
+            {hubError && <div className="mb-4 rounded-[4px] border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">{hubError}</div>}
+            {hub === null ? (
+              <p className="text-sm text-[#8d9ab0]">{t("loading")}</p>
+            ) : hub.length === 0 ? (
+              <p className="text-sm text-[#8d9ab0]">{t("hub_empty")}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                {hub.map((p) => (
+                  <HubCockpitCard key={p.name} plugin={p} installed={installedNames.has(p.name)}
+                    busy={busyName === p.name} onInstall={() => handleInstall(p.name)} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {tab === "installed" && (
+          <div>
+            {installed.length === 0 ? (
+              <p className="text-sm text-[#8d9ab0]">{t("installed_empty")}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                {installed.map((p) => (
+                  <InstalledCockpitCard key={p.name} plugin={p} busy={busyName === p.name}
+                    onUpdate={() => handleUpdate(p.name)} onUninstall={() => handleUninstall(p.name)} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {restart.state !== "idle" && (
+        <RestartModal state={restart.state} errorMessage={restart.error} onConfirm={restart.confirm} onClose={restart.close} />
+      )}
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Dritter Admin-Bereich (nach Users #345, Modules #346) vom Legacy-Sprung auf ein eingerastetes Cockpit-Overlay umgestellt.

## Änderungen
- **PluginsOverlay** — Hub/Installed-Tabs + Restart-Button im `AdminOverlay`-Rahmen (Cockpit-Design). Nutzt `usePlugins` + `RestartModal` unverändert; schließt nur über X/Schließen.
- **PluginCockpitCards** — `HubCockpitCard` + `InstalledCockpitCard` im Cockpit-Design (Pendant zu `features/plugins/PluginCard`, ohne `box`/`zinc`/`rgbFor`).
- **AdminCockpitPage** — `plugins` in `OVERLAY_BY_ACTION` + `OVERLAY_BY_PATH` (Admin-Bereich-Kachel und Integrations-Kachel öffnen beide das Overlay).

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler)
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Nächste: Credentials.