### PR TITLE
feat(auth): stabile Benutzeridentitäten für benutzereigene Module

### DIFF
--- a/core/src/hydrahive/api/middleware/api_keys.py
+++ b/core/src/hydrahive/api/middleware/api_keys.py
@@ -45,6 +45,13 @@ def _save(data: dict) -> None:
     tmp.replace(p)
 
 
+def _verified_identity(entry: dict) -> dict:
+    identity = {"username": entry["username"], "role": entry["role"]}
+    if entry.get("user_id"):
+        identity["user_id"] = entry["user_id"]
+    return identity
+
+
 def _is_new_format(plain: str) -> bool:
     """Erkennt neues Format: hhk_<16 Hex-Zeichen>_<Rest>.
     Hex-Zeichen sind [0-9a-f] — kein Überschneidung mit Base64url-Uppercase."""
@@ -56,8 +63,17 @@ def _is_new_format(plain: str) -> bool:
     )
 
 
-def create(name: str, username: str, role: str) -> str:
-    """Erzeugt einen neuen API-Key im neuen Format. Gibt den Klartext zurück (einmalig)."""
+def create(name: str, username: str, role: str, user_id: str | None = None) -> str:
+    """Erzeugt einen neuen API-Key im neuen Format. Gibt den Klartext zurück (einmalig).
+
+    User-Keys werden an die unveränderliche Benutzer-ID gebunden. Sonderrollen- und
+    Legacy-Keys ohne passende ID bleiben für die alte Tuple-Auth kompatibel, werden
+    von der strikten Principal-Auth jedoch abgewiesen.
+    """
+    if user_id is None:
+        from hydrahive.api.middleware.users import get_by_username
+        user = get_by_username(username)
+        user_id = user["user_id"] if user else None
     key_id = secrets.token_hex(8)            # 16 Hex-Zeichen
     random_part = secrets.token_urlsafe(32)  # 43 Zeichen
     plain = f"{PREFIX}{key_id}_{random_part}"
@@ -67,6 +83,7 @@ def create(name: str, username: str, role: str) -> str:
         "name": name,
         "key_hash": key_hash,
         "username": username,
+        "user_id": user_id,
         "role": role,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -90,7 +107,7 @@ def verify(plain: str) -> dict | None:
             return None
         try:
             if bcrypt.checkpw(encoded, entry["key_hash"].encode()):
-                return {"username": entry["username"], "role": entry["role"]}
+                return _verified_identity(entry)
         except (ValueError, KeyError) as exc:
             # Defekter/fehlender Hash-Eintrag — Key gilt als ungültig, aber der
             # Grund darf nicht still verschwinden (Auth-Debugging).
@@ -104,7 +121,7 @@ def verify(plain: str) -> dict | None:
             continue
         try:
             if bcrypt.checkpw(encoded, entry["key_hash"].encode()):
-                return {"username": entry["username"], "role": entry["role"]}
+                return _verified_identity(entry)
         except Exception:
             continue
     return None

--- a/core/src/hydrahive/api/middleware/auth.py
+++ b/core/src/hydrahive/api/middleware/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
@@ -15,12 +16,23 @@ logger = logging.getLogger(__name__)
 _bearer = HTTPBearer(auto_error=False)
 
 
-def create_token(username: str, role: str) -> str:
+@dataclass(frozen=True, slots=True)
+class AuthPrincipal:
+    """A currently existing user resolved through an immutable ID."""
+
+    user_id: str
+    username: str
+    role: str
+
+
+def create_token(username: str, role: str, user_id: str | None = None) -> str:
     payload = {
         "sub": username,
         "role": role,
         "exp": datetime.now(timezone.utc) + timedelta(minutes=settings.jwt_expire_minutes),
     }
+    if user_id:
+        payload["uid"] = user_id
     return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
 
 
