### PR TITLE
fix(updater): LLM-Config-Rechte auf Altinstallationen reparieren

### DIFF
--- a/core/tests/test_installer_config_permissions.py
+++ b/core/tests/test_installer_config_permissions.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import pwd
+import stat
+import subprocess
+
+
+HELPER = Path(__file__).parents[2] / "installer" / "lib" / "config-permissions.sh"
+
+
+def _run_helper(config_dir: Path) -> None:
+    user = pwd.getpwuid(os.getuid()).pw_name
+    subprocess.run(
+        [
+            "bash",
+            "-c",
+            'set -euo pipefail; log() { :; }; source "$1"; repair_llm_config_permissions',
+            "test-config-permissions",
+            str(HELPER),
+        ],
+        env={**os.environ, "HH_CONFIG_DIR": str(config_dir), "HH_USER": user},
+        check=True,
+    )
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_repair_llm_config_permissions(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(mode=0o700)
+    llm_config = config_dir / "llm.json"
+    llm_config.write_text('{"providers": []}')
+    llm_config.chmod(0o444)
+
+    _run_helper(config_dir)
+
+    assert _mode(config_dir) == 0o750
+    assert _mode(llm_config) == 0o640
+    assert llm_config.stat().st_uid == os.getuid()
+
+
+def test_repair_rejects_llm_config_symlink(tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(mode=0o700)
+    target = tmp_path / "outside.json"
+    target.write_text("secret")
+    target.chmod(0o600)
+    (config_dir / "llm.json").symlink_to(target)
+
+    _run_helper(config_dir)
+
+    assert _mode(target) == 0o600

--- a/installer/lib/config-permissions.sh
+++ b/installer/lib/config-permissions.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Self-Heal für schreibbare Runtime-Konfigurationen auf bestehenden Installationen.
+
+repair_llm_config_permissions() {
+  local config_dir="${HH_CONFIG_DIR:-/etc/hydrahive2}"
+  local service_user="${HH_USER:-hydrahive}"
+  local llm_config="$config_dir/llm.json"
+
+  [ -e "$llm_config" ] || return 0
+
+  # Keine Links verfolgen: Update darf nie Besitzer/Rechte eines fremden Ziels ändern.
+  if [ -L "$config_dir" ] || [ -L "$llm_config" ] || [ ! -d "$config_dir" ] || [ ! -f "$llm_config" ]; then
+    log "WARNUNG: $llm_config ist keine reguläre Config-Datei — Permission-Self-Heal übersprungen"
+    return 0
+  fi
+
+  log "LLM-Config-Rechte prüfen und reparieren"
+  chown -- "$service_user:$service_user" "$config_dir" "$llm_config"
+  chmod 750 -- "$config_dir"
+  chmod 640 -- "$llm_config"
+}

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -73,6 +73,12 @@ if [ -z "${HH_UPDATE_REEXECED:-}" ] && [ -n "$SELF_HASH_BEFORE" ]; then
   fi
 fi
 
+# Bestehende Installationen können eine vom Installer als root erzeugte llm.json
+# besitzen. Dann scheitern Hinzufügen, Bearbeiten und Löschen in der Web-UI.
+# shellcheck source=lib/config-permissions.sh
+source "$HH_REPO_DIR/installer/lib/config-permissions.sh"
+repair_llm_config_permissions
+
 log "Node.js prüfen"
 if ! command -v node >/dev/null 2>&1 || [ "$(node -v 2>/dev/null | cut -d. -f1 | tr -d v)" -lt 20 ]; then
   log "Node.js 20 fehlt — installiere via NodeSource"


### PR DESCRIPTION
## Problem
Bei älteren Installationen kann `/etc/hydrahive2/llm.json` noch `root:root` gehören. Das Backend läuft als `hydrahive` und kann die Datei dann nicht überschreiben. In der LLM-Verwaltung schlagen dadurch Hinzufügen, Bearbeiten und Löschen fehl beziehungsweise sind nach einem Reload wieder rückgängig.

Der vorhandene Fix aus `c9f07a7a` korrigierte nur Installations-/LLM-Wizard-Schreibvorgänge. Ein normales Update reparierte bereits vorhandene Dateien nicht.

## Fix
- neuer idempotenter Permission-Self-Heal im Update-Lauf
- repariert Config-Verzeichnis und `llm.json` auf den Service-User
- setzt restriktive Modi `0750` (Verzeichnis) und `0640` (Datei)
- verweigert Symlinks und nicht-reguläre Dateien, damit `chown`/`chmod` nie fremde Ziele verfolgen
- läuft dank bestehendem Update-Script-Reexec bereits im Update, das diesen Fix herunterlädt

## Tests
- Regressionstest für Modus-/Besitzer-Reparatur
- Regressionstest: Symlink-Ziel bleibt unangetastet
- `ruff check` grün
- `pytest`: 2 passed
- `bash -n` für beide Shellskripte grün
- `git diff --check` grün

## Sofortmaßnahme auf betroffenen Servern
```bash
sudo chown hydrahive:hydrahive /etc/hydrahive2/llm.json
sudo chmod 640 /etc/hydrahive2/llm.json
```
