### PR TITLE
feat(admin): System als eingerastetes Cockpit-Overlay

### DIFF
--- a/frontend/src/features/cockpit/AdminCockpitPage.tsx
+++ b/frontend/src/features/cockpit/AdminCockpitPage.tsx
@@ -13,17 +13,18 @@ import { ThemesOverlay } from "./admin/ThemesOverlay"
 import { McpOverlay } from "./admin/McpOverlay"
 import { LlmOverlay } from "./admin/LlmOverlay"
 import { ExtensionsOverlay } from "./admin/ExtensionsOverlay"
+import { SystemOverlay } from "./admin/SystemOverlay"
 
 /** Admin-Bereiche, die bereits als eingerastetes Cockpit-Overlay existieren.
  *  Alles andere fällt (noch) auf die bestehende Legacy-Seite via openLocalPath. */
-type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes" | "mcp" | "llm" | "extensions"
+type AdminOverlayId = "users" | "modules" | "plugins" | "credentials" | "themes" | "mcp" | "llm" | "extensions" | "system"
 
 const adminIcons = [Server, Users, Boxes, PlugZap, CircuitBoard, KeyRound]
 // action.ids mit Overlay werden eingerastet, der Rest per Pfad geöffnet.
 const adminLinks = adminOfflineActions.map((action, index) => ({ id: action.id, title: action.label, path: action.path ?? "/admin", icon: adminIcons[index] ?? Server, desc: action.description ?? "Lokale Admin-Seite öffnen." }))
-const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials", extensions: "extensions" }
+const OVERLAY_BY_ACTION: Record<string, AdminOverlayId> = { users: "users", modules: "modules", plugins: "plugins", credentials: "credentials", extensions: "extensions", system: "system" }
 // Pfad-basierte Kacheln (Ops/Integrationen ohne action.id) auf Overlays mappen.