@@ -48,6 +60,48 @@ def require_auth(
         return user["username"], user["role"]
     payload = _decode(token)
     return payload["sub"], payload["role"]
+
+
+def require_principal(
+    creds: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)],
+) -> AuthPrincipal:
+    """Resolve an authenticated credential against the current user store.
+
+    Unlike ``require_auth``, this rejects legacy credentials without an immutable
+    user ID as well as credentials for deleted/recreated or renamed users. New
+    user-owned resources should depend on this function.
+    """
+    if not creds:
+        raise coded(status.HTTP_401_UNAUTHORIZED, "not_authenticated")
+
+    token = creds.credentials
+    credential: dict
+    if token.startswith("hhk_"):
+        from hydrahive.api.middleware.api_keys import verify as verify_key
+        credential = verify_key(token) or {}
+        user_id = credential.get("user_id")
+    else:
+        credential = _decode(token)
+        user_id = credential.get("uid")
+
+    if not isinstance(user_id, str) or not user_id:
+        raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
+
+    from hydrahive.api.middleware.users import get_by_id
+    current = get_by_id(user_id)
+    if not current or current["username"] != credential.get("sub", credential.get("username")):
+        raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
+
+    # API keys are explicit credential grants. A role change invalidates them;
+    # JWTs instead receive the user's current role immediately.
+    if token.startswith("hhk_") and current["role"] != credential.get("role"):
+        raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
+
+    return AuthPrincipal(
+        user_id=current["user_id"],
+        username=current["username"],
+        role=current["role"],
+    )
 
 
 def require_admin(

--- a/core/src/hydrahive/api/middleware/users.py
+++ b/core/src/hydrahive/api/middleware/users.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import logging
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import bcrypt
 
@@ -12,26 +16,65 @@ from hydrahive.settings import settings
 logger = logging.getLogger(__name__)
 
 # User-Struktur:
-# {"username": {"password_hash": "...", "role": "admin|user"}}
+# {"username": {"user_id": "uuid", "password_hash": "...", "role": "admin|user"}}
 # password_hash kann bcrypt ($2b$...) oder Legacy-SHA256 (64 hex chars) sein.
-# Legacy-Hashes werden beim nächsten erfolgreichen Login transparent auf bcrypt
-# migriert (lazy re-hash).
+# Fehlende user_id und Legacy-Hashes werden transparent migriert.
 
 
-def _load() -> dict:
+def _read_unlocked() -> dict:
     path: Path = settings.users_config
     if not path.exists():
         return {}
     return json.loads(path.read_text())
 
 
-def _save(users: dict) -> None:
-    """Atomic write — verhindert truncated users.json bei parallelem
-    Login + Hash-Migration (Race-Condition vor Fix war beobachtbar)."""
+def _save_unlocked(users: dict) -> None:
+    """Atomic write while the caller holds the cross-process users lock."""
     settings.users_config.parent.mkdir(parents=True, exist_ok=True)
     tmp = settings.users_config.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(users, indent=2))
     tmp.replace(settings.users_config)
+
+
+def _migrate_user_ids(users: dict) -> bool:
+    changed = False
+    for username, user in users.items():
+        if not user.get("user_id"):
+            # Deterministic only for one-time legacy migration: parallel workers
+            # must not mint competing IDs for the same pre-migration record.
+            legacy_key = f"hydrahive-user:{username}:{user.get('password_hash', '')}"
+            user["user_id"] = str(uuid5(NAMESPACE_URL, legacy_key))
+            changed = True
+    return changed
+
+
+@contextmanager
+def _locked_users() -> Iterator[dict]:
+    """Serialize reads that may migrate and every users.json mutation."""
+    path: Path = settings.users_config
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        users = _read_unlocked()
+        migrated = _migrate_user_ids(users)
+        before = json.dumps(users, sort_keys=True)
+        try:
+            yield users
+        except Exception:
+            raise
+        else:
+            if migrated or json.dumps(users, sort_keys=True) != before:
+                _save_unlocked(users)
+                if migrated:
+                    logger.info("Bestehende Benutzer um stabile user_id ergänzt")
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load() -> dict:
+    with _locked_users() as users:
+        return users
 
 
 def _hash(password: str) -> str:
