### PR TITLE
feat(admin): MCP-Server als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -10,17 +10,18 @@ import { ModulesOverlay } from "./admin/ModulesOverlay"
 import { PluginsOverlay } from "./admin/PluginsOverlay"
 import { CredentialsOverlay } from "./admin/CredentialsOverlay"
 import { ThemesOverlay } from "./admin/ThemesOverlay"
+import { McpOverlay } from "./admin/McpOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes"
+type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes" | "mcp"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
 // action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
 const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials" }
 // Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
-const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes" }
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes", "/mcp": "mcp" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -181,6 +182,7 @@ export function AdminCockpitPage() {
       {overlay === "plugins" && <PluginsOverlay onClose={() => setOverlay(null)} />}
       {overlay === "credentials" && <CredentialsOverlay onClose={() => setOverlay(null)} />}
       {overlay === "themes" && <ThemesOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "mcp" && <McpOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/McpOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/McpOverlay.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react"
+import { Plus, Server } from "lucide-react"
+import { mcpApi } from "@/features/mcp/api"
+import { McpServerForm } from "@/features/mcp/McpServerForm"
+import { NewMcpServerDialog } from "@/features/mcp/NewMcpServerDialog"
+import { QuickAddPanel } from "@/features/mcp/QuickAddPanel"
+import type { McpServer } from "@/features/mcp/types"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+
+export function McpOverlay({ onClose }: { onClose: () => void }) {
+  const [servers, setServers] = useState<McpServer[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [showNew, setShowNew] = useState(false)
+
+  async function loadServers(selectId?: string) {
+    const list = await mcpApi.list()
+    setServers(list)
+    if (selectId) setActiveId(selectId)
+    else if (!activeId && list.length > 0) setActiveId(list[0].id)
+  }
+  useEffect(() => { loadServers().catch(() => {}) }, [])
+
+  function handleSaved(updated: McpServer) {
+    setServers((cur) => cur.map((s) => (s.id === updated.id ? updated : s)))
+  }
+  function handleDeleted() {
+    if (!activeId) return
+    setServers((cur) => cur.filter((s) => s.id !== activeId))
+    setActiveId(null)
+  }
+  function handleCreated(id: string) { setShowNew(false); loadServers(id) }
+
+  const active = servers.find((s) => s.id === activeId) ?? null
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title="MCP-Server"
+      onClose={onClose}
+      maxWidthClass="max-w-5xl"
+      headerActions={
+        <CockpitButton tone="primary" onClick={() => setShowNew(true)}>
+          <Plus size={12} className="mr-1 inline" />Neuer Server
+        </CockpitButton>
+      }
+    >
+      <div className="grid gap-4 md:grid-cols-[220px_1fr]">
+        {/* Server-Liste */}
+        <aside className="space-y-1.5">
+          <button onClick={() => setActiveId(null)}
+            className={`flex w-full items-center gap-2 rounded-[4px] border px-3 py-2 text-left text-xs font-medium transition-colors ${
+              activeId === null ? "border-[#46617f] bg-[#172133] text-[#e8eef8]" : "border-[#2a364b] bg-[#111827] text-[#8d9ab0] hover:border-[#46617f] hover:text-[#e8eef8]"
+            }`}>
+            <Plus size={13} /> Schnell hinzufügen
+          </button>
+          {servers.length === 0 ? (
+            <p className="py-6 text-center text-xs text-[#8d9ab0]">Noch keine Server.</p>
+          ) : (
+            servers.map((s) => (
+              <button key={s.id} onClick={() => setActiveId(s.id)}
+                className={`flex w-full items-start gap-2 rounded-[4px] border px-3 py-2 text-left transition-colors ${
+                  s.id === activeId ? "border-[#46617f] bg-[#172133]" : "border-[#2a364b] bg-[#111827] hover:border-[#46617f]"
+                }`}>
+                <Server size={13} className="mt-0.5 shrink-0 text-[#69d7ff]" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs font-medium text-[#e8eef8]">{s.name || s.id}</span>
+                  <span className="mt-0.5 block truncate font-mono text-[10px] text-[#5b6675]">{s.id}</span>
+                </span>
+              </button>
+            ))
+          )}
+        </aside>
+
+        {/* Detail: Form oder QuickAdd */}
+        <main className="min-w-0">
+          {active ? (
+            <McpServerForm key={active.id} server={active} onSaved={handleSaved} onDeleted={handleDeleted} />
+          ) : (
+            <QuickAddPanel existingIds={new Set(servers.map((s) => s.id))} onCreated={handleCreated} />
+          )}
+        </main>
+      </div>
+
+      {showNew && <NewMcpServerDialog onClose={() => setShowNew(false)} onCreated={handleCreated} />}
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Sechster Admin-Bereich (opsLinks-Pfad `/mcp`) auf ein eingerastetes Cockpit-Overlay umgestellt.

## Änderungen
- **McpOverlay** — Master-Detail-Layout (Server-Liste links + Form/QuickAdd rechts) im `AdminOverlay`-Rahmen. Statt der viewport-fixierten `CollapsibleSidebar` (die im Overlay-Kontext falsch positioniert würde) eine reguläre Flex-Sidebar im Cockpit-Design. Wiederverwendet `McpServerForm`, `QuickAddPanel` und `NewMcpServerDialog` (eigenes `fixed`-Overlay, stackt sauber darüber) + `mcpApi` unverändert.
- **AdminCockpitPage** — `/mcp` in `OVERLAY_BY_PATH`.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler; nur bekannte set-state/exhaustive-deps-Warnungen)
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Nächste: LLM.