### PR TITLE
feat(admin): Credentials als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -8,17 +8,18 @@ import { adminOfflineActions, explicitAiActions, openLocalPath } from "./actionR
 import { UsersOverlay } from "./admin/UsersOverlay"
 import { ModulesOverlay } from "./admin/ModulesOverlay"
 import { PluginsOverlay } from "./admin/PluginsOverlay"
+import { CredentialsOverlay } from "./admin/CredentialsOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users" | "modules" | "plugins"
+type AdminOverlayId = "users" | "modules" | "plugins" | "credentials"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
 // action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
-const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins" }
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials" }
 // Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
-const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins" }
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -177,6 +178,7 @@ export function AdminCockpitPage() {
       {overlay === "users" && <UsersOverlay onClose={() => setOverlay(null)} />}
       {overlay === "modules" && <ModulesOverlay onClose={() => setOverlay(null)} />}
       {overlay === "plugins" && <PluginsOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "credentials" && <CredentialsOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/CredentialsOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/CredentialsOverlay.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react"
+import { Key, Loader2, Plus } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { credentialsApi } from "@/features/credentials/api"
+import { CredentialEditor } from "@/features/credentials/CredentialEditor"
+import { ExtensionCredentials } from "@/features/credentials/ExtensionCredentials"
+import type { Credential } from "@/features/credentials/types"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+
+type Tab = "http" | "extensions"
+
+export function CredentialsOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("credentials")
+  const role = useAuthStore((s) => s.role)
+  const [tab, setTab] = useState<Tab>("http")
+  const [creds, setCreds] = useState<Credential[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editor, setEditor] = useState<Credential | "new" | null>(null)
+
+  async function reload() {
+    setLoading(true)
+    try { setCreds(await credentialsApi.list()) } catch { setCreds([]) } finally { setLoading(false) }
+  }
+  useEffect(() => { reload() }, [])
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      maxWidthClass="max-w-4xl"
+      headerActions={tab === "http" ? (
+        <CockpitButton tone="primary" onClick={() => setEditor("new")}>
+          <Plus size={12} className="mr-1 inline" />{t("new")}
+        </CockpitButton>
+      ) : undefined}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-[#8d9ab0]">{t("subtitle")}</p>
+
+        <div className="flex gap-2 border-b border-[#2a364b]">
+          <button onClick={() => setTab("http")}
+            className={`-mb-px flex items-center gap-1.5 border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+              tab === "http" ? "border-violet-500 text-violet-300" : "border-transparent text-[#8d9ab0] hover:text-[#e8eef8]"
+            }`}>
+            <Key size={13} /> HTTP-Credentials
+          </button>
+          {role === "admin" && (
+            <button onClick={() => setTab("extensions")}
+              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === "extensions" ? "border-violet-500 text-violet-300" : "border-transparent text-[#8d9ab0] hover:text-[#e8eef8]"
+              }`}>
+              Extensions
+            </button>
+          )}
+        </div>
+
+        {tab === "extensions" && <ExtensionCredentials />}
+
+        {tab === "http" && (
+          <>
+            <p className="rounded-[4px] border border-amber-500/15 bg-amber-500/[5%] px-3 py-2 text-[11px] text-amber-200/90">
+              {t("security_note")}
+            </p>
+
+            {loading ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 size={20} className="animate-spin text-[#8d9ab0]" />
+              </div>
+            ) : creds.length === 0 ? (
+              <p className="py-8 text-center text-xs text-[#8d9ab0]">{t("empty")}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                {creds.map((c) => (
+                  <button key={c.name} onClick={() => setEditor(c)}
+                    className="rounded-[6px] border border-[#2a364b] bg-[#111827] p-3 text-left transition-colors hover:border-[#46617f] hover:bg-[#172133]">
+                    <div className="mb-1 flex items-center gap-2">
+                      <Key size={11} className="shrink-0 text-amber-300" />
+                      <p className="flex-1 truncate font-mono text-sm text-[#e8eef8]">{c.name}</p>
+                      <span className="shrink-0 rounded-full border border-violet-500/20 bg-violet-500/[8%] px-1.5 py-0.5 text-[10px] text-violet-300">
+                        {t(`type_${c.type}`)}
+                      </span>
+                    </div>
+                    {c.description && <p className="line-clamp-1 text-xs text-[#8d9ab0]">{c.description}</p>}
+                    <p className="mt-1 truncate font-mono text-[10px] text-[#5b6675]">{c.url_pattern}</p>
+                  </button>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {tab === "http" && editor && (
+        <CredentialEditor
+          credential={editor === "new" ? null : editor}
+          onClose={() => setEditor(null)}
+          onSaved={async () => { setEditor(null); await reload() }}
+          onDeleted={async () => { setEditor(null); await reload() }}
+        />
+      )}
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Vierter Admin-Bereich (nach Users #345, Modules #346, Plugins #347) vom Legacy-Sprung auf ein eingerastetes Cockpit-Overlay umgestellt.

## Änderungen
- **CredentialsOverlay** — HTTP/Extensions-Tabs + Credential-Liste im `AdminOverlay`-Rahmen (Cockpit-Design, `box` raus). Nutzt `credentialsApi`, den bestehenden `CredentialEditor` (eigenes `fixed`-Overlay, stackt sauber darüber) und `ExtensionCredentials` unverändert.
- **AdminCockpitPage** — `credentials` in `OVERLAY_BY_ACTION` + `OVERLAY_BY_PATH` (Admin-Bereich- und Integrations-Kachel öffnen beide das Overlay).

## Sicherheit
Die Liste rendert nur `name`/`type`/`description`/`url_pattern`. Secret-Werte bleiben **maskiert** (`value` ist beim Listing leer) — kein Klartext im Overlay. Der Editor nutzt die bestehende, geprüfte Speicher-Logik.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler; nur die bekannte set-state-in-effect-Warnung)
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Nächste: Themes (erster opsLinks-Pfad-Bereich).