-const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes", "/mcp": "mcp", "/llm": "llm", "/extensions": "extensions" }
+const OVERLAY_BY_PATH: Record<string, AdminOverlayId> = { "/modules": "modules", "/plugins": "plugins", "/credentials": "credentials", "/themes": "themes", "/mcp": "mcp", "/llm": "llm", "/extensions": "extensions", "/system": "system" }
 
 const opsLinks = [
   { title: "LLM", path: "/llm", icon: Brain },
@@ -64,11 +65,11 @@ export function AdminCockpitPage() {
       eyebrow="Admin"
       title="Admin-Cockpit"
       description="Schaltzentrale für System, User, Module, Integrationen, Credentials und Infrastruktur. Die Route bleibt durch AdminGuard geschützt."
-      actions={<CockpitButton tone="primary" onClick={() => openLocalPath("/system")}>System öffnen</CockpitButton>}
+      actions={<CockpitButton tone="primary" onClick={() => setOverlay("system")}>System öffnen</CockpitButton>}
       className="flex h-full min-h-0 flex-col overflow-hidden bg-[#080b11]"
       hideHeader
     >
-      <CockpitTopbar active="admin" context="Admin" action={{ label: "System öffnen", path: "/system" }} />
+      <CockpitTopbar active="admin" context="Admin" />
       <div className="grid min-h-0 flex-1 gap-[10px] overflow-hidden p-[10px] xl:grid-cols-[280px_minmax(520px,1fr)_370px]">
         <aside className="space-y-[10px]">
           <CockpitPanel title="Admin-Bereiche" eyebrow="Control">
@@ -149,8 +150,8 @@ export function AdminCockpitPage() {
 
           <CockpitPanel title="Wartung & Backups" eyebrow="Recovery">
             <div className="grid gap-2 md:grid-cols-2">
-              <Info title="Backup" icon={DatabaseBackup} text="Backup/Restore bleibt im Systembereich, damit bestehende Confirmations und Guards greifen." path="/system" />
-              <Info title="System-Settings" icon={SlidersHorizontal} text="Globale Einstellungen und Migrationen bleiben geschützt unter /system/settings." path="/system/settings" />
+              <Info title="Backup" icon={DatabaseBackup} text="Backup/Restore bleibt im Systembereich, damit bestehende Confirmations und Guards greifen." onOpen={() => openPath("/system")} />
+              <Info title="System-Settings" icon={SlidersHorizontal} text="Globale Einstellungen und Migrationen bleiben geschützt unter /system/settings." onOpen={() => openPath("/system/settings")} />
             </div>
           </CockpitPanel>
         </main>
@@ -187,13 +188,14 @@ export function AdminCockpitPage() {
       {overlay === "mcp" && <McpOverlay onClose={() => setOverlay(null)} />}
       {overlay === "llm" && <LlmOverlay onClose={() => setOverlay(null)} />}
       {overlay === "extensions" && <ExtensionsOverlay onClose={() => setOverlay(null)} />}
+      {overlay === "system" && <SystemOverlay onClose={() => setOverlay(null)} />}
     </CockpitShell>
   )
 }
 
-function Info({ title, text, path, icon: Icon }: { title: string; text: string; path: string; icon: ComponentType<{ size?: number; className?: string }> }) {
+function Info({ title, text, onOpen, icon: Icon }: { title: string; text: string; onOpen: () => void; icon: ComponentType<{ size?: number; className?: string }> }) {
   return (
-    <button onClick={() => openLocalPath(path)} className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left hover:border-[#46617f] hover:bg-[#172133]">
+    <button onClick={onOpen} className="rounded-[4px] border border-[#2a364b] bg-[#111827] p-3 text-left hover:border-[#46617f] hover:bg-[#172133]">
       <div className="mb-2 flex items-center gap-2">
         <Icon size={16} className="text-[#69d7ff]" />
         <h3 className="text-sm font-bold text-[#e8eef8]">{title}</h3>

--- a/frontend/src/features/cockpit/admin/SystemOverlay.tsx
+++ b/frontend/src/features/cockpit/admin/SystemOverlay.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react"
+import { Activity, Bot, Database, Folder, MessageSquare, Mic, RotateCw, Server, SlidersHorizontal, Wrench, Zap } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { useAuthStore } from "@/features/auth/useAuthStore"
+import { RestartModal } from "@/shared/RestartModal"
+import { useRestart } from "@/shared/useRestart"
+import { systemApi, type HealthCheck, type SystemInfo, type SystemStats } from "@/features/system/api"
+import { AgentLinkCard } from "@/features/system/AgentLinkCard"
+import { BridgeCard } from "@/features/system/BridgeCard"
+import { SambaCard } from "@/features/system/SambaCard"
+import { TailscaleCard } from "@/features/system/TailscaleCard"
+import { BackupCard } from "@/features/system/BackupCard"
+import { MigrationCard } from "@/features/system/MigrationCard"
+import { HealthBar } from "@/features/system/HealthBar"
+import { StatCard } from "@/features/system/StatCard"
+import { VoiceInstallModal } from "@/features/system/VoiceInstallModal"
+import { useVoiceInstall } from "@/features/system/useVoiceInstall"
+import { PathRow, formatBytes, formatUptime } from "@/features/system/_systemHelpers"
+import { CockpitButton } from "../CockpitButton"
+import { AdminOverlay } from "./AdminOverlay"
+
+const REFRESH_MS = 10_000
+
+export function SystemOverlay({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("system")
+  const { t: tAgents } = useTranslation("agents")
+  const { t: tNav } = useTranslation("nav")
+  const role = useAuthStore((s) => s.role)
+  const restart = useRestart()
+  const voice = useVoiceInstall()
+  const [info, setInfo] = useState<SystemInfo | null>(null)
+  const [stats, setStats] = useState<SystemStats | null>(null)
+  const [checks, setChecks] = useState<HealthCheck[]>([])
+
+  async function loadAll() {
+    try {
+      const [i, s, h] = await Promise.all([systemApi.info(), systemApi.stats(), systemApi.health()])
+      setInfo(i); setStats(s); setChecks(h.checks)
+    } catch { /* leise */ }
+  }
+  useEffect(() => {
+    loadAll()
+    const id = setInterval(loadAll, REFRESH_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <AdminOverlay
+      eyebrow="Admin"
+      title={t("title")}
+      onClose={onClose}
+      maxWidthClass="max-w-6xl"
+      headerActions={role === "admin" ? (
+        <div className="flex items-center gap-2">
+          <CockpitButton onClick={() => window.open("/system/settings", "_self")}>
+            <SlidersHorizontal size={12} className="mr-1 inline" />Einstellungen
+          </CockpitButton>
+          <CockpitButton onClick={voice.begin}>
+            <Mic size={12} className="mr-1 inline" />Voice installieren
+          </CockpitButton>
+          <CockpitButton onClick={restart.open}>
+            <RotateCw size={12} className="mr-1 inline" />{tNav("restart.button")}
+          </CockpitButton>
+        </div>
+      ) : undefined}
+    >
+      <div className="space-y-6">
+        <p className="text-sm text-[#8d9ab0]">
+          {info
+            ? t("subtitle_with_uptime", { seconds: REFRESH_MS / 1000, uptime: formatUptime(info.uptime_seconds, t) })
+            : t("subtitle", { seconds: REFRESH_MS / 1000 })}
+        </p>
+
+        <HealthBar checks={checks} />
+
+        {stats && (
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <StatCard icon={Bot} label={t("stats.agents")} value={stats.agents.total}
+              detail={Object.entries(stats.agents.by_type).map(([k, v]) => t("stats.agents_detail", { count: v, type: tAgents(`type.${k}`) })).join(", ")} glow="bg-violet-500/40" />
+            <StatCard icon={Folder} label={t("stats.projects")} value={stats.projects.total}
+              detail={t("stats.projects_detail", { count: stats.projects.active })} glow="bg-indigo-500/40" />
+            <StatCard icon={MessageSquare} label={t("stats.sessions")} value={stats.sessions.total}
+              detail={t("stats.sessions_detail", { count: stats.sessions.active })} glow="bg-fuchsia-500/40" />
+            <StatCard icon={Activity} label={t("stats.messages")} value={stats.messages.total}
+              detail={t("stats.messages_detail", { count: stats.messages.compactions })} glow="bg-amber-500/40" />
+            <StatCard icon={Wrench} label={t("stats.tool_calls")} value={stats.tool_calls.total}
+              detail={t("stats.tool_calls_detail", { rate: stats.tool_calls.success_rate })} glow="bg-emerald-500/40" />
+            <StatCard icon={Database} label={t("stats.db_size")} value={info ? formatBytes(info.db_size_bytes) : "—"}
+              detail={t("stats.db_size_detail")} glow="bg-cyan-500/40" />
+            <StatCard icon={Zap} label={t("stats.python")} value={info?.python ?? "—"} detail={info?.platform} glow="bg-yellow-500/40" />
+            <StatCard icon={Server} label={t("stats.version")} value={info?.version ?? "—"}
+              detail={t("stats.version_detail")} glow="bg-rose-500/40" />
+          </div>
+        )}
+
+        {info && (
+          <div className="space-y-1 rounded-[6px] border border-[#2a364b] bg-[#111827] p-4">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[#8d9ab0]">{t("paths.title")}</p>
+            <PathRow label={t("paths.data")} value={info.data_dir} />
+            <PathRow label={t("paths.config")} value={info.config_dir} />
+            <PathRow label={t("paths.db")} value={info.db_path} />
+          </div>
+        )}
+
+        <AgentLinkCard />
+        {role === "admin" && <TailscaleCard />}
+        {role === "admin" && <BridgeCard />}
+        {role === "admin" && <SambaCard />}
+        {role === "admin" && <BackupCard />}
+        {role === "admin" && <MigrationCard />}
+      </div>
+
+      {restart.state !== "idle" && (
+        <RestartModal state={restart.state} errorMessage={restart.error} onConfirm={restart.confirm} onClose={restart.close} />
+      )}
+      {voice.state !== "idle" && (
+        <VoiceInstallModal state={voice.state} errorMessage={voice.error} onConfirm={voice.confirm} onClose={voice.close} />
+      )}
+    </AdminOverlay>
+  )
+}


### PR DESCRIPTION
## Ziel
Neunter und umfangreichster Admin-Bereich auf ein eingerastetes Cockpit-Overlay umgestellt. `system` hat action.id, Pfad `/system`, ist der **primäre `System öffnen`-Button** und war die Topbar-Action.

## Änderungen
- **SystemOverlay** — Header-Aktionen (Einstellungen/Voice/Restart), `HealthBar`, `StatCard`-Grid, Pfade-Block (`box` raus → Cockpit-Panel) im `AdminOverlay`-Rahmen. Bindet die **6 System-Karten** (AgentLink/Tailscale/Bridge/Samba/Backup/Migration) **unverändert** ein — sie setzen ihre `--c`-Akzentfarbe selbst und rendern korrekt. `RestartModal` + `VoiceInstallModal` stacken als eigene `fixed`-Overlays.
- **AdminCockpitPage** — `system` in `OVERLAY_BY_ACTION` + `/system` in `OVERLAY_BY_PATH`; primärer `System öffnen`-Button und die Backup-Wartungskachel öffnen das Overlay; redundante Topbar-`action` entfernt; `Info`-Kachel auf Callback umgestellt.

## Sicherheit
Keine automatischen Aktionen beim Laden. Backup/Restore/Migration/Voice/Restart bleiben in ihren Karten/Modals mit den **bestehenden Confirms**. Es läuft nur der 10s-Polling-Refresh (info/stats/health), exakt wie im Original.

## Verifikation
- `tsc --noEmit` grün · `npm run build` grün · ESLint grün (0 Fehler) · 121 Zeilen (Original 154z)
- Browser-Boot gegen `vite preview`: **0 pageerrors, kein schwarzer Screen**.

## Reihe
Verbleibend: System-Settings, VMs, Containers.