@@ -52,74 +95,103 @@ def _verify_hash(password: str, stored: str) -> bool:
 
 
 def verify(username: str, password: str) -> dict | None:
-    """Returns user dict {username, role} or None if invalid.
+    """Returns public user data or None and lazily migrates legacy hashes."""
+    with _locked_users() as users:
+        user = users.get(username)
+        if not user:
+            return None
+        stored = user["password_hash"]
+        if not _verify_hash(password, stored):
+            return None
+        if not _is_bcrypt(stored):
+            user["password_hash"] = _hash(password)
+            logger.info("User '%s' Hash auf bcrypt migriert", username)
+        return {"user_id": user["user_id"], "username": username, "role": user["role"]}
 
-    Migrates legacy SHA256 hashes to bcrypt on successful login.
+
+def create(username: str, password: str, role: str = "user") -> str:
+    """Creates a new user and returns its immutable ID.
+
+    Raises ValueError if the username already exists.
     """
-    users = _load()
-    user = users.get(username)
-    if not user:
-        return None
-    stored = user["password_hash"]
-    if not _verify_hash(password, stored):
-        return None
-    if not _is_bcrypt(stored):
-        users[username]["password_hash"] = _hash(password)
-        _save(users)
-        logger.info("User '%s' Hash auf bcrypt migriert", username)
-    return {"username": username, "role": user["role"]}
-
-
-def create(username: str, password: str, role: str = "user") -> None:
-    """Creates a new user. Raises ValueError if username exists."""
-    users = _load()
-    if username in users:
-        raise ValueError(f"User '{username}' existiert bereits")
-    users[username] = {"password_hash": _hash(password), "role": role}
-    _save(users)
-    logger.info("User '%s' angelegt (role=%s)", username, role)
+    user_id = str(uuid4())
+    password_hash = _hash(password)
+    with _locked_users() as users:
+        if username in users:
+            raise ValueError(f"User '{username}' existiert bereits")
+        users[username] = {
+            "user_id": user_id,
+            "password_hash": password_hash,
+            "role": role,
+        }
+    logger.info("User '%s' angelegt (role=%s, user_id=%s)", username, role, user_id)
+    return user_id
 
 
 def update_password(username: str, new_password: str) -> None:
-    users = _load()
-    if username not in users:
-        raise ValueError(f"User '{username}' nicht gefunden")
-    users[username]["password_hash"] = _hash(new_password)
-    _save(users)
+    password_hash = _hash(new_password)
+    with _locked_users() as users:
+        if username not in users:
+            raise ValueError(f"User '{username}' nicht gefunden")
+        users[username]["password_hash"] = password_hash
 
 
 def update_role(username: str, role: str) -> None:
     if role not in ("admin", "user"):
         raise ValueError(f"Ungültige Rolle: {role}")
-    users = _load()
-    if username not in users:
-        raise ValueError(f"User '{username}' nicht gefunden")
-    if users[username]["role"] == "admin" and role != "admin":
-        admins = [u for u, v in users.items() if v["role"] == "admin"]
-        if len(admins) <= 1:
-            raise ValueError("last_admin")
-    users[username]["role"] = role
-    _save(users)
+    with _locked_users() as users:
+        if username not in users:
+            raise ValueError(f"User '{username}' nicht gefunden")
+        if users[username]["role"] == "admin" and role != "admin":
+            admins = [u for u, value in users.items() if value["role"] == "admin"]
+            if len(admins) <= 1:
+                raise ValueError("last_admin")
+        users[username]["role"] = role
     logger.info("User '%s' Rolle auf '%s' geändert", username, role)
 
 
 def delete(username: str) -> None:
-    users = _load()
-    users.pop(username, None)
-    _save(users)
+    with _locked_users() as users:
+        users.pop(username, None)
+
+
+def get_by_username(username: str) -> dict | None:
+    """Returns one public user record without exposing the user list."""
+    with _locked_users() as users:
+        user = users.get(username)
+        if not user:
+            return None
+        return {"user_id": user["user_id"], "username": username, "role": user["role"]}
+
+
+def get_by_id(user_id: str) -> dict | None:
+    """Returns one public user record for an immutable ID."""
+    with _locked_users() as users:
+        for username, user in users.items():
+            if user["user_id"] == user_id:
+                return {"user_id": user_id, "username": username, "role": user["role"]}
+    return None
 
 
 def list_users() -> list[dict]:
-    return [
-        {"username": k, "role": v["role"]}
-        for k, v in _load().items()
-    ]
+    with _locked_users() as users:
+        return [
+            {"user_id": value["user_id"], "username": username, "role": value["role"]}
+            for username, value in users.items()
+        ]
 
 
 def ensure_admin(username: str, password: str) -> bool:
-    """Creates admin user if no users exist yet. Returns True if a new user was created."""
-    if not _load():
-        create(username, password, role="admin")
-        logger.info("Admin '%s' beim ersten Start angelegt", username)
-        return True
-    return False
+    """Creates admin user if no users exist yet. Returns whether it was created."""
+    user_id = str(uuid4())
+    password_hash = _hash(password)
+    with _locked_users() as users:
+        if users:
+            return False
+        users[username] = {
+            "user_id": user_id,
+            "password_hash": password_hash,
+            "role": "admin",
+        }
+    logger.info("Admin '%s' beim ersten Start angelegt", username)
+    return True

--- a/core/src/hydrahive/api/routes/auth.py
+++ b/core/src/hydrahive/api/routes/auth.py
@@ -10,7 +10,7 @@ from hydrahive.api.middleware.client_ip import client_ip
 from hydrahive.api.middleware.api_keys import create as create_key
 from hydrahive.api.middleware.api_keys import delete as delete_key
 from hydrahive.api.middleware.api_keys import list_keys
-from hydrahive.api.middleware.auth import create_token, require_auth
+from hydrahive.api.middleware.auth import AuthPrincipal, create_token, require_auth, require_principal
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api.middleware.users import verify
 
@@ -41,7 +41,7 @@ def login(req: LoginRequest, request: Request) -> LoginResponse:
         lockout.record_failure(req.username, ip)
         raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_credentials")
     lockout.reset(req.username, ip)
-    token = create_token(user["username"], user["role"])
+    token = create_token(user["username"], user["role"], user["user_id"])
     return LoginResponse(access_token=token, username=user["username"], role=user["role"])
 
 
@@ -64,13 +64,17 @@ def get_api_keys(auth: Annotated[tuple[str, str], Depends(require_auth)]) -> lis
 @router.post("/apikeys", status_code=status.HTTP_201_CREATED)
 def create_api_key(
     req: CreateKeyRequest,
-    auth: Annotated[tuple[str, str], Depends(require_auth)],
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
 ) -> dict:
-    username, role = auth
     if not req.name.strip():
         raise coded(status.HTTP_400_BAD_REQUEST, "name_required")
-    plain = create_key(req.name.strip(), username, role)
-    return {"key": plain, "name": req.name.strip(), "username": username}
+    plain = create_key(
+        req.name.strip(),
+        principal.username,
+        principal.role,
+        principal.user_id,
+    )
+    return {"key": plain, "name": req.name.strip(), "username": principal.username}
 
 
 @router.delete("/apikeys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/core/tests/test_api_integration.py
+++ b/core/tests/test_api_integration.py
@@ -23,6 +23,10 @@ def test_login_success(client):
     assert data["username"] == "testuser"
     assert data["role"] == "user"
 
+    from hydrahive.api.middleware.auth import _decode
+    payload = _decode(data["access_token"])
+    assert payload["uid"]
+
 
 def test_login_wrong_password(client):
     """POST /api/auth/login mit falschem Passwort → 401."""
@@ -47,6 +51,29 @@ def test_me_with_valid_token(client, auth_headers):
     data = response.json()
     assert data["username"] == "testuser"
     assert data["role"] == "user"
+
+
+def test_create_api_key_requires_current_stable_principal(
+    client, tmp_path, monkeypatch,
+):
+    from hydrahive.api.middleware import users
+    from hydrahive.api.middleware.auth import create_token
+    from hydrahive.settings import settings
+
+    monkeypatch.setattr(settings, "users_config", tmp_path / "users.json", raising=False)
+    old_id = users.create("reused", "first-password")
+    stale_token = create_token("reused", "user", old_id)
+    users.delete("reused")
+    users.create("reused", "second-password")
+
+    response = client.post(
+        "/api/auth/apikeys",
+        json={"name": "must-not-be-created"},
+        headers={"Authorization": f"Bearer {stale_token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "invalid_token"
 
 
 # ============================================================================

--- a/core/tests/test_auth.py
+++ b/core/tests/test_auth.py
@@ -18,6 +18,7 @@ from hydrahive.api.middleware.auth import (
     get_current_user_optional,
     require_admin,
     require_auth,
+    require_principal,
 )
 from hydrahive.settings import settings
 
@@ -51,6 +52,11 @@ def test_gueltiges_token_dekodiert_korrekt():
     assert payload["sub"] == "alice"
     assert payload["role"] == "user"
     assert "exp" in payload
+
+
+def test_neues_token_enthaelt_stabile_user_id():
+    token = create_token("alice", "user", "stable-123")
+    assert _decode(token)["uid"] == "stable-123"
 
 
 def test_falscher_secret_wirft_401():
@@ -97,6 +103,106 @@ def test_require_auth_mit_gueltigem_token_gibt_username_und_rolle():
     username, role = require_auth(_creds(token))
     assert username == "clara"
     assert role == "editor"
+
+
+# ---------------------------------------------------------------------------
+# require_principal
+# ---------------------------------------------------------------------------
+
+
+def test_require_principal_nutzt_stabile_id_und_aktuelle_rolle(monkeypatch):
+    from hydrahive.api.middleware import users
+
+    monkeypatch.setattr(
+        users,
+        "get_by_id",
+        lambda user_id: {
+            "user_id": user_id,
+            "username": "clara",
+            "role": "admin",
+        },
+    )
+    token = create_token("clara", "user", "stable-123")
+
+    principal = require_principal(_creds(token))
+
+    assert principal.user_id == "stable-123"
+    assert principal.username == "clara"
+    assert principal.role == "admin"
+
+
+def test_require_principal_lehnt_legacy_token_ohne_user_id_ab():
+    token = create_token("clara", "user")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(_creds(token))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["code"] == "invalid_token"
+
+
+def test_require_principal_lehnt_geloeschten_user_ab(monkeypatch):
+    from hydrahive.api.middleware import users
+
+    monkeypatch.setattr(users, "get_by_id", lambda _user_id: None)
+    token = create_token("clara", "user", "deleted-123")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(_creds(token))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail["code"] == "invalid_token"
+
+
+def test_require_principal_lehnt_neuangelegten_user_mit_gleichem_namen_ab(monkeypatch):
+    from hydrahive.api.middleware import users
+
+    monkeypatch.setattr(users, "get_by_id", lambda _user_id: None)
+    old_token = create_token("clara", "user", "old-user-id")
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(_creds(old_token))
+
+    assert exc_info.value.status_code == 401
+
+
+def test_require_principal_akzeptiert_id_gebundenen_api_key(monkeypatch):
+    from hydrahive.api.middleware import api_keys, users
+
+    monkeypatch.setattr(
+        api_keys,
+        "verify",
+        lambda _token: {"user_id": "stable-123", "username": "clara", "role": "user"},
+    )
+    monkeypatch.setattr(
+        users,
+        "get_by_id",
+        lambda user_id: {"user_id": user_id, "username": "clara", "role": "user"},
+    )
+
+    principal = require_principal(_creds("hhk_test"))
+
+    assert principal.user_id == "stable-123"
+
+
+def test_require_principal_lehnt_api_key_nach_rollenaenderung_ab(monkeypatch):
+    from hydrahive.api.middleware import api_keys, users
+
+    monkeypatch.setattr(
+        api_keys,
+        "verify",
+        lambda _token: {"user_id": "stable-123", "username": "clara", "role": "admin"},
+    )
+    monkeypatch.setattr(
+        users,
+        "get_by_id",
+        lambda user_id: {"user_id": user_id, "username": "clara", "role": "user"},
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        require_principal(_creds("hhk_test"))
+
+    assert exc_info.value.status_code == 401
 
 
 # ---------------------------------------------------------------------------

--- a/core/tests/test_user_identities.py
+++ b/core/tests/test_user_identities.py
@@ -1,0 +1,60 @@
+"""Regression tests for immutable Core user identities."""
+from __future__ import annotations
+
+import json
+
+from hydrahive.api.middleware import users
+from hydrahive.settings import settings
+
+
+def _legacy_users_file(tmp_path, monkeypatch):
+    path = tmp_path / "users.json"
+    path.write_text(json.dumps({
+        "alice": {"password_hash": "legacy-hash", "role": "user"},
+    }))
+    monkeypatch.setattr(settings, "users_config", path, raising=False)
+    return path
+
+
+def test_legacy_user_receives_persisted_stable_id(tmp_path, monkeypatch):
+    path = _legacy_users_file(tmp_path, monkeypatch)
+
+    first = users.get_by_username("alice")
+    second = users.get_by_username("alice")
+    stored = json.loads(path.read_text())
+
+    assert first is not None
+    assert first["user_id"] == second["user_id"]
+    assert stored["alice"]["user_id"] == first["user_id"]
+    assert "password_hash" not in first
+
+
+def test_delete_and_recreate_same_username_gets_new_id(tmp_path, monkeypatch):
+    path = tmp_path / "users.json"
+    path.write_text("{}")
+    monkeypatch.setattr(settings, "users_config", path, raising=False)
+
+    old_id = users.create("alice", "first-password")
+    users.delete("alice")
+    new_id = users.create("alice", "second-password")
+
+    assert old_id != new_id
+    assert users.get_by_id(old_id) is None
+    assert users.get_by_id(new_id) == {
+        "user_id": new_id,
+        "username": "alice",
+        "role": "user",
+    }
+
+
+def test_list_users_includes_id_without_password_hash(tmp_path, monkeypatch):
+    _legacy_users_file(tmp_path, monkeypatch)
+
+    result = users.list_users()
+
+    assert result == [{
+        "user_id": result[0]["user_id"],
+        "username": "alice",
+        "role": "user",
+    }]
+    assert "password_hash" not in result[0]


### PR DESCRIPTION
## Zweck
Voraussetzung für das Haushaltsbuch V1: benutzereigene Daten werden an eine unveränderliche Core-Benutzer-ID statt an wiederverwendbare Benutzernamen gebunden.

## Änderungen
- rückwärtskompatible `user_id`-Migration für bestehende `users.json`
- Cross-Process-Lock für Migration und alle User-Read-Modify-Write-Operationen
- JWTs und neue API-Keys tragen die stabile ID
- neuer strikter `AuthPrincipal` / `require_principal` mit aktueller User- und Rollenprüfung
- API-Key-Erstellung erfordert einen aktuellen stabilen Principal
- Legacy-`require_auth` bleibt für bestehende Endpunkte kompatibel
- Regressionstests gegen Löschen/Neuanlegen desselben Benutzernamens

## Verifikation
- `PYTHONPATH=src pytest -q`: **1741 passed**
- gezielter Ruff-Check: **grün**
- Security-Re-Review: **keine verbleibenden Blocker/High Findings**

## Abgrenzung
Die globale Migration bestehender `require_admin`-Endpunkte auf aktuelle Principals ist ein separater Security-Task, da vorher die Federation-Sonderrolle `projektx` entkoppelt werden muss.