### PR TITLE
feat(admin): Extensions als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -12,17 +12,18 @@ import { CredentialsOverlay } from "./admin/CredentialsOverlay"
 import { ThemesOverlay } from "./admin/ThemesOverlay"
 import { McpOverlay } from "./admin/McpOverlay"
 import { LlmOverlay } from "./admin/LlmOverlay"
+import { ExtensionsOverlay } from "./admin/ExtensionsOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes" | "mcp" | "llm"
+type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes" | "mcp" | "llm" | "extensions"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
 // action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
-const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials" }
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials", extensions: "extensions" }
 // Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
-const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes", "/mcp": "mcp", "/llm": "llm" }
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes", "/mcp": "mcp", "/llm": "llm", "/extensions": "extensions" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -185,6 +186,7 @@ export function AdminCockpitPage() {
       {overlay === "themes" && <ThemesOverlay onClose={() => setOverlay(null)} />}
       {overlay === "mcp" && <McpOverlay onClose={() => setOverlay(null)} />}
       {overlay === "llm" && <LlmOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "extensions" && <ExtensionsOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }

--- a/frontend/src/features/cockpit/admin/ExtensionsOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/ExtensionsOverlay.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Container, RefreshCw, Terminal } from "lucide-react"
+import { fetchExtensions } from "@/features/extensions/api"
+import { ExtensionCard } from "@/features/extensions/ExtensionCard"
+import { InstallModal } from "@/features/extensions/InstallModal"
+import { CATEGORIES, type Extension, type InstallMode } from "@/features/extensions/types"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+import { useDockerInstall } from "./useDockerInstall"
+
+interface ModalState { ext: Extension; action: "install" | "uninstall"; mode: InstallMode }
+
+export function ExtensionsOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("extensions")
+  const [extensions, setExtensions] = useState<Extension[]>([])
+  const [loading, setLoading] = useState(true)
+  const [category, setCategory] = useState("all")
+  const [modal, setModal] = useState<ModalState | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try { setExtensions(await fetchExtensions()) } catch { /* leer bei Fehler */ }
+    setLoading(false)
+  }, [])
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { load() }, [load])
+
+  const docker = useDockerInstall(load)
+  const visible = category === "all" ? extensions : extensions.filter((e) => e.category === category)
+  const categoriesWithCount = CATEGORIES.map((c) => ({
+    ...c, count: c.id === "all" ? extensions.length : extensions.filter((e) => e.category === c.id).length,
+  })).filter((c) => c.count > 0 || c.id === "all")
+  const dockerAvailable = extensions.some((e) => e.docker_available)
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      maxWidthClass="max-w-5xl"
+      headerActions={
+        <CockpitButton onClick={load}>
+          <RefreshCw size={13} className={loading ? "animate-spin" : ""} />
+        </CockpitButton>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-[#8d9ab0]">
+          {t("installed_count", { installed: extensions.filter((e) => e.installed).length, total: extensions.length })}
+        </p>
+
+        <div className="flex gap-4">
+          <nav className="hidden w-40 shrink-0 flex-col gap-0.5 md:flex">
+            {categoriesWithCount.map((c) => (
+              <button key={c.id} onClick={() => setCategory(c.id)}
+                className={`flex items-center justify-between rounded-[4px] px-3 py-1.5 text-left text-xs font-medium transition-colors ${
+                  category === c.id ? "bg-violet-500/15 text-violet-300" : "text-[#8d9ab0] hover:bg-white/[4%] hover:text-[#e8eef8]"
+                }`}>
+                <span>{c.label}</span>
+                <span className={`text-[10px] ${category === c.id ? "text-violet-400" : "text-[#5b6675]"}`}>{c.count}</span>
+              </button>
+            ))}
+          </nav>
+
+          <div className="w-full md:hidden">
+            <select value={category} onChange={(e) => setCategory(e.target.value)}
+              className="w-full rounded-[4px] border border-[#2a364b] bg-[#0d1420] px-3 py-2 text-sm text-[#e8eef8] focus:border-violet-500/60 focus:outline-none">
+              {categoriesWithCount.map((c) => <option key={c.id} value={c.id}>{c.label} ({c.count})</option>)}
+            </select>
+          </div>
+
+          <div className="min-w-0 flex-1 space-y-4">
+            {category === "dockertools" && (
+              <div className={`flex items-start gap-3 rounded-[6px] border p-4 ${dockerAvailable ? "border-emerald-500/20 bg-emerald-500/5" : "border-blue-500/20 bg-blue-500/5"}`}>
+                <Container size={18} className={dockerAvailable ? "mt-0.5 text-emerald-400" : "mt-0.5 text-blue-400"} />
+                <div className="min-w-0 flex-1">
+                  <p className={`text-sm font-medium ${dockerAvailable ? "text-emerald-300" : "text-blue-300"}`}>
+                    {dockerAvailable ? t("docker.available") : t("docker.not_installed")}
+                  </p>
+                  <p className="mt-0.5 text-xs text-[#8d9ab0]">{dockerAvailable ? t("docker.available_hint") : t("docker.not_installed_hint")}</p>
+                </div>
+                {!dockerAvailable && (
+                  <button onClick={docker.install} disabled={docker.installing}
+                    className="flex shrink-0 items-center gap-1.5 rounded-[4px] bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-500 disabled:opacity-50">
+                    <Terminal size={12} />{docker.installing ? t("docker.installing") : t("docker.install_button")}
+                  </button>
+                )}
+              </div>
+            )}
+
+            {category === "dockertools" && docker.log && (
+              <div className="max-h-48 overflow-y-auto rounded-[6px] border border-[#2a364b] bg-[#0b111c] p-4 font-mono text-xs leading-relaxed">
+                {docker.log.map((l, i) => (
+                  <div key={i} className={l.startsWith("[OK]") ? "text-emerald-400" : l.startsWith("[FEHLER]") ? "text-rose-400" : "text-[#d7deea]"}>{l}</div>
+                ))}
+              </div>
+            )}
+
+            {loading && extensions.length === 0 ? (
+              <p className="text-sm text-[#8d9ab0]">{t("loading")}</p>
+            ) : visible.length === 0 ? (
+              <p className="text-sm text-[#8d9ab0]">{t("empty_category")}</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                {visible.map((ext) => (
+                  <ExtensionCard key={ext.id} ext={ext}
+                    onInstall={(mode) => setModal({ ext, action: "install", mode })}
+                    onUninstall={(mode) => setModal({ ext, action: "uninstall", mode })}
+                    onRefresh={load} />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {modal && (
+        <InstallModal ext={modal.ext} action={modal.action} mode={modal.mode}
+          onClose={(refresh) => { setModal(null); if (refresh) load() }} />
+      )}
+    </AdminOverlay>
+  )
+}

--- a/frontend/src/features/cockpit/admin/useDockerInstall.ts
+++ b/frontend/src/features/cockpit/admin/useDockerInstall.ts
@@ -1,0 +1,48 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { authHeaders } from "@/features/extensions/api"
+
+/** Docker-Installation als SSE-Stream (aus ExtensionsPage ausgelagert, damit das
+ *  Overlay schlank unter ~200 Zeilen bleibt). onDone wird bei Abschluss gerufen. */
+export function useDockerInstall(onDone: () => void) {
+  const { t } = useTranslation("extensions")
+  const [log, setLog] = useState<string[] | null>(null)
+  const [installing, setInstalling] = useState(false)
+
+  async function install() {
+    setInstalling(true)
+    setLog([t("docker.log_starting")])
+    try {
+      const res = await fetch("/api/admin/extensions/install-docker", { method: "POST", headers: authHeaders() })
+      if (!res.ok || !res.body) {
+        setLog((l) => [...(l ?? []), `[FEHLER] HTTP ${res.status}`])
+        setInstalling(false)
+        return
+      }
+      const reader = res.body.getReader()
+      const dec = new TextDecoder()
+      let buf = ""
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += dec.decode(value, { stream: true })
+        const parts = buf.split("\n\n")
+        buf = parts.pop() ?? ""
+        for (const part of parts) {
+          const dataLine = part.split("\n").find((l) => l.startsWith("data:"))
+          if (!dataLine) continue
+          try {
+            const obj = JSON.parse(dataLine.slice(5).trim())
+            if (obj.line !== undefined) setLog((l) => [...(l ?? []), obj.line])
+            if (obj.done) { onDone(); break }
+          } catch { /* unvollständige SSE-Zeile überspringen */ }
+        }
+      }
+    } catch (e) {
+      setLog((l) => [...(l ?? []), `[FEHLER] ${String(e)}`])
+    }
+    setInstalling(false)
+  }
+
+  return { log, installing, install }
+}


### PR DESCRIPTION
## Ziel
Achter Admin-Bereich (action.id `extensions` + Pfad `/extensions`) auf ein eingerastetes Cockpit-Overlay umgestellt.

## Änderungen
- **ExtensionsOverlay** — Kategorie-Sidebar + Docker-Banner/Log + Extension-Grid im `AdminOverlay`-Rahmen (Cockpit-Design, `box` raus). Wiederverwendet `ExtensionCard` (setzt `--c` selbst → korrektes Rendering) und `InstallModal` (eigenes `fixed`-Overlay, stackt sauber darüber).
- **useDockerInstall** — Docker-Install-SSE-Logik aus der Seite ausgelagert, damit das Overlay die ~200-Zeilen-Regel einhält (124z Overlay + 48z Hook).
- **AdminCockpitPage** — `extensions` in `OVERLAY_BY_ACTION` + `/extensions` in `OVERLAY_BY_PATH` (Admin-Bereich-Kachel und Gitea-Integrationskachel öffnen beide das Overlay).

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler)
- Dateigrößen konform: 124 + 48 Zeilen (Original war 208z).
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Verbleibend: System, System-Settings, VMs, Containers.