### PR TITLE
feat(compute): add cluster node foundation

### DIFF
--- a/core/src/hydrahive/api/routes/_container_helpers.py
+++ b/core/src/hydrahive/api/routes/_container_helpers.py
@@ -5,7 +5,9 @@ from pydantic import BaseModel, Field
 
 from hydrahive.api.middleware.errors import coded
 from hydrahive.containers import db as cdb
-from hydrahive.containers.models import MAX_CPU, MAX_RAM_MB, MIN_CPU, MIN_RAM_MB
+from hydrahive.containers import incus_client as incus
+from hydrahive.containers import lifecycle
+from hydrahive.containers.models import MAX_CPU, MAX_RAM_MB, MIN_CPU, MIN_RAM_MB, Container
 
 
 class ContainerCreate(BaseModel):
@@ -15,6 +17,7 @@ class ContainerCreate(BaseModel):
     cpu: int | None = Field(default=None, ge=MIN_CPU, le=MAX_CPU)
     ram_mb: int | None = Field(default=None, ge=MIN_RAM_MB, le=MAX_RAM_MB)
     network_mode: str = "bridged"
+    node_id: str = Field(default="local", min_length=1, max_length=128)
 
 
 class ContainerUpdate(BaseModel):
@@ -30,7 +33,14 @@ def is_admin(role: str) -> bool:
     return role == "admin"
 
 
-def container_or_404(container_id: str, owner: str, role: str):
+def ensure_local_container(container: Container) -> None:
+    try:
+        lifecycle.ensure_local(container)
+    except incus.IncusError as exc:
+        raise coded(status.HTTP_400_BAD_REQUEST, exc.code, **exc.params)
+
+
+def container_or_404(container_id: str, owner: str, role: str) -> Container:
     c = cdb.get(container_id)
     if not c:
         raise coded(status.HTTP_404_NOT_FOUND, "container_not_found")

--- a/core/src/hydrahive/api/routes/_vm_lifecycle_schemas.py
+++ b/core/src/hydrahive/api/routes/_vm_lifecycle_schemas.py
@@ -19,6 +19,7 @@ class VMCreate(BaseModel):
     disk_interface: str = "virtio"
     machine_type: str = "q35"
     network_device: str = "virtio-net-pci"
+    node_id: str = Field(default="local", min_length=1, max_length=128)
 
 
 class VMUpdate(BaseModel):

--- a/core/src/hydrahive/api/routes/_vms_helpers.py
+++ b/core/src/hydrahive/api/routes/_vms_helpers.py
@@ -2,6 +2,7 @@
 
 Auth-Check + 404/403-Resolution + Serialisierung + Create-Input-Validation.
 """
+
 from __future__ import annotations
 
 from dataclasses import asdict
@@ -13,13 +14,22 @@ from hydrahive.api.middleware.errors import coded
 from hydrahive.vms import db as vmdb
 from hydrahive.vms import import_job as vmimport
 from hydrahive.vms import iso as vmiso
+from hydrahive.vms import lifecycle
+from hydrahive.vms.models import VM
 
 
 def is_admin(role: str) -> bool:
     return role == "admin"
 
 
-def vm_or_404(vm_id: str, owner: str, role: str):
+def ensure_local_vm(vm: VM) -> None:
+    try:
+        lifecycle.ensure_local(vm)
+    except lifecycle.VMLifecycleError as exc:
+        raise coded(status.HTTP_400_BAD_REQUEST, exc.code, **exc.params)
+
+
+def vm_or_404(vm_id: str, owner: str, role: str) -> VM:
     vm = vmdb.get_vm(vm_id)
     if not vm:
         raise coded(status.HTTP_404_NOT_FOUND, "vm_not_found")
@@ -28,7 +38,7 @@ def vm_or_404(vm_id: str, owner: str, role: str):
     return vm
 
 
-def serialize(vm) -> dict:
+def serialize(vm: VM) -> dict:
     return asdict(vm)
 
 

--- a/core/src/hydrahive/api/routes/container_console.py
+++ b/core/src/hydrahive/api/routes/container_console.py
@@ -8,6 +8,7 @@ Nachrichten-Format:
 Auth via JWT im Query-Param `?token=...` (WS unterstützt keine
 Authorization-Header in Browsern).
 """
+
 from __future__ import annotations
 
 import json
@@ -45,6 +46,9 @@ async def container_console(ws: WebSocket, container_id: str, token: str | None 
     c = cdb.get(container_id)
     if not c or (c.owner != user and role != "admin"):
         await ws.close(code=4404)
+        return
+    if c.node_id != "local":
+        await ws.close(code=4409, reason="container_not_local")
         return
     if c.actual_state != "running":
         await ws.close(code=4409)

--- a/core/src/hydrahive/api/routes/containers_crud.py
+++ b/core/src/hydrahive/api/routes/containers_crud.py
@@ -1,4 +1,5 @@
 """Container CRUD routes (list / create / get / update / delete)."""
+
 from __future__ import annotations
 
 import logging
@@ -11,7 +12,10 @@ from fastapi import APIRouter, Depends, status
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api.routes._container_helpers import (
-    ContainerCreate, ContainerUpdate, container_or_404, is_admin,
+    ContainerCreate,
+    ContainerUpdate,
+    container_or_404,
+    is_admin,
 )
 from hydrahive.containers import db as cdb
 from hydrahive.containers import incus_client as incus
@@ -40,6 +44,8 @@ async def create_container(
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     user, _ = auth
+    if body.node_id != "local":
+        raise coded(status.HTTP_400_BAD_REQUEST, "container_remote_execution_not_supported")
     if not re.match(NAME_RE, body.name):
         raise coded(status.HTTP_400_BAD_REQUEST, "container_name_invalid")
     if body.network_mode not in ("bridged", "isolated"):
@@ -56,9 +62,14 @@ async def create_container(
         raise coded(status.HTTP_503_SERVICE_UNAVAILABLE, "incus_missing")
 
     c = cdb.create(
-        owner=user, name=body.name, description=body.description,
-        image=image, cpu=body.cpu, ram_mb=body.ram_mb,
+        owner=user,
+        name=body.name,
+        description=body.description,
+        image=image,
+        cpu=body.cpu,
+        ram_mb=body.ram_mb,
         network_mode=body.network_mode,
+        node_id=body.node_id,
     )
     try:
         await lifecycle.create_and_start(c.container_id)
@@ -84,8 +95,7 @@ def update_container(
 ) -> dict:
     c = container_or_404(container_id, *auth)
     if c.actual_state not in ("stopped", "created", "error"):
-        raise coded(status.HTTP_400_BAD_REQUEST, "container_must_be_stopped",
-                    state=c.actual_state)
+        raise coded(status.HTTP_400_BAD_REQUEST, "container_must_be_stopped", state=c.actual_state)
     if req.name and req.name != c.name and not re.match(NAME_RE, req.name):
         raise coded(status.HTTP_400_BAD_REQUEST, "container_name_invalid", name=req.name)
     if req.name and req.name != c.name and cdb.name_taken(req.name, exclude_id=container_id):

--- a/core/src/hydrahive/api/routes/containers_ops.py
+++ b/core/src/hydrahive/api/routes/containers_ops.py
@@ -1,4 +1,5 @@
 """Container lifecycle + inspection routes (start / stop / restart / log / config / info)."""
+
 from __future__ import annotations
 
 import logging
@@ -9,7 +10,7 @@ from fastapi import APIRouter, Depends
 
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._container_helpers import container_or_404
+from hydrahive.api.routes._container_helpers import container_or_404, ensure_local_container
 from hydrahive.containers import db as cdb
 from hydrahive.containers import incus_client as incus
 from hydrahive.containers import lifecycle
@@ -64,6 +65,7 @@ async def container_log(
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     c = container_or_404(container_id, *auth)
+    ensure_local_container(c)
     return {"text": await incus.show_log(c.name)}
 
 
@@ -73,6 +75,7 @@ async def container_config(
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     c = container_or_404(container_id, *auth)
+    ensure_local_container(c)
     return {"text": await incus.show_config(c.name)}
 
 
@@ -83,6 +86,7 @@ async def container_info(
 ) -> dict:
     """Live info from incus: status, CPU/memory, IP."""
     c = container_or_404(container_id, *auth)
+    ensure_local_container(c)
     info = await incus.info(c.name)
     if not info:
         return {"alive": False}

--- a/core/src/hydrahive/api/routes/vms_lifecycle.py
+++ b/core/src/hydrahive/api/routes/vms_lifecycle.py
@@ -2,6 +2,7 @@
 
 Per-User-Owner: Liste/Detail nur eigene VMs (außer Admin).
 """
+
 from __future__ import annotations
 
 import logging
@@ -16,14 +17,21 @@ from hydrahive.api.middleware.errors import coded
 from hydrahive.settings import settings
 from hydrahive.api.routes._vm_lifecycle_schemas import VMCreate, VMUpdate
 from hydrahive.api.routes._vms_helpers import (
-    is_admin, resolve_import_job, resolve_iso, serialize, vm_or_404,
+    is_admin,
+    resolve_import_job,
+    resolve_iso,
+    serialize,
+    vm_or_404,
 )
 from hydrahive.vms import db as vmdb
 from hydrahive.vms import disk as vmdisk
 from hydrahive.vms import import_job as vmimport
 from hydrahive.vms import lifecycle
 from hydrahive.vms.models import (
-    DISK_INTERFACES, MACHINE_TYPES, NAME_RE, NETWORK_DEVICES,
+    DISK_INTERFACES,
+    MACHINE_TYPES,
+    NAME_RE,
+    NETWORK_DEVICES,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,19 +51,18 @@ async def create_vm(
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     user, role = auth
+    if body.node_id != "local":
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_remote_execution_not_supported")
     if not re.match(NAME_RE, body.name):
         raise coded(status.HTTP_400_BAD_REQUEST, "vm_name_invalid")
     if body.network_mode not in ("bridged", "isolated"):
         raise coded(status.HTTP_400_BAD_REQUEST, "vm_network_mode_invalid")
     if body.disk_interface not in DISK_INTERFACES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_disk_interface_invalid",
-                    value=body.disk_interface)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_disk_interface_invalid", value=body.disk_interface)
     if body.machine_type not in MACHINE_TYPES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_machine_type_invalid",
-                    value=body.machine_type)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_machine_type_invalid", value=body.machine_type)
     if body.network_device not in NETWORK_DEVICES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_network_device_invalid",
-                    value=body.network_device)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_network_device_invalid", value=body.network_device)
     if vmdb.name_taken(user, body.name):
         raise coded(status.HTTP_409_CONFLICT, "vm_name_taken")
 
@@ -63,11 +70,19 @@ async def create_vm(
     import_qcow2 = resolve_import_job(body.import_job_id, user, role)
 
     vm = vmdb.create_vm(
-        owner=user, name=body.name, description=body.description,
-        cpu=body.cpu, ram_mb=body.ram_mb, disk_gb=body.disk_gb,
-        iso_filename=iso_safe, network_mode=body.network_mode,
-        qcow2_path="", disk_interface=body.disk_interface,
-        machine_type=body.machine_type, network_device=body.network_device,
+        owner=user,
+        name=body.name,
+        description=body.description,
+        cpu=body.cpu,
+        ram_mb=body.ram_mb,
+        disk_gb=body.disk_gb,
+        iso_filename=iso_safe,
+        network_mode=body.network_mode,
+        qcow2_path="",
+        disk_interface=body.disk_interface,
+        machine_type=body.machine_type,
+        network_device=body.network_device,
+        node_id=body.node_id,
     )
     try:
         if import_qcow2:
@@ -83,12 +98,11 @@ async def create_vm(
         raise coded(status.HTTP_500_INTERNAL_SERVER_ERROR, e.code, **e.params)
     except OSError as e:
         vmdb.delete_vm(vm.vm_id)
-        raise coded(status.HTTP_500_INTERNAL_SERVER_ERROR, "import_move_failed",
-                    error=str(e))
+        raise coded(status.HTTP_500_INTERNAL_SERVER_ERROR, "import_move_failed", error=str(e))
     from hydrahive.db.connection import db as _db
+
     with _db() as conn:
-        conn.execute("UPDATE vms SET qcow2_path = ? WHERE vm_id = ?",
-                     (str(path), vm.vm_id))
+        conn.execute("UPDATE vms SET qcow2_path = ? WHERE vm_id = ?", (str(path), vm.vm_id))
     return serialize(vmdb.get_vm(vm.vm_id))
 
 
@@ -105,25 +119,26 @@ async def update_vm(
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     vm = vm_or_404(vm_id, *auth)
+    try:
+        lifecycle.ensure_local(vm)
+    except lifecycle.VMLifecycleError as e:
+        raise coded(status.HTTP_400_BAD_REQUEST, e.code, **e.params)
     if vm.actual_state not in ("stopped", "created", "error"):
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_must_be_stopped",
-                    state=vm.actual_state)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_must_be_stopped", state=vm.actual_state)
     if req.name and req.name != vm.name and not re.match(NAME_RE, req.name):
         raise coded(status.HTTP_400_BAD_REQUEST, "vm_name_invalid", name=req.name)
     if req.name and req.name != vm.name and vmdb.name_taken(vm.owner, req.name, exclude_id=vm_id):
         raise coded(status.HTTP_409_CONFLICT, "vm_name_taken", name=req.name)
     if req.disk_gb is not None and req.disk_gb < vm.disk_gb:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_disk_shrink_not_supported",
-                    current=vm.disk_gb, requested=req.disk_gb)
+        raise coded(
+            status.HTTP_400_BAD_REQUEST, "vm_disk_shrink_not_supported", current=vm.disk_gb, requested=req.disk_gb
+        )
     if req.disk_interface is not None and req.disk_interface not in DISK_INTERFACES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_disk_interface_invalid",
-                    value=req.disk_interface)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_disk_interface_invalid", value=req.disk_interface)
     if req.machine_type is not None and req.machine_type not in MACHINE_TYPES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_machine_type_invalid",
-                    value=req.machine_type)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_machine_type_invalid", value=req.machine_type)
     if req.network_device is not None and req.network_device not in NETWORK_DEVICES:
-        raise coded(status.HTTP_400_BAD_REQUEST, "vm_network_device_invalid",
-                    value=req.network_device)
+        raise coded(status.HTTP_400_BAD_REQUEST, "vm_network_device_invalid", value=req.network_device)
 
     iso_kw: dict = {}
     if req.clear_iso:
@@ -161,9 +176,11 @@ async def update_vm(
 @router.delete("/{vm_id}", status_code=204)
 async def delete_vm(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> None:
     vm = vm_or_404(vm_id, *auth)
+    try:
+        lifecycle.ensure_local(vm)
+    except lifecycle.VMLifecycleError as e:
+        raise coded(status.HTTP_400_BAD_REQUEST, e.code, **e.params)
     if vm.actual_state in ("running", "starting"):
         await lifecycle.shutdown(vm_id, hard=True)
     vmdisk.remove_qcow2(vm_id)
     vmdb.delete_vm(vm_id)
-
-

--- a/core/src/hydrahive/api/routes/vms_ops.py
+++ b/core/src/hydrahive/api/routes/vms_ops.py
@@ -1,4 +1,5 @@
 """VM runtime operation routes (start / stop / poweroff / stats / log)."""
+
 from __future__ import annotations
 
 import logging
@@ -8,7 +9,7 @@ from fastapi import APIRouter, Depends
 
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._vms_helpers import serialize, vm_or_404
+from hydrahive.api.routes._vms_helpers import ensure_local_vm, serialize, vm_or_404
 from hydrahive.settings import settings
 from hydrahive.vms import db as vmdb
 from hydrahive.vms import lifecycle
@@ -31,30 +32,39 @@ async def start_vm(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_
 
 @router.post("/{vm_id}/stop")
 async def stop_vm(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
-    vm_or_404(vm_id, *auth)
-    await lifecycle.shutdown(vm_id, hard=False)
+    ensure_local_vm(vm_or_404(vm_id, *auth))
+    try:
+        await lifecycle.shutdown(vm_id, hard=False)
+    except lifecycle.VMLifecycleError as e:
+        raise coded(status.HTTP_400_BAD_REQUEST, e.code, **e.params)
     return serialize(vmdb.get_vm(vm_id))
 
 
 @router.post("/{vm_id}/poweroff")
 async def poweroff_vm(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
-    vm_or_404(vm_id, *auth)
-    await lifecycle.shutdown(vm_id, hard=True)
+    ensure_local_vm(vm_or_404(vm_id, *auth))
+    try:
+        await lifecycle.shutdown(vm_id, hard=True)
+    except lifecycle.VMLifecycleError as e:
+        raise coded(status.HTTP_400_BAD_REQUEST, e.code, **e.params)
     return serialize(vmdb.get_vm(vm_id))
 
 
 @router.get("/{vm_id}/stats")
 def vm_stats(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     return vmstats.read_stats(vm.vm_id, vm.pid)
 
 
 @router.get("/{vm_id}/log")
 def vm_log(
-    vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)],
+    vm_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
     tail: int = 200,
 ) -> dict:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     log_path = settings.vms_logs_dir / f"{vm.vm_id}.log"
     if not log_path.exists():
         return {"lines": [], "exists": False}

--- a/core/src/hydrahive/api/routes/vms_passthrough.py
+++ b/core/src/hydrahive/api/routes/vms_passthrough.py
@@ -1,4 +1,5 @@
 """Passthrough-Disk-Routes — nur Admins."""
+
 from __future__ import annotations
 
 import logging
@@ -9,7 +10,7 @@ from pydantic import BaseModel
 
 from hydrahive.api.middleware.auth import require_admin, require_auth
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._vms_helpers import vm_or_404
+from hydrahive.api.routes._vms_helpers import ensure_local_vm, vm_or_404
 from hydrahive.vms import passthrough as pt
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,7 @@ async def add_passthrough_disk(
 ) -> dict:
     require_admin(auth)
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     if vm.actual_state not in ("stopped", "created", "error"):
         raise coded(status.HTTP_409_CONFLICT, "vm_must_be_stopped")
     try:
@@ -86,8 +88,7 @@ async def add_passthrough_disk(
     return _serialize_disk(disk)
 
 
-@router.delete("/{vm_id}/passthrough-disks/{passthrough_id}",
-               status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/{vm_id}/passthrough-disks/{passthrough_id}", status_code=status.HTTP_204_NO_CONTENT)
 def remove_passthrough_disk(
     vm_id: str,
     passthrough_id: str,
@@ -95,6 +96,7 @@ def remove_passthrough_disk(
 ) -> None:
     require_admin(auth)
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     if vm.actual_state not in ("stopped", "created", "error"):
         raise coded(status.HTTP_409_CONFLICT, "vm_must_be_stopped")
     try:

--- a/core/src/hydrahive/api/routes/vms_snapshots.py
+++ b/core/src/hydrahive/api/routes/vms_snapshots.py
@@ -1,4 +1,5 @@
 """VM-Snapshots: list, create, restore, delete (alle offline)."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,7 +10,7 @@ from pydantic import BaseModel, Field
 
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._vms_helpers import vm_or_404
+from hydrahive.api.routes._vms_helpers import ensure_local_vm, vm_or_404
 from hydrahive.vms import snapshots as vmsnap
 
 router = APIRouter(prefix="/api/vms", tags=["vms"])
@@ -28,10 +29,12 @@ def list_snapshots(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_
 
 @router.post("/{vm_id}/snapshots", status_code=status.HTTP_201_CREATED)
 async def create_snapshot(
-    vm_id: str, body: SnapshotCreate,
+    vm_id: str,
+    body: SnapshotCreate,
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     if vm.actual_state != "stopped":
         raise coded(status.HTTP_409_CONFLICT, "snapshot_vm_not_stopped")
     try:
@@ -44,10 +47,12 @@ async def create_snapshot(
 
 @router.post("/{vm_id}/snapshots/{snapshot_id}/restore", status_code=204)
 async def restore_snapshot(
-    vm_id: str, snapshot_id: str,
+    vm_id: str,
+    snapshot_id: str,
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> None:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     if vm.actual_state != "stopped":
         raise coded(status.HTTP_409_CONFLICT, "snapshot_vm_not_stopped")
     snap = vmsnap.db_get(snapshot_id)
@@ -61,10 +66,12 @@ async def restore_snapshot(
 
 @router.delete("/{vm_id}/snapshots/{snapshot_id}", status_code=204)
 async def delete_snapshot(
-    vm_id: str, snapshot_id: str,
+    vm_id: str,
+    snapshot_id: str,
     auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> None:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     snap = vmsnap.db_get(snapshot_id)
     if not snap or snap["vm_id"] != vm_id:
         raise coded(status.HTTP_404_NOT_FOUND, "snapshot_not_found")

--- a/core/src/hydrahive/api/routes/vms_vnc.py
+++ b/core/src/hydrahive/api/routes/vms_vnc.py
@@ -2,6 +2,7 @@
 
 websockify ist hinter nginx /vnc-ws/ gemounted (siehe 60-nginx.sh).
 """
+
 from __future__ import annotations
 
 from typing import Annotated
@@ -10,7 +11,7 @@ from fastapi import APIRouter, Depends, status
 
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._vms_helpers import vm_or_404
+from hydrahive.api.routes._vms_helpers import ensure_local_vm, vm_or_404
 
 router = APIRouter(prefix="/api/vms", tags=["vms"])
 
@@ -18,6 +19,7 @@ router = APIRouter(prefix="/api/vms", tags=["vms"])
 @router.get("/{vm_id}/vnc")
 def vnc_info(vm_id: str, auth: Annotated[tuple[str, str], Depends(require_auth)]) -> dict:
     vm = vm_or_404(vm_id, *auth)
+    ensure_local_vm(vm)
     if vm.actual_state != "running" or not vm.vnc_token:
         raise coded(status.HTTP_409_CONFLICT, "vm_not_running")
     return {"token": vm.vnc_token, "ws_path": "/vnc-ws/"}

--- a/core/src/hydrahive/compute/__init__.py
+++ b/core/src/hydrahive/compute/__init__.py
@@ -1,0 +1,1 @@
+"""Compute-cluster persistence foundation."""

--- a/core/src/hydrahive/compute/_node_codec.py
+++ b/core/src/hydrahive/compute/_node_codec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from typing import cast
 
@@ -18,6 +19,9 @@ from hydrahive.compute.models import (
     NodeStatus,
 )
 
+NODE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+CERTIFICATE_FINGERPRINT_RE = re.compile(r"^(?:[0-9A-Fa-f]{64}|(?:[0-9A-Fa-f]{2}:){31}[0-9A-Fa-f]{2})$")
+
 ALLOWED_STATUS_TRANSITIONS: dict[str, frozenset[str]] = {
     "pending": frozenset({"online", "disabled", "revoked"}),
     "online": frozenset({"degraded", "offline", "draining", "disabled", "revoked"}),
@@ -30,10 +34,18 @@ ALLOWED_STATUS_TRANSITIONS: dict[str, frozenset[str]] = {
 
 
 def validate_identity(node_id: str, name: str) -> None:
-    if not node_id or len(node_id) > MAX_NODE_ID_LENGTH:
-        raise ValueError(f"node_id must contain 1-{MAX_NODE_ID_LENGTH} characters")
-    if not name or len(name) > MAX_NODE_NAME_LENGTH:
-        raise ValueError(f"name must contain 1-{MAX_NODE_NAME_LENGTH} characters")
+    if not node_id or len(node_id) > MAX_NODE_ID_LENGTH or NODE_ID_RE.fullmatch(node_id) is None:
+        raise ValueError(f"node_id must contain 1-{MAX_NODE_ID_LENGTH} safe characters")
+    if not name or len(name) > MAX_NODE_NAME_LENGTH or any(not char.isprintable() for char in name):
+        raise ValueError(f"name must contain 1-{MAX_NODE_NAME_LENGTH} printable characters")
+
+
+def normalize_certificate_fingerprint(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if CERTIFICATE_FINGERPRINT_RE.fullmatch(value) is None:
+        raise ValueError("certificate_fingerprint must be a SHA-256 fingerprint")
+    return value.replace(":", "").lower()
 
 
 def validate_kind(kind: str) -> NodeKind:

--- a/core/src/hydrahive/compute/_node_codec.py
+++ b/core/src/hydrahive/compute/_node_codec.py
@@ -1,0 +1,88 @@
+"""Validation and row/JSON conversion for compute-node persistence."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import cast
+
+from hydrahive.compute.models import (
+    MAX_NODE_ID_LENGTH,
+    MAX_NODE_JSON_BYTES,
+    MAX_NODE_NAME_LENGTH,
+    NODE_KINDS,
+    NODE_STATUSES,
+    ComputeNode,
+    JSONObject,
+    NodeKind,
+    NodeStatus,
+)
+
+ALLOWED_STATUS_TRANSITIONS: dict[str, frozenset[str]] = {
+    "pending": frozenset({"online", "disabled", "revoked"}),
+    "online": frozenset({"degraded", "offline", "draining", "disabled", "revoked"}),
+    "degraded": frozenset({"online", "offline", "draining", "disabled", "revoked"}),
+    "offline": frozenset({"online", "degraded", "draining", "disabled", "revoked"}),
+    "draining": frozenset({"online", "offline", "disabled", "revoked"}),
+    "disabled": frozenset({"online", "offline", "revoked"}),
+    "revoked": frozenset(),
+}
+
+
+def validate_identity(node_id: str, name: str) -> None:
+    if not node_id or len(node_id) > MAX_NODE_ID_LENGTH:
+        raise ValueError(f"node_id must contain 1-{MAX_NODE_ID_LENGTH} characters")
+    if not name or len(name) > MAX_NODE_NAME_LENGTH:
+        raise ValueError(f"name must contain 1-{MAX_NODE_NAME_LENGTH} characters")
+
+
+def validate_kind(kind: str) -> NodeKind:
+    if kind not in NODE_KINDS:
+        raise ValueError(f"invalid node kind: {kind}")
+    return cast(NodeKind, kind)
+
+
+def validate_status(status: str) -> NodeStatus:
+    if status not in NODE_STATUSES:
+        raise ValueError(f"invalid node status: {status}")
+    return cast(NodeStatus, status)
+
+
+def dump_json(value: JSONObject, field_name: str) -> str:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a JSON object")
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must contain valid JSON") from exc
+    if len(encoded.encode("utf-8")) > MAX_NODE_JSON_BYTES:
+        raise ValueError(f"{field_name} JSON is too large")
+    return encoded
+
+
+def load_json(value: str, field_name: str) -> JSONObject:
+    decoded = json.loads(value)
+    if not isinstance(decoded, dict):
+        raise ValueError(f"stored {field_name} must be a JSON object")
+    return cast(JSONObject, decoded)
+
+
+def row_to_node(row: sqlite3.Row) -> ComputeNode:
+    return ComputeNode(
+        node_id=row["node_id"],
+        name=row["name"],
+        kind=validate_kind(row["kind"]),
+        status=validate_status(row["status"]),
+        certificate_fingerprint=row["certificate_fingerprint"],
+        protocol_version=row["protocol_version"],
+        agent_version=row["agent_version"],
+        capabilities=load_json(row["capabilities_json"], "capabilities"),
+        resources=load_json(row["resources_json"], "resources"),
+        labels=load_json(row["labels_json"], "labels"),
+        last_seen_at=row["last_seen_at"],
+        approved_at=row["approved_at"],
+        approved_by=row["approved_by"],
+        revoked_at=row["revoked_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/core/src/hydrahive/compute/_node_status.py
+++ b/core/src/hydrahive/compute/_node_status.py
@@ -1,0 +1,87 @@
+"""Atomic trust and health-state transitions for compute nodes."""
+
+from __future__ import annotations
+
+from hydrahive.compute._node_codec import ALLOWED_STATUS_TRANSITIONS, row_to_node, validate_status
+from hydrahive.compute.models import ComputeNode, NodeStatus
+from hydrahive.db._utils import now_iso
+from hydrahive.db.connection import db
+
+LOCAL_NODE_ID = "local"
+
+
+def _read_node(node_id: str) -> ComputeNode | None:
+    with db() as conn:
+        row = conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+    return row_to_node(row) if row else None
+
+
+def approve_node(node_id: str, approved_by: str) -> ComputeNode | None:
+    if node_id == LOCAL_NODE_ID:
+        raise ValueError("local node does not require approval")
+    if not approved_by or len(approved_by) > 128:
+        raise ValueError("approved_by must contain 1-128 characters")
+    timestamp = now_iso()
+    with db(immediate=True) as conn:
+        row = conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return None
+        current = row_to_node(row)
+        if current.status != "pending":
+            raise ValueError("only pending nodes can be approved")
+        if current.certificate_fingerprint is None:
+            raise ValueError("node requires a certificate fingerprint before approval")
+        conn.execute(
+            """UPDATE compute_nodes
+               SET status = 'online', approved_at = ?, approved_by = ?, updated_at = ?
+               WHERE node_id = ? AND status = 'pending'""",
+            (timestamp, approved_by, timestamp, node_id),
+        )
+    return _read_node(node_id)
+
+
+def transition_node_status(node_id: str, status: NodeStatus) -> ComputeNode | None:
+    if node_id == LOCAL_NODE_ID:
+        raise ValueError("local node status is managed by the control plane")
+    validate_status(status)
+    with db(immediate=True) as conn:
+        row = conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return None
+        current = row_to_node(row)
+        if status == current.status:
+            return current
+        if status not in ALLOWED_STATUS_TRANSITIONS[current.status]:
+            raise ValueError(f"invalid node status transition: {current.status} -> {status}")
+        if status == "online" and (
+            current.certificate_fingerprint is None or current.approved_at is None or current.approved_by is None
+        ):
+            raise ValueError("node must be activated through approval before going online")
+        result = conn.execute(
+            """UPDATE compute_nodes SET status = ?, updated_at = ?
+               WHERE node_id = ? AND status = ?""",
+            (status, now_iso(), node_id, current.status),
+        )
+        if result.rowcount != 1:  # pragma: no cover - protected by BEGIN IMMEDIATE
+            raise RuntimeError("compute node status changed concurrently")
+    return _read_node(node_id)
+
+
+def revoke_node(node_id: str) -> ComputeNode | None:
+    if node_id == LOCAL_NODE_ID:
+        raise ValueError("local node cannot be revoked")
+    timestamp = now_iso()
+    with db(immediate=True) as conn:
+        row = conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return None
+        current = row_to_node(row)
+        if current.status != "revoked" and "revoked" not in ALLOWED_STATUS_TRANSITIONS[current.status]:
+            raise ValueError(f"invalid node status transition: {current.status} -> revoked")
+        conn.execute(
+            """UPDATE compute_nodes
+               SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+               WHERE node_id = ? AND status = ?""",
+            ("revoked", timestamp, timestamp, node_id, current.status),
+        )
+    return _read_node(node_id)

--- a/core/src/hydrahive/compute/db.py
+++ b/core/src/hydrahive/compute/db.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from hydrahive.compute._node_codec import (
-    ALLOWED_STATUS_TRANSITIONS,
     dump_json,
+    normalize_certificate_fingerprint,
     row_to_node,
     validate_identity,
     validate_kind,
     validate_status,
 )
+from hydrahive.compute._node_status import approve_node, revoke_node, transition_node_status
 from hydrahive.compute.models import ComputeNode, JSONObject, NodeKind, NodeStatus
 from hydrahive.db._utils import now_iso
 from hydrahive.db.connection import db
@@ -33,10 +34,13 @@ def create_node(
     validate_identity(node_id, name)
     validate_kind(kind)
     validate_status(status)
+    if status != "pending":
+        raise ValueError("new agent nodes must start in pending status")
     if node_id == LOCAL_NODE_ID or kind == "local":
         raise ValueError("local node identity is reserved")
     if protocol_version < 1:
         raise ValueError("protocol_version must be at least 1")
+    certificate_fingerprint = normalize_certificate_fingerprint(certificate_fingerprint)
     capabilities_json = dump_json(capabilities or {}, "capabilities")
     resources_json = dump_json(resources or {}, "resources")
     labels_json = dump_json(labels or {}, "labels")
@@ -89,16 +93,12 @@ def update_node(
     node_id: str,
     *,
     name: str | None = None,
-    status: NodeStatus | None = None,
-    certificate_fingerprint: str | None = None,
     protocol_version: int | None = None,
     agent_version: str | None = None,
     capabilities: JSONObject | None = None,
     resources: JSONObject | None = None,
     labels: JSONObject | None = None,
     last_seen_at: str | None = None,
-    approved_at: str | None = None,
-    approved_by: str | None = None,
 ) -> ComputeNode | None:
     current = get_node(node_id)
     if current is None:
@@ -109,15 +109,6 @@ def update_node(
         validate_identity(node_id, name)
         fields.append("name = ?")
         values.append(name)
-    if status is not None:
-        validate_status(status)
-        if status != current.status and status not in ALLOWED_STATUS_TRANSITIONS[current.status]:
-            raise ValueError(f"invalid node status transition: {current.status} -> {status}")
-        fields.append("status = ?")
-        values.append(status)
-    if certificate_fingerprint is not None:
-        fields.append("certificate_fingerprint = ?")
-        values.append(certificate_fingerprint)
     if protocol_version is not None:
         if protocol_version < 1:
             raise ValueError("protocol_version must be at least 1")
@@ -126,8 +117,6 @@ def update_node(
     for column, value in (
         ("agent_version", agent_version),
         ("last_seen_at", last_seen_at),
-        ("approved_at", approved_at),
-        ("approved_by", approved_by),
     ):
         if value is not None:
             fields.append(f"{column} = ?")
@@ -152,27 +141,17 @@ def update_node(
     return get_node(node_id)
 
 
-def revoke_node(node_id: str) -> ComputeNode | None:
-    if node_id == LOCAL_NODE_ID:
-        raise ValueError("local node cannot be revoked")
-    current = get_node(node_id)
-    if current is None:
-        return None
-    if current.status != "revoked" and "revoked" not in ALLOWED_STATUS_TRANSITIONS[current.status]:
-        raise ValueError(f"invalid node status transition: {current.status} -> revoked")
-    timestamp = now_iso()
-    with db() as conn:
-        conn.execute(
-            """UPDATE compute_nodes
-               SET status = ?, revoked_at = ?, updated_at = ?
-               WHERE node_id = ?""",
-            ("revoked", timestamp, timestamp, node_id),
-        )
-    return get_node(node_id)
-
-
 def delete_node(node_id: str) -> None:
     if node_id == LOCAL_NODE_ID:
         raise ValueError("local node cannot be deleted")
-    with db() as conn:
+    with db(immediate=True) as conn:
+        in_use = conn.execute(
+            """SELECT
+                   EXISTS(SELECT 1 FROM containers WHERE node_id = ?)
+                   OR EXISTS(SELECT 1 FROM vms WHERE node_id = ?)
+                   OR EXISTS(SELECT 1 FROM compute_jobs WHERE node_id = ?)""",
+            (node_id, node_id, node_id),
+        ).fetchone()[0]
+        if in_use:
+            raise ValueError("compute node is still in use")
         conn.execute("DELETE FROM compute_nodes WHERE node_id = ?", (node_id,))

--- a/core/src/hydrahive/compute/db.py
+++ b/core/src/hydrahive/compute/db.py
@@ -1,0 +1,178 @@
+"""Parameterized persistence operations for the compute-node registry."""
+
+from __future__ import annotations
+
+from hydrahive.compute._node_codec import (
+    ALLOWED_STATUS_TRANSITIONS,
+    dump_json,
+    row_to_node,
+    validate_identity,
+    validate_kind,
+    validate_status,
+)
+from hydrahive.compute.models import ComputeNode, JSONObject, NodeKind, NodeStatus
+from hydrahive.db._utils import now_iso
+from hydrahive.db.connection import db
+
+LOCAL_NODE_ID = "local"
+
+
+def create_node(
+    *,
+    node_id: str,
+    name: str,
+    kind: NodeKind = "agent",
+    status: NodeStatus = "pending",
+    certificate_fingerprint: str | None = None,
+    protocol_version: int = 1,
+    agent_version: str | None = None,
+    capabilities: JSONObject | None = None,
+    resources: JSONObject | None = None,
+    labels: JSONObject | None = None,
+) -> ComputeNode:
+    validate_identity(node_id, name)
+    validate_kind(kind)
+    validate_status(status)
+    if node_id == LOCAL_NODE_ID or kind == "local":
+        raise ValueError("local node identity is reserved")
+    if protocol_version < 1:
+        raise ValueError("protocol_version must be at least 1")
+    capabilities_json = dump_json(capabilities or {}, "capabilities")
+    resources_json = dump_json(resources or {}, "resources")
+    labels_json = dump_json(labels or {}, "labels")
+    timestamp = now_iso()
+    with db() as conn:
+        conn.execute(
+            """INSERT INTO compute_nodes (
+                   node_id, name, kind, status, certificate_fingerprint,
+                   protocol_version, agent_version, capabilities_json,
+                   resources_json, labels_json, created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                node_id,
+                name,
+                kind,
+                status,
+                certificate_fingerprint,
+                protocol_version,
+                agent_version,
+                capabilities_json,
+                resources_json,
+                labels_json,
+                timestamp,
+                timestamp,
+            ),
+        )
+    node = get_node(node_id)
+    if node is None:  # pragma: no cover - defensive invariant
+        raise RuntimeError("created compute node could not be read back")
+    return node
+
+
+def get_node(node_id: str) -> ComputeNode | None:
+    with db() as conn:
+        row = conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+    return row_to_node(row) if row else None
+
+
+def list_nodes() -> list[ComputeNode]:
+    with db() as conn:
+        rows = conn.execute(
+            """SELECT * FROM compute_nodes
+               ORDER BY CASE WHEN node_id = ? THEN 0 ELSE 1 END, name, node_id""",
+            (LOCAL_NODE_ID,),
+        ).fetchall()
+    return [row_to_node(row) for row in rows]
+
+
+def update_node(
+    node_id: str,
+    *,
+    name: str | None = None,
+    status: NodeStatus | None = None,
+    certificate_fingerprint: str | None = None,
+    protocol_version: int | None = None,
+    agent_version: str | None = None,
+    capabilities: JSONObject | None = None,
+    resources: JSONObject | None = None,
+    labels: JSONObject | None = None,
+    last_seen_at: str | None = None,
+    approved_at: str | None = None,
+    approved_by: str | None = None,
+) -> ComputeNode | None:
+    current = get_node(node_id)
+    if current is None:
+        return None
+    fields: list[str] = []
+    values: list[object] = []
+    if name is not None:
+        validate_identity(node_id, name)
+        fields.append("name = ?")
+        values.append(name)
+    if status is not None:
+        validate_status(status)
+        if status != current.status and status not in ALLOWED_STATUS_TRANSITIONS[current.status]:
+            raise ValueError(f"invalid node status transition: {current.status} -> {status}")
+        fields.append("status = ?")
+        values.append(status)
+    if certificate_fingerprint is not None:
+        fields.append("certificate_fingerprint = ?")
+        values.append(certificate_fingerprint)
+    if protocol_version is not None:
+        if protocol_version < 1:
+            raise ValueError("protocol_version must be at least 1")
+        fields.append("protocol_version = ?")
+        values.append(protocol_version)
+    for column, value in (
+        ("agent_version", agent_version),
+        ("last_seen_at", last_seen_at),
+        ("approved_at", approved_at),
+        ("approved_by", approved_by),
+    ):
+        if value is not None:
+            fields.append(f"{column} = ?")
+            values.append(value)
+    for column, value, field_name in (
+        ("capabilities_json", capabilities, "capabilities"),
+        ("resources_json", resources, "resources"),
+        ("labels_json", labels, "labels"),
+    ):
+        if value is not None:
+            fields.append(f"{column} = ?")
+            values.append(dump_json(value, field_name))
+    if not fields:
+        return current
+    fields.append("updated_at = ?")
+    values.extend((now_iso(), node_id))
+    with db() as conn:
+        conn.execute(
+            f"UPDATE compute_nodes SET {', '.join(fields)} WHERE node_id = ?",
+            values,
+        )
+    return get_node(node_id)
+
+
+def revoke_node(node_id: str) -> ComputeNode | None:
+    if node_id == LOCAL_NODE_ID:
+        raise ValueError("local node cannot be revoked")
+    current = get_node(node_id)
+    if current is None:
+        return None
+    if current.status != "revoked" and "revoked" not in ALLOWED_STATUS_TRANSITIONS[current.status]:
+        raise ValueError(f"invalid node status transition: {current.status} -> revoked")
+    timestamp = now_iso()
+    with db() as conn:
+        conn.execute(
+            """UPDATE compute_nodes
+               SET status = ?, revoked_at = ?, updated_at = ?
+               WHERE node_id = ?""",
+            ("revoked", timestamp, timestamp, node_id),
+        )
+    return get_node(node_id)
+
+
+def delete_node(node_id: str) -> None:
+    if node_id == LOCAL_NODE_ID:
+        raise ValueError("local node cannot be deleted")
+    with db() as conn:
+        conn.execute("DELETE FROM compute_nodes WHERE node_id = ?", (node_id,))

--- a/core/src/hydrahive/compute/models.py
+++ b/core/src/hydrahive/compute/models.py
@@ -1,0 +1,86 @@
+"""Typed persistence models and bounds for the compute-cluster foundation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+NodeKind = Literal["local", "agent"]
+NodeStatus = Literal["pending", "online", "degraded", "offline", "draining", "disabled", "revoked"]
+JobResourceKind = Literal["container", "vm", "node"]
+JobStatus = Literal["queued", "leased", "running", "succeeded", "failed", "cancelled", "expired"]
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+JSONObject: TypeAlias = dict[str, JSONValue]
+
+NODE_KINDS: frozenset[str] = frozenset({"local", "agent"})
+NODE_STATUSES: frozenset[str] = frozenset(
+    {"pending", "online", "degraded", "offline", "draining", "disabled", "revoked"}
+)
+MAX_NODE_ID_LENGTH = 128
+MAX_NODE_NAME_LENGTH = 255
+MAX_NODE_JSON_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeNode:
+    node_id: str
+    name: str
+    kind: NodeKind
+    status: NodeStatus
+    protocol_version: int
+    created_at: str
+    updated_at: str
+    capabilities: JSONObject = field(default_factory=dict)
+    resources: JSONObject = field(default_factory=dict)
+    labels: JSONObject = field(default_factory=dict)
+    certificate_fingerprint: str | None = None
+    agent_version: str | None = None
+    last_seen_at: str | None = None
+    approved_at: str | None = None
+    approved_by: str | None = None
+    revoked_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeEnrollmentToken:
+    token_id: str
+    token_hmac: str
+    requested_name: str
+    expires_at: str
+    created_by: str
+    created_at: str
+    consumed_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeJob:
+    job_id: str
+    node_id: str
+    resource_kind: JobResourceKind
+    resource_id: str | None
+    operation: str
+    generation: int
+    payload: JSONObject
+    idempotency_key: str
+    status: JobStatus
+    attempts: int
+    progress: int
+    created_by: str
+    created_at: str
+    lease_id: str | None = None
+    lease_until: str | None = None
+    error_code: str | None = None
+    error_params: JSONObject | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeJobEvent:
+    event_id: int
+    job_id: str
+    sequence: int
+    event_type: str
+    data: JSONObject
+    created_at: str

--- a/core/src/hydrahive/containers/db.py
+++ b/core/src/hydrahive/containers/db.py
@@ -1,4 +1,5 @@
 """DB-CRUD für Container."""
+
 from __future__ import annotations
 
 import json
@@ -13,28 +14,45 @@ def _row_to_container(r: sqlite3.Row) -> Container:
     params = json.loads(r["last_error_params"]) if r["last_error_params"] else None
     keys = r.keys() if hasattr(r, "keys") else []
     return Container(
-        container_id=r["container_id"], owner=r["owner"], name=r["name"],
-        description=r["description"], image=r["image"],
-        cpu=r["cpu"], ram_mb=r["ram_mb"], network_mode=r["network_mode"],
-        desired_state=r["desired_state"], actual_state=r["actual_state"],
-        last_error_code=r["last_error_code"], last_error_params=params,
-        created_at=r["created_at"], updated_at=r["updated_at"],
+        container_id=r["container_id"],
+        owner=r["owner"],
+        name=r["name"],
+        description=r["description"],
+        image=r["image"],
+        cpu=r["cpu"],
+        ram_mb=r["ram_mb"],
+        network_mode=r["network_mode"],
+        desired_state=r["desired_state"],
+        actual_state=r["actual_state"],
+        last_error_code=r["last_error_code"],
+        last_error_params=params,
+        created_at=r["created_at"],
+        updated_at=r["updated_at"],
         project_id=r["project_id"] if "project_id" in keys else None,
+        node_id=r["node_id"] if "node_id" in keys else "local",
+        generation=r["generation"] if "generation" in keys else 0,
     )
 
 
-def create(owner: str, name: str, image: str, network_mode: str = "bridged",
-           cpu: int | None = None, ram_mb: int | None = None,
-           description: str | None = None) -> Container:
+def create(
+    owner: str,
+    name: str,
+    image: str,
+    network_mode: str = "bridged",
+    cpu: int | None = None,
+    ram_mb: int | None = None,
+    description: str | None = None,
+    node_id: str = "local",
+) -> Container:
     cid = uuid7()
     ts = now_iso()
     with db() as conn:
         conn.execute(
             """INSERT INTO containers (container_id, owner, name, description, image,
-                                        cpu, ram_mb, network_mode,
+                                        cpu, ram_mb, network_mode, node_id,
                                         desired_state, actual_state, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'stopped', 'created', ?, ?)""",
-            (cid, owner, name, description, image, cpu, ram_mb, network_mode, ts, ts),
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'stopped', 'created', ?, ?)""",
+            (cid, owner, name, description, image, cpu, ram_mb, network_mode, node_id, ts, ts),
         )
     return get(cid)  # type: ignore[return-value]
 
@@ -42,7 +60,8 @@ def create(owner: str, name: str, image: str, network_mode: str = "bridged",
 def get(container_id: str) -> Container | None:
     with db() as conn:
         row = conn.execute(
-            "SELECT * FROM containers WHERE container_id = ?", (container_id,),
+            "SELECT * FROM containers WHERE container_id = ?",
+            (container_id,),
         ).fetchone()
     return _row_to_container(row) if row else None
 
@@ -50,9 +69,7 @@ def get(container_id: str) -> Container | None:
 def list_(owner: str | None = None) -> list[Container]:
     with db() as conn:
         if owner is None:
-            rows = conn.execute(
-                "SELECT * FROM containers ORDER BY created_at DESC"
-            ).fetchall()
+            rows = conn.execute("SELECT * FROM containers ORDER BY created_at DESC").fetchall()
         else:
             rows = conn.execute(
                 "SELECT * FROM containers WHERE owner = ? ORDER BY created_at DESC",
@@ -70,22 +87,31 @@ def name_taken(name: str, exclude_id: str | None = None) -> bool:
             ).fetchone()
         else:
             row = conn.execute(
-                "SELECT 1 FROM containers WHERE name = ?", (name,),
+                "SELECT 1 FROM containers WHERE name = ?",
+                (name,),
             ).fetchone()
     return row is not None
 
 
-def update_state(container_id: str, *, desired: str | None = None,
-                 actual: str | None = None,
-                 error_code: str | None = ..., error_params: dict | None = ...) -> None:
+def update_state(
+    container_id: str,
+    *,
+    desired: str | None = None,
+    actual: str | None = None,
+    error_code: str | None = ...,
+    error_params: dict | None = ...,
+) -> None:
     sets: list[str] = ["updated_at = ?"]
     vals: list = [now_iso()]
     if desired is not None:
-        sets.append("desired_state = ?"); vals.append(desired)
+        sets.extend(("desired_state = ?", "generation = generation + 1"))
+        vals.append(desired)
     if actual is not None:
-        sets.append("actual_state = ?"); vals.append(actual)
+        sets.append("actual_state = ?")
+        vals.append(actual)
     if error_code is not ...:
-        sets.append("last_error_code = ?"); vals.append(error_code)
+        sets.append("last_error_code = ?")
+        vals.append(error_code)
     if error_params is not ...:
         sets.append("last_error_params = ?")
         vals.append(json.dumps(error_params) if error_params else None)
@@ -99,21 +125,30 @@ def delete(container_id: str) -> None:
         conn.execute("DELETE FROM containers WHERE container_id = ?", (container_id,))
 
 
-def update_container_config(container_id: str, *, name: str | None = None,
-                             description: str | None = ...,
-                             cpu: int | None = ..., ram_mb: int | None = ...) -> None:
+def update_container_config(
+    container_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = ...,
+    cpu: int | None = ...,
+    ram_mb: int | None = ...,
+) -> None:
     """Konfig-Update (Name, Description, CPU, RAM). cpu/ram_mb können explizit
     auf None gesetzt werden für 'unbegrenzt' (Sentinel ... = nicht ändern)."""
-    sets: list[str] = ["updated_at = ?"]
+    sets: list[str] = ["updated_at = ?", "generation = generation + 1"]
     vals: list = [now_iso()]
     if name is not None:
-        sets.append("name = ?"); vals.append(name)
+        sets.append("name = ?")
+        vals.append(name)
     if description is not ...:
-        sets.append("description = ?"); vals.append(description)
+        sets.append("description = ?")
+        vals.append(description)
     if cpu is not ...:
-        sets.append("cpu = ?"); vals.append(cpu)
+        sets.append("cpu = ?")
+        vals.append(cpu)
     if ram_mb is not ...:
-        sets.append("ram_mb = ?"); vals.append(ram_mb)
+        sets.append("ram_mb = ?")
+        vals.append(ram_mb)
     vals.append(container_id)
     with db() as conn:
         conn.execute(f"UPDATE containers SET {', '.join(sets)} WHERE container_id = ?", vals)
@@ -139,5 +174,6 @@ def list_for_project(project_id: str) -> list[Container]:
 def clear_project_assignments(project_id: str) -> None:
     with db() as conn:
         conn.execute(
-            "UPDATE containers SET project_id = NULL WHERE project_id = ?", (project_id,),
+            "UPDATE containers SET project_id = NULL WHERE project_id = ?",
+            (project_id,),
         )

--- a/core/src/hydrahive/containers/lifecycle.py
+++ b/core/src/hydrahive/containers/lifecycle.py
@@ -1,4 +1,5 @@
 """Container-Lifecycle: launch/start/stop/delete via incus_client."""
+
 from __future__ import annotations
 
 import logging
@@ -6,6 +7,7 @@ import logging
 from hydrahive.settings import settings
 from hydrahive.containers import db as cdb
 from hydrahive.containers import incus_client as incus
+from hydrahive.containers.models import Container
 
 logger = logging.getLogger(__name__)
 
@@ -14,22 +16,32 @@ def _bridge() -> str:
     return settings.vms_bridge  # br0 — Default für VMs UND Container
 
 
+def ensure_local(container: Container) -> None:
+    if container.node_id != "local":
+        raise incus.IncusError(
+            "container_not_local",
+            container_id=container.container_id,
+            node_id=container.node_id,
+        )
+
+
 async def create_and_start(container_id: str) -> None:
     c = cdb.get(container_id)
     if not c:
         raise incus.IncusError("container_not_found", id=container_id)
-    cdb.update_state(container_id, desired="running", actual="starting",
-                     error_code=None, error_params=None)
+    ensure_local(c)
+    cdb.update_state(container_id, desired="running", actual="starting", error_code=None, error_params=None)
     try:
         await incus.launch(
-            c.name, c.image,
+            c.name,
+            c.image,
             network_mode=c.network_mode,
-            cpu=c.cpu, ram_mb=c.ram_mb,
+            cpu=c.cpu,
+            ram_mb=c.ram_mb,
             bridge=_bridge(),
         )
     except incus.IncusError as e:
-        cdb.update_state(container_id, actual="error",
-                         error_code=e.code, error_params=e.params)
+        cdb.update_state(container_id, actual="error", error_code=e.code, error_params=e.params)
         raise
     cdb.update_state(container_id, actual="running")
 
@@ -38,13 +50,12 @@ async def start(container_id: str) -> None:
     c = cdb.get(container_id)
     if not c:
         raise incus.IncusError("container_not_found", id=container_id)
-    cdb.update_state(container_id, desired="running", actual="starting",
-                     error_code=None, error_params=None)
+    ensure_local(c)
+    cdb.update_state(container_id, desired="running", actual="starting", error_code=None, error_params=None)
     try:
         await incus.start(c.name)
     except incus.IncusError as e:
-        cdb.update_state(container_id, actual="error",
-                         error_code=e.code, error_params=e.params)
+        cdb.update_state(container_id, actual="error", error_code=e.code, error_params=e.params)
         raise
     cdb.update_state(container_id, actual="running")
 
@@ -53,12 +64,12 @@ async def stop(container_id: str, *, force: bool = False) -> None:
     c = cdb.get(container_id)
     if not c:
         raise incus.IncusError("container_not_found", id=container_id)
+    ensure_local(c)
     cdb.update_state(container_id, desired="stopped", actual="stopping")
     try:
         await incus.stop(c.name, force=force)
     except incus.IncusError as e:
-        cdb.update_state(container_id, actual="error",
-                         error_code=e.code, error_params=e.params)
+        cdb.update_state(container_id, actual="error", error_code=e.code, error_params=e.params)
         raise
     cdb.update_state(container_id, actual="stopped")
 
@@ -67,15 +78,16 @@ async def restart_(container_id: str) -> None:
     c = cdb.get(container_id)
     if not c:
         raise incus.IncusError("container_not_found", id=container_id)
+    ensure_local(c)
     await incus.restart_(c.name)
-    cdb.update_state(container_id, actual="running",
-                     error_code=None, error_params=None)
+    cdb.update_state(container_id, actual="running", error_code=None, error_params=None)
 
 
 async def delete(container_id: str) -> None:
     c = cdb.get(container_id)
     if not c:
         return
+    ensure_local(c)
     try:
         await incus.delete(c.name, force=True)
     except incus.IncusError:

--- a/core/src/hydrahive/containers/models.py
+++ b/core/src/hydrahive/containers/models.py
@@ -26,6 +26,8 @@ class Container:
     last_error_code: str | None = None
     last_error_params: dict | None = None
     project_id: str | None = None
+    node_id: str = "local"
+    generation: int = 0
 
 
 @dataclass

--- a/core/src/hydrahive/containers/reconciler.py
+++ b/core/src/hydrahive/containers/reconciler.py
@@ -24,6 +24,8 @@ async def reconcile_once() -> None:
         return
 
     for c in local:
+        if c.node_id != "local":
+            continue
         if c.actual_state not in ACTIVE_STATES:
             continue
         is_running = c.name in running

--- a/core/src/hydrahive/db/migrations/032_compute_nodes.sql
+++ b/core/src/hydrahive/db/migrations/032_compute_nodes.sql
@@ -1,0 +1,87 @@
+-- 032: Compute-cluster foundation: node registry, enrollment/job persistence,
+-- and additive placement metadata for existing local resources.
+
+CREATE TABLE compute_nodes (
+    node_id                  TEXT PRIMARY KEY,
+    name                     TEXT NOT NULL UNIQUE,
+    kind                     TEXT NOT NULL CHECK (kind IN ('local', 'agent')),
+    status                   TEXT NOT NULL CHECK (
+        status IN ('pending', 'online', 'degraded', 'offline', 'draining', 'disabled', 'revoked')
+    ),
+    certificate_fingerprint  TEXT UNIQUE,
+    protocol_version         INTEGER NOT NULL CHECK (protocol_version >= 1),
+    agent_version            TEXT,
+    capabilities_json        TEXT NOT NULL,
+    resources_json           TEXT NOT NULL,
+    labels_json              TEXT NOT NULL,
+    last_seen_at             TEXT,
+    approved_at              TEXT,
+    approved_by              TEXT,
+    revoked_at               TEXT,
+    created_at               TEXT NOT NULL,
+    updated_at               TEXT NOT NULL
+);
+
+INSERT INTO compute_nodes (
+    node_id, name, kind, status, protocol_version,
+    capabilities_json, resources_json, labels_json, created_at, updated_at
+) VALUES (
+    'local', 'Local Host', 'local', 'online', 1,
+    '{}', '{}', '{}', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+) ON CONFLICT(node_id) DO NOTHING;
+
+CREATE TABLE compute_enrollment_tokens (
+    token_id         TEXT PRIMARY KEY,
+    token_hmac       TEXT NOT NULL UNIQUE,
+    requested_name   TEXT NOT NULL,
+    expires_at       TEXT NOT NULL,
+    consumed_at      TEXT,
+    created_by       TEXT NOT NULL,
+    created_at       TEXT NOT NULL
+);
+
+CREATE TABLE compute_jobs (
+    job_id               TEXT PRIMARY KEY,
+    node_id               TEXT NOT NULL REFERENCES compute_nodes(node_id),
+    resource_kind         TEXT NOT NULL CHECK (resource_kind IN ('container', 'vm', 'node')),
+    resource_id           TEXT,
+    operation             TEXT NOT NULL,
+    generation            INTEGER NOT NULL CHECK (generation >= 0),
+    payload_json          TEXT NOT NULL,
+    idempotency_key       TEXT NOT NULL UNIQUE,
+    status                TEXT NOT NULL CHECK (
+        status IN ('queued', 'leased', 'running', 'succeeded', 'failed', 'cancelled', 'expired')
+    ),
+    lease_id              TEXT,
+    lease_until           TEXT,
+    attempts              INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    progress              INTEGER NOT NULL DEFAULT 0 CHECK (progress BETWEEN 0 AND 100),
+    error_code            TEXT,
+    error_params_json     TEXT,
+    created_by            TEXT NOT NULL,
+    created_at            TEXT NOT NULL,
+    started_at            TEXT,
+    finished_at           TEXT
+);
+
+CREATE TABLE compute_job_events (
+    event_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id         TEXT NOT NULL REFERENCES compute_jobs(job_id) ON DELETE CASCADE,
+    sequence       INTEGER NOT NULL CHECK (sequence >= 0),
+    event_type     TEXT NOT NULL,
+    data_json      TEXT NOT NULL,
+    created_at     TEXT NOT NULL,
+    UNIQUE(job_id, sequence)
+);
+
+CREATE INDEX idx_compute_nodes_status ON compute_nodes(status);
+CREATE INDEX idx_compute_jobs_node_status ON compute_jobs(node_id, status);
+CREATE INDEX idx_compute_job_events_job ON compute_job_events(job_id, sequence);
+
+ALTER TABLE containers ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE containers ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);
+CREATE INDEX idx_containers_node_id ON containers(node_id);
+
+ALTER TABLE vms ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE vms ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);
+CREATE INDEX idx_vms_node_id ON vms(node_id);

--- a/core/src/hydrahive/db/migrations/032_compute_nodes.sql
+++ b/core/src/hydrahive/db/migrations/032_compute_nodes.sql
@@ -1,7 +1,6 @@
--- 032: Compute-cluster foundation: node registry, enrollment/job persistence,
--- and additive placement metadata for existing local resources.
+-- 032: Compute-cluster foundation: idempotent node registry and job tables.
 
-CREATE TABLE compute_nodes (
+CREATE TABLE IF NOT EXISTS compute_nodes (
     node_id                  TEXT PRIMARY KEY,
     name                     TEXT NOT NULL UNIQUE,
     kind                     TEXT NOT NULL CHECK (kind IN ('local', 'agent')),
@@ -28,9 +27,9 @@ INSERT INTO compute_nodes (
 ) VALUES (
     'local', 'Local Host', 'local', 'online', 1,
     '{}', '{}', '{}', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-) ON CONFLICT(node_id) DO NOTHING;
+) ON CONFLICT DO NOTHING;
 
-CREATE TABLE compute_enrollment_tokens (
+CREATE TABLE IF NOT EXISTS compute_enrollment_tokens (
     token_id         TEXT PRIMARY KEY,
     token_hmac       TEXT NOT NULL UNIQUE,
     requested_name   TEXT NOT NULL,
@@ -40,7 +39,7 @@ CREATE TABLE compute_enrollment_tokens (
     created_at       TEXT NOT NULL
 );
 
-CREATE TABLE compute_jobs (
+CREATE TABLE IF NOT EXISTS compute_jobs (
     job_id               TEXT PRIMARY KEY,
     node_id               TEXT NOT NULL REFERENCES compute_nodes(node_id),
     resource_kind         TEXT NOT NULL CHECK (resource_kind IN ('container', 'vm', 'node')),
@@ -64,7 +63,7 @@ CREATE TABLE compute_jobs (
     finished_at           TEXT
 );
 
-CREATE TABLE compute_job_events (
+CREATE TABLE IF NOT EXISTS compute_job_events (
     event_id       INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id         TEXT NOT NULL REFERENCES compute_jobs(job_id) ON DELETE CASCADE,
     sequence       INTEGER NOT NULL CHECK (sequence >= 0),
@@ -74,14 +73,6 @@ CREATE TABLE compute_job_events (
     UNIQUE(job_id, sequence)
 );
 
-CREATE INDEX idx_compute_nodes_status ON compute_nodes(status);
-CREATE INDEX idx_compute_jobs_node_status ON compute_jobs(node_id, status);
-CREATE INDEX idx_compute_job_events_job ON compute_job_events(job_id, sequence);
-
-ALTER TABLE containers ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';
-ALTER TABLE containers ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);
-CREATE INDEX idx_containers_node_id ON containers(node_id);
-
-ALTER TABLE vms ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';
-ALTER TABLE vms ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);
-CREATE INDEX idx_vms_node_id ON vms(node_id);
+CREATE INDEX IF NOT EXISTS idx_compute_nodes_status ON compute_nodes(status);
+CREATE INDEX IF NOT EXISTS idx_compute_jobs_node_status ON compute_jobs(node_id, status);
+CREATE INDEX IF NOT EXISTS idx_compute_job_events_job ON compute_job_events(job_id, sequence);

--- a/core/src/hydrahive/db/migrations/033_containers_node_id.sql
+++ b/core/src/hydrahive/db/migrations/033_containers_node_id.sql
@@ -1,0 +1,2 @@
+-- 033: Bind every container to a compute node; existing rows remain local.
+ALTER TABLE containers ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';

--- a/core/src/hydrahive/db/migrations/034_containers_generation.sql
+++ b/core/src/hydrahive/db/migrations/034_containers_generation.sql
@@ -1,0 +1,2 @@
+-- 034: Monotonic container configuration generation.
+ALTER TABLE containers ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);

--- a/core/src/hydrahive/db/migrations/035_vms_node_id.sql
+++ b/core/src/hydrahive/db/migrations/035_vms_node_id.sql
@@ -1,0 +1,2 @@
+-- 035: Bind every VM to a compute node; existing rows remain local.
+ALTER TABLE vms ADD COLUMN node_id TEXT NOT NULL DEFAULT 'local';

--- a/core/src/hydrahive/db/migrations/036_vms_generation.sql
+++ b/core/src/hydrahive/db/migrations/036_vms_generation.sql
@@ -1,0 +1,2 @@
+-- 036: Monotonic VM configuration generation.
+ALTER TABLE vms ADD COLUMN generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0);

--- a/core/src/hydrahive/db/migrations/037_vms_runtime.sql
+++ b/core/src/hydrahive/db/migrations/037_vms_runtime.sql
@@ -1,0 +1,2 @@
+-- 037: VM execution backend; legacy VMs continue to use local QEMU.
+ALTER TABLE vms ADD COLUMN runtime TEXT NOT NULL DEFAULT 'qemu' CHECK (runtime IN ('qemu', 'incus'));

--- a/core/src/hydrahive/db/migrations/038_vms_runtime_ref.sql
+++ b/core/src/hydrahive/db/migrations/038_vms_runtime_ref.sql
@@ -1,0 +1,2 @@
+-- 038: Backend-specific VM instance reference.
+ALTER TABLE vms ADD COLUMN runtime_ref TEXT;

--- a/core/src/hydrahive/db/migrations/039_compute_placement_integrity.sql
+++ b/core/src/hydrahive/db/migrations/039_compute_placement_integrity.sql
@@ -1,0 +1,56 @@
+-- 039: Enforce compute-node placement without rebuilding legacy resource tables.
+CREATE INDEX IF NOT EXISTS idx_containers_node_id ON containers(node_id);
+CREATE INDEX IF NOT EXISTS idx_vms_node_id ON vms(node_id);
+
+CREATE TRIGGER IF NOT EXISTS containers_node_exists_insert
+BEFORE INSERT ON containers
+WHEN NOT EXISTS (SELECT 1 FROM compute_nodes WHERE node_id = NEW.node_id)
+BEGIN
+    SELECT RAISE(ABORT, 'compute_node_not_found');
+END;
+
+CREATE TRIGGER IF NOT EXISTS containers_node_exists_update
+BEFORE UPDATE OF node_id ON containers
+WHEN NOT EXISTS (SELECT 1 FROM compute_nodes WHERE node_id = NEW.node_id)
+BEGIN
+    SELECT RAISE(ABORT, 'compute_node_not_found');
+END;
+
+CREATE TRIGGER IF NOT EXISTS vms_node_exists_insert
+BEFORE INSERT ON vms
+WHEN NOT EXISTS (SELECT 1 FROM compute_nodes WHERE node_id = NEW.node_id)
+BEGIN
+    SELECT RAISE(ABORT, 'compute_node_not_found');
+END;
+
+CREATE TRIGGER IF NOT EXISTS vms_node_exists_update
+BEFORE UPDATE OF node_id ON vms
+WHEN NOT EXISTS (SELECT 1 FROM compute_nodes WHERE node_id = NEW.node_id)
+BEGIN
+    SELECT RAISE(ABORT, 'compute_node_not_found');
+END;
+
+CREATE TRIGGER IF NOT EXISTS vms_runtime_matches_node_insert
+BEFORE INSERT ON vms
+WHEN (NEW.node_id = 'local' AND NEW.runtime != 'qemu')
+  OR (NEW.node_id != 'local' AND NEW.runtime != 'incus')
+BEGIN
+    SELECT RAISE(ABORT, 'vm_runtime_node_mismatch');
+END;
+
+CREATE TRIGGER IF NOT EXISTS vms_runtime_matches_node_update
+BEFORE UPDATE OF node_id, runtime ON vms
+WHEN (NEW.node_id = 'local' AND NEW.runtime != 'qemu')
+  OR (NEW.node_id != 'local' AND NEW.runtime != 'incus')
+BEGIN
+    SELECT RAISE(ABORT, 'vm_runtime_node_mismatch');
+END;
+
+CREATE TRIGGER IF NOT EXISTS compute_nodes_restrict_delete
+BEFORE DELETE ON compute_nodes
+WHEN OLD.node_id = 'local'
+  OR EXISTS (SELECT 1 FROM containers WHERE node_id = OLD.node_id)
+  OR EXISTS (SELECT 1 FROM vms WHERE node_id = OLD.node_id)
+BEGIN
+    SELECT RAISE(ABORT, 'compute_node_in_use');
+END;

--- a/core/src/hydrahive/vms/_passthrough_db.py
+++ b/core/src/hydrahive/vms/_passthrough_db.py
@@ -1,0 +1,70 @@
+"""Persistence helpers for VM passthrough disks and VM generations."""
+
+from __future__ import annotations
+
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+from hydrahive.vms.models import PassthroughDisk
+
+
+def _row_to_passthrough(row) -> PassthroughDisk:
+    return PassthroughDisk(
+        passthrough_id=row["passthrough_id"],
+        vm_id=row["vm_id"],
+        device_path=row["device_path"],
+        label=row["label"],
+        added_at=row["added_at"],
+    )
+
+
+def list_for_vm(vm_id: str) -> list[PassthroughDisk]:
+    with db() as conn:
+        rows = conn.execute(
+            "SELECT * FROM vm_passthrough_disks WHERE vm_id = ? ORDER BY added_at",
+            (vm_id,),
+        ).fetchall()
+    return [_row_to_passthrough(row) for row in rows]
+
+
+def list_all_paths() -> set[str]:
+    with db() as conn:
+        rows = conn.execute("SELECT device_path FROM vm_passthrough_disks").fetchall()
+    return {row["device_path"] for row in rows}
+
+
+def insert(vm_id: str, device_path: str, label: str | None) -> PassthroughDisk:
+    passthrough_id = uuid7()
+    timestamp = now_iso()
+    with db() as conn:
+        conn.execute(
+            """INSERT INTO vm_passthrough_disks
+                   (passthrough_id, vm_id, device_path, label, added_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (passthrough_id, vm_id, device_path, label, timestamp),
+        )
+        conn.execute(
+            "UPDATE vms SET generation = generation + 1, updated_at = ? WHERE vm_id = ?",
+            (timestamp, vm_id),
+        )
+    return PassthroughDisk(
+        passthrough_id=passthrough_id,
+        vm_id=vm_id,
+        device_path=device_path,
+        label=label,
+        added_at=timestamp,
+    )
+
+
+def remove(vm_id: str, passthrough_id: str) -> bool:
+    timestamp = now_iso()
+    with db() as conn:
+        result = conn.execute(
+            "DELETE FROM vm_passthrough_disks WHERE passthrough_id = ? AND vm_id = ?",
+            (passthrough_id, vm_id),
+        )
+        if result.rowcount:
+            conn.execute(
+                "UPDATE vms SET generation = generation + 1, updated_at = ? WHERE vm_id = ?",
+                (timestamp, vm_id),
+            )
+    return result.rowcount > 0

--- a/core/src/hydrahive/vms/_vms_db_updates.py
+++ b/core/src/hydrahive/vms/_vms_db_updates.py
@@ -1,4 +1,5 @@
 """Partial-update helpers for VM state and config."""
+
 from __future__ import annotations
 
 import json
@@ -7,25 +8,38 @@ from hydrahive.db.connection import db
 from hydrahive.db._utils import now_iso
 
 
-def update_vm_state(vm_id: str, *, desired: str | None = None, actual: str | None = None,
-                    pid: int | None = ..., vnc_port: int | None = ...,
-                    vnc_token: str | None = ...,
-                    error_code: str | None = ..., error_params: dict | None = ...) -> None:
+def update_vm_state(
+    vm_id: str,
+    *,
+    desired: str | None = None,
+    actual: str | None = None,
+    pid: int | None = ...,
+    vnc_port: int | None = ...,
+    vnc_token: str | None = ...,
+    error_code: str | None = ...,
+    error_params: dict | None = ...,
+) -> None:
     """Partial update — Sentinels (...) = nicht ändern, None = explizit auf NULL setzen."""
     sets: list[str] = ["updated_at = ?"]
     vals: list = [now_iso()]
     if desired is not None:
-        sets.append("desired_state = ?"); vals.append(desired)
+        sets.extend(("desired_state = ?", "generation = generation + 1"))
+        vals.append(desired)
     if actual is not None:
-        sets.append("actual_state = ?"); vals.append(actual)
+        sets.append("actual_state = ?")
+        vals.append(actual)
     if pid is not ...:
-        sets.append("pid = ?"); vals.append(pid)
+        sets.append("pid = ?")
+        vals.append(pid)
     if vnc_port is not ...:
-        sets.append("vnc_port = ?"); vals.append(vnc_port)
+        sets.append("vnc_port = ?")
+        vals.append(vnc_port)
     if vnc_token is not ...:
-        sets.append("vnc_token = ?"); vals.append(vnc_token)
+        sets.append("vnc_token = ?")
+        vals.append(vnc_token)
     if error_code is not ...:
-        sets.append("last_error_code = ?"); vals.append(error_code)
+        sets.append("last_error_code = ?")
+        vals.append(error_code)
     if error_params is not ...:
         sets.append("last_error_params = ?")
         vals.append(json.dumps(error_params) if error_params else None)
@@ -34,35 +48,50 @@ def update_vm_state(vm_id: str, *, desired: str | None = None, actual: str | Non
         conn.execute(f"UPDATE vms SET {', '.join(sets)} WHERE vm_id = ?", vals)
 
 
-def update_vm_config(vm_id: str, *, name: str | None = None, description: str | None = ...,
-                     cpu: int | None = None, ram_mb: int | None = None,
-                     disk_gb: int | None = None,
-                     iso_filename: str | None = ...,
-                     disk_interface: str | None = None,
-                     machine_type: str | None = None,
-                     network_device: str | None = None) -> None:
+def update_vm_config(
+    vm_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = ...,
+    cpu: int | None = None,
+    ram_mb: int | None = None,
+    disk_gb: int | None = None,
+    iso_filename: str | None = ...,
+    disk_interface: str | None = None,
+    machine_type: str | None = None,
+    network_device: str | None = None,
+) -> None:
     """Konfig-Update für eine VM. Nur im stopped-State erlaubt — der Caller validiert.
     Sentinels (...) für optionale clear-zu-NULL."""
-    sets: list[str] = ["updated_at = ?"]
+    sets: list[str] = ["updated_at = ?", "generation = generation + 1"]
     vals: list = [now_iso()]
     if name is not None:
-        sets.append("name = ?"); vals.append(name)
+        sets.append("name = ?")
+        vals.append(name)
     if description is not ...:
-        sets.append("description = ?"); vals.append(description)
+        sets.append("description = ?")
+        vals.append(description)
     if cpu is not None:
-        sets.append("cpu = ?"); vals.append(cpu)
+        sets.append("cpu = ?")
+        vals.append(cpu)
     if ram_mb is not None:
-        sets.append("ram_mb = ?"); vals.append(ram_mb)
+        sets.append("ram_mb = ?")
+        vals.append(ram_mb)
     if disk_gb is not None:
-        sets.append("disk_gb = ?"); vals.append(disk_gb)
+        sets.append("disk_gb = ?")
+        vals.append(disk_gb)
     if iso_filename is not ...:
-        sets.append("iso_filename = ?"); vals.append(iso_filename)
+        sets.append("iso_filename = ?")
+        vals.append(iso_filename)
     if disk_interface is not None:
-        sets.append("disk_interface = ?"); vals.append(disk_interface)
+        sets.append("disk_interface = ?")
+        vals.append(disk_interface)
     if machine_type is not None:
-        sets.append("machine_type = ?"); vals.append(machine_type)
+        sets.append("machine_type = ?")
+        vals.append(machine_type)
     if network_device is not None:
-        sets.append("network_device = ?"); vals.append(network_device)
+        sets.append("network_device = ?")
+        vals.append(network_device)
     vals.append(vm_id)
     with db() as conn:
         conn.execute(f"UPDATE vms SET {', '.join(sets)} WHERE vm_id = ?", vals)

--- a/core/src/hydrahive/vms/db.py
+++ b/core/src/hydrahive/vms/db.py
@@ -1,4 +1,5 @@
 """DB-Zugriff für VMs — Mapping zu/von Dataclasses + simple CRUD."""
+
 from __future__ import annotations
 
 import json
@@ -7,13 +8,20 @@ import sqlite3
 from hydrahive.db.connection import db
 from hydrahive.db._utils import now_iso, uuid7
 from hydrahive.vms._vms_db_updates import update_vm_config, update_vm_state
-from hydrahive.vms.models import VM, ImportJob, Snapshot
+from hydrahive.vms.models import ImportJob, Snapshot, VM, VMRuntime
 
 __all__ = [
-    "create_vm", "get_vm", "list_vms", "delete_vm",
-    "update_vm_state", "update_vm_config",
-    "set_project", "list_for_project", "clear_project_assignments",
-    "name_taken", "used_vnc_ports",
+    "create_vm",
+    "get_vm",
+    "list_vms",
+    "delete_vm",
+    "update_vm_state",
+    "update_vm_config",
+    "set_project",
+    "list_for_project",
+    "clear_project_assignments",
+    "name_taken",
+    "used_vnc_ports",
 ]
 
 
@@ -21,39 +29,84 @@ def _row_to_vm(r: sqlite3.Row) -> VM:
     params = json.loads(r["last_error_params"]) if r["last_error_params"] else None
     keys = r.keys() if hasattr(r, "keys") else []
     return VM(
-        vm_id=r["vm_id"], owner=r["owner"], name=r["name"], description=r["description"],
-        cpu=r["cpu"], ram_mb=r["ram_mb"], disk_gb=r["disk_gb"],
-        iso_filename=r["iso_filename"], network_mode=r["network_mode"],
+        vm_id=r["vm_id"],
+        owner=r["owner"],
+        name=r["name"],
+        description=r["description"],
+        cpu=r["cpu"],
+        ram_mb=r["ram_mb"],
+        disk_gb=r["disk_gb"],
+        iso_filename=r["iso_filename"],
+        network_mode=r["network_mode"],
         qcow2_path=r["qcow2_path"],
         disk_interface=r["disk_interface"] if "disk_interface" in keys else "virtio",
         machine_type=r["machine_type"] if "machine_type" in keys else "q35",
         network_device=r["network_device"] if "network_device" in keys else "virtio-net-pci",
-        desired_state=r["desired_state"], actual_state=r["actual_state"],
-        pid=r["pid"], vnc_port=r["vnc_port"], vnc_token=r["vnc_token"],
-        last_error_code=r["last_error_code"], last_error_params=params,
-        created_at=r["created_at"], updated_at=r["updated_at"],
+        desired_state=r["desired_state"],
+        actual_state=r["actual_state"],
+        pid=r["pid"],
+        vnc_port=r["vnc_port"],
+        vnc_token=r["vnc_token"],
+        last_error_code=r["last_error_code"],
+        last_error_params=params,
+        created_at=r["created_at"],
+        updated_at=r["updated_at"],
         project_id=r["project_id"] if "project_id" in keys else None,
+        node_id=r["node_id"] if "node_id" in keys else "local",
+        generation=r["generation"] if "generation" in keys else 0,
+        runtime=r["runtime"] if "runtime" in keys else "qemu",
+        runtime_ref=r["runtime_ref"] if "runtime_ref" in keys else None,
     )
 
 
-def create_vm(owner: str, name: str, cpu: int, ram_mb: int, disk_gb: int,
-              qcow2_path: str, network_mode: str = "bridged",
-              description: str | None = None, iso_filename: str | None = None,
-              disk_interface: str = "virtio",
-              machine_type: str = "q35",
-              network_device: str = "virtio-net-pci") -> VM:
+def create_vm(
+    owner: str,
+    name: str,
+    cpu: int,
+    ram_mb: int,
+    disk_gb: int,
+    qcow2_path: str,
+    network_mode: str = "bridged",
+    description: str | None = None,
+    iso_filename: str | None = None,
+    disk_interface: str = "virtio",
+    machine_type: str = "q35",
+    network_device: str = "virtio-net-pci",
+    node_id: str = "local",
+    runtime: VMRuntime = "qemu",
+    runtime_ref: str | None = None,
+) -> VM:
+    if (node_id == "local") != (runtime == "qemu"):
+        raise ValueError("local VMs require qemu and remote VMs require incus")
     vm_id = uuid7()
     ts = now_iso()
     with db() as conn:
         conn.execute(
             """INSERT INTO vms (vm_id, owner, name, description, cpu, ram_mb, disk_gb,
                                 iso_filename, network_mode, qcow2_path, disk_interface,
-                                machine_type, network_device,
+                                machine_type, network_device, node_id, runtime, runtime_ref,
                                 desired_state, actual_state, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'stopped', 'created', ?, ?)""",
-            (vm_id, owner, name, description, cpu, ram_mb, disk_gb,
-             iso_filename, network_mode, qcow2_path, disk_interface,
-             machine_type, network_device, ts, ts),
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'stopped', 'created', ?, ?)""",
+            (
+                vm_id,
+                owner,
+                name,
+                description,
+                cpu,
+                ram_mb,
+                disk_gb,
+                iso_filename,
+                network_mode,
+                qcow2_path,
+                disk_interface,
+                machine_type,
+                network_device,
+                node_id,
+                runtime,
+                runtime_ref,
+                ts,
+                ts,
+            ),
         )
     return get_vm(vm_id)  # type: ignore[return-value]
 
@@ -101,7 +154,8 @@ def list_for_project(project_id: str) -> list[VM]:
 def clear_project_assignments(project_id: str) -> None:
     with db() as conn:
         conn.execute(
-            "UPDATE vms SET project_id = NULL WHERE project_id = ?", (project_id,),
+            "UPDATE vms SET project_id = NULL WHERE project_id = ?",
+            (project_id,),
         )
 
 
@@ -114,14 +168,13 @@ def name_taken(owner: str, name: str, exclude_id: str | None = None) -> bool:
             ).fetchone()
         else:
             row = conn.execute(
-                "SELECT 1 FROM vms WHERE owner = ? AND name = ?", (owner, name),
+                "SELECT 1 FROM vms WHERE owner = ? AND name = ?",
+                (owner, name),
             ).fetchone()
     return row is not None
 
 
 def used_vnc_ports() -> set[int]:
     with db() as conn:
-        rows = conn.execute(
-            "SELECT vnc_port FROM vms WHERE vnc_port IS NOT NULL"
-        ).fetchall()
+        rows = conn.execute("SELECT vnc_port FROM vms WHERE vnc_port IS NOT NULL").fetchall()
     return {r["vnc_port"] for r in rows}

--- a/core/src/hydrahive/vms/lifecycle.py
+++ b/core/src/hydrahive/vms/lifecycle.py
@@ -1,4 +1,5 @@
 """VM-Lifecycle: start/stop/poweroff via QEMU-Subprocess."""
+
 from __future__ import annotations
 
 import asyncio
@@ -12,6 +13,7 @@ from hydrahive.settings import settings
 from hydrahive.vms import vnc
 from hydrahive.vms.db import get_vm, update_vm_state
 from hydrahive.vms import passthrough as pt
+from hydrahive.vms.models import VM
 from hydrahive.vms.ports import allocate_vnc_port
 from hydrahive.vms.qemu_args import build_qemu_args, ensure_dirs
 
@@ -25,12 +27,23 @@ class VMLifecycleError(RuntimeError):
         self.params = params
 
 
+def ensure_local(vm: VM) -> None:
+    if vm.node_id != "local" or vm.runtime != "qemu":
+        raise VMLifecycleError(
+            "vm_not_local",
+            vm_id=vm.vm_id,
+            node_id=vm.node_id,
+            runtime=vm.runtime,
+        )
+
+
 async def start(vm_id: str) -> None:
     """Startet QEMU als Daemon (-daemonize), liest PID aus Pidfile."""
-    ensure_dirs()
     vm = get_vm(vm_id)
     if not vm:
         raise VMLifecycleError("vm_not_found", vm_id=vm_id)
+    ensure_local(vm)
+    ensure_dirs()
     if vm.actual_state in ("running", "starting"):
         return  # idempotent
     if not Path(vm.qcow2_path).exists():
@@ -41,9 +54,9 @@ async def start(vm_id: str) -> None:
         raise VMLifecycleError("vnc_ports_exhausted")
     token = secrets.token_urlsafe(24)
 
-    update_vm_state(vm_id, desired="running", actual="starting",
-                    vnc_port=port, vnc_token=token,
-                    error_code=None, error_params=None)
+    update_vm_state(
+        vm_id, desired="running", actual="starting", vnc_port=port, vnc_token=token, error_code=None, error_params=None
+    )
 
     passthrough_disks = pt.list_for_vm(vm_id)
     args = build_qemu_args(vm, port, passthrough_disks)
@@ -53,28 +66,27 @@ async def start(vm_id: str) -> None:
         with log_path.open("ab") as logf:
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    *args, stdout=logf, stderr=asyncio.subprocess.STDOUT,
+                    *args,
+                    stdout=logf,
+                    stderr=asyncio.subprocess.STDOUT,
                 )
             except FileNotFoundError:
-                update_vm_state(vm_id, actual="error",
-                                error_code="qemu_system_missing", error_params={})
+                update_vm_state(vm_id, actual="error", error_code="qemu_system_missing", error_params={})
                 raise VMLifecycleError("qemu_system_missing")
             rc = await asyncio.wait_for(proc.wait(), timeout=20.0)
         if rc != 0:
             tail = _tail(log_path, 20)
-            update_vm_state(vm_id, actual="error",
-                            error_code="qemu_start_failed",
-                            error_params={"rc": rc, "log_tail": tail})
+            update_vm_state(
+                vm_id, actual="error", error_code="qemu_start_failed", error_params={"rc": rc, "log_tail": tail}
+            )
             raise VMLifecycleError("qemu_start_failed", rc=rc)
     except asyncio.TimeoutError:
-        update_vm_state(vm_id, actual="error",
-                        error_code="qemu_daemonize_timeout", error_params={})
+        update_vm_state(vm_id, actual="error", error_code="qemu_daemonize_timeout", error_params={})
         raise VMLifecycleError("qemu_daemonize_timeout")
 
     pid = _read_pid(vm_id)
     if pid is None or not _pid_alive(pid):
-        update_vm_state(vm_id, actual="error",
-                        error_code="qemu_died_after_start", error_params={})
+        update_vm_state(vm_id, actual="error", error_code="qemu_died_after_start", error_params={})
         raise VMLifecycleError("qemu_died_after_start")
 
     # Token-File für websockify schreiben — erst NACHDEM QEMU als running
@@ -92,10 +104,10 @@ async def shutdown(vm_id: str, *, hard: bool = False) -> None:
     vm = get_vm(vm_id)
     if not vm:
         raise VMLifecycleError("vm_not_found", vm_id=vm_id)
+    ensure_local(vm)
     if vm.pid is None or not _pid_alive(vm.pid):
         vnc.remove_token(vm.vnc_token)
-        update_vm_state(vm_id, desired="stopped", actual="stopped", pid=None,
-                        vnc_port=None, vnc_token=None)
+        update_vm_state(vm_id, desired="stopped", actual="stopped", pid=None, vnc_port=None, vnc_token=None)
         return
     update_vm_state(vm_id, desired="stopped", actual="stopping")
     try:
@@ -108,8 +120,7 @@ async def shutdown(vm_id: str, *, hard: bool = False) -> None:
         if not _pid_alive(vm.pid):
             break
     vnc.remove_token(vm.vnc_token)
-    update_vm_state(vm_id, actual="stopped", pid=None,
-                    vnc_port=None, vnc_token=None)
+    update_vm_state(vm_id, actual="stopped", pid=None, vnc_port=None, vnc_token=None)
 
 
 def _read_pid(vm_id: str) -> int | None:

--- a/core/src/hydrahive/vms/models.py
+++ b/core/src/hydrahive/vms/models.py
@@ -14,6 +14,7 @@ MachineType = Literal["q35", "pc"]
 MACHINE_TYPES: tuple[str, ...] = ("q35", "pc")
 NetworkDevice = Literal["virtio-net-pci", "e1000"]
 NETWORK_DEVICES: tuple[str, ...] = ("virtio-net-pci", "e1000")
+VMRuntime = Literal["qemu", "incus"]
 
 
 @dataclass
@@ -41,6 +42,10 @@ class VM:
     last_error_code: str | None = None
     last_error_params: dict | None = None
     project_id: str | None = None
+    node_id: str = "local"
+    generation: int = 0
+    runtime: VMRuntime = "qemu"
+    runtime_ref: str | None = None
 
 
 @dataclass

--- a/core/src/hydrahive/vms/passthrough.py
+++ b/core/src/hydrahive/vms/passthrough.py
@@ -5,6 +5,7 @@ Sicherheits-Invarianten:
 - Nur unmountete Devices dürfen hinzugefügt werden (geprüft via lsblk)
 - Kein shell=True, kein String-Join für Subprocess-Argumente
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -12,8 +13,7 @@ import json
 import logging
 from pathlib import Path
 
-from hydrahive.db._utils import now_iso, uuid7
-from hydrahive.db.connection import db
+from hydrahive.vms import _passthrough_db as passthrough_db
 from hydrahive.vms.models import HostDisk, PassthroughDisk
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ class PassthroughError(RuntimeError):
 # Host-Disks listing
 # ---------------------------------------------------------------------------
 
+
 async def list_host_disks() -> list[HostDisk]:
     """Listet alle Block-Devices des Hosts via lsblk (JSON).
 
@@ -38,7 +39,10 @@ async def list_host_disks() -> list[HostDisk]:
     """
     try:
         proc = await asyncio.create_subprocess_exec(
-            "lsblk", "--json", "--output", "NAME,PATH,SIZE,TYPE,MOUNTPOINT,MODEL,SERIAL",
+            "lsblk",
+            "--json",
+            "--output",
+            "NAME,PATH,SIZE,TYPE,MOUNTPOINT,MODEL,SERIAL",
             "--tree",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -54,8 +58,11 @@ async def list_host_disks() -> list[HostDisk]:
     except json.JSONDecodeError:
         raise PassthroughError("lsblk_parse_error")
 
-    return [_parse_disk(d) for d in data.get("blockdevices", [])
-            if d.get("type") == "disk" and not d.get("name", "").startswith("loop")]
+    return [
+        _parse_disk(d)
+        for d in data.get("blockdevices", [])
+        if d.get("type") == "disk" and not d.get("name", "").startswith("loop")
+    ]
 
 
 def _parse_disk(raw: dict) -> HostDisk:
@@ -88,7 +95,10 @@ async def list_unmounted_host_disks() -> list[HostDisk]:
     """Nur Disks ohne aktive Mount-Points (inkl. Partitionen)."""
     try:
         proc = await asyncio.create_subprocess_exec(
-            "lsblk", "--json", "--output", "NAME,PATH,SIZE,TYPE,MOUNTPOINT,MODEL,SERIAL",
+            "lsblk",
+            "--json",
+            "--output",
+            "NAME,PATH,SIZE,TYPE,MOUNTPOINT,MODEL,SERIAL",
             "--tree",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -127,77 +137,31 @@ def _has_any_mountpoint(raw: dict) -> bool:
     return False
 
 
-# ---------------------------------------------------------------------------
-# DB-Zugriff
-# ---------------------------------------------------------------------------
-
-def _row_to_passthrough(r) -> PassthroughDisk:
-    return PassthroughDisk(
-        passthrough_id=r["passthrough_id"],
-        vm_id=r["vm_id"],
-        device_path=r["device_path"],
-        label=r["label"],
-        added_at=r["added_at"],
-    )
-
-
-def list_for_vm(vm_id: str) -> list[PassthroughDisk]:
-    with db() as conn:
-        rows = conn.execute(
-            "SELECT * FROM vm_passthrough_disks WHERE vm_id = ? ORDER BY added_at",
-            (vm_id,),
-        ).fetchall()
-    return [_row_to_passthrough(r) for r in rows]
-
-
-def list_all_paths() -> set[str]:
-    """Alle device_paths aller VMs — für lsblk-Overlay im Frontend."""
-    with db() as conn:
-        rows = conn.execute("SELECT device_path FROM vm_passthrough_disks").fetchall()
-    return {r["device_path"] for r in rows}
+list_for_vm = passthrough_db.list_for_vm
+list_all_paths = passthrough_db.list_all_paths
 
 
 async def add(vm_id: str, device_path: str, label: str | None = None) -> PassthroughDisk:
-    """Fügt ein Block-Device als Passthrough hinzu.
-
-    Validiert:
-    1. Pfad liegt unter /dev/
-    2. Ist ein Block-Device (Path.is_block_device)
-    3. Hat keinen aktiven Mountpoint (lsblk)
-    """
+    """Validate a host block device, attach it, and advance the VM generation."""
     _validate_path(device_path)
     await _assert_unmounted(device_path)
-
-    pid = uuid7()
-    ts = now_iso()
     try:
-        with db() as conn:
-            conn.execute(
-                """INSERT INTO vm_passthrough_disks (passthrough_id, vm_id, device_path, label, added_at)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (pid, vm_id, device_path, label, ts),
-            )
-    except Exception as e:
-        if "UNIQUE" in str(e):
+        return passthrough_db.insert(vm_id, device_path, label)
+    except Exception as exc:
+        if "UNIQUE" in str(exc):
             raise PassthroughError("already_attached", path=device_path)
         raise
-    return PassthroughDisk(passthrough_id=pid, vm_id=vm_id,
-                           device_path=device_path, label=label, added_at=ts)
 
 
 def remove(vm_id: str, passthrough_id: str) -> None:
-    with db() as conn:
-        result = conn.execute(
-            "DELETE FROM vm_passthrough_disks WHERE passthrough_id = ? AND vm_id = ?",
-            (passthrough_id, vm_id),
-        )
-    if result.rowcount == 0:
+    if not passthrough_db.remove(vm_id, passthrough_id):
         raise PassthroughError("not_found", passthrough_id=passthrough_id)
 
 
 # ---------------------------------------------------------------------------
 # Validation helpers
 # ---------------------------------------------------------------------------
+
 
 def _validate_path(device_path: str) -> None:
     p = Path(device_path).resolve()
@@ -212,7 +176,11 @@ def _validate_path(device_path: str) -> None:
 async def _assert_unmounted(device_path: str) -> None:
     try:
         proc = await asyncio.create_subprocess_exec(
-            "lsblk", "--json", "--output", "NAME,PATH,MOUNTPOINT", device_path,
+            "lsblk",
+            "--json",
+            "--output",
+            "NAME,PATH,MOUNTPOINT",
+            device_path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/core/src/hydrahive/vms/reconciler.py
+++ b/core/src/hydrahive/vms/reconciler.py
@@ -43,6 +43,8 @@ async def reconcile_once() -> None:
 
     active_tokens: set[str] = set()
     for vm in vms:
+        if vm.node_id != "local" or vm.runtime != "qemu":
+            continue
         if vm.actual_state not in ACTIVE_STATES:
             continue
         alive = _pid_alive(vm.pid)

--- a/core/tests/test_compute_local_dispatch.py
+++ b/core/tests/test_compute_local_dispatch.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.containers import lifecycle as container_lifecycle
+from hydrahive.containers import reconciler as container_reconciler
+from hydrahive.containers.incus_client import IncusError
+from hydrahive.containers.models import Container
+from hydrahive.vms import lifecycle as vm_lifecycle
+from hydrahive.vms import reconciler as vm_reconciler
+from hydrahive.vms.models import VM
+
+
+def _container(*, node_id: str = "local") -> Container:
+    return Container(
+        container_id="container-1",
+        owner="admin",
+        name="placed-container",
+        image="images:debian/12",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+    )
+
+
+def _vm(*, node_id: str = "local", runtime: str = "qemu") -> VM:
+    return VM(
+        vm_id="vm-1",
+        owner="admin",
+        name="placed-vm",
+        cpu=2,
+        ram_mb=2048,
+        disk_gb=20,
+        qcow2_path="/tmp/placed-vm.qcow2",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+        runtime=runtime,
+    )
+
+
+def test_container_reconciler_ignores_remote_resources(monkeypatch) -> None:
+    updates: list[tuple] = []
+
+    monkeypatch.setattr(container_reconciler.incus, "is_available", lambda: True)
+
+    async def running_names() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(container_reconciler.incus, "list_running_names", running_names)
+    monkeypatch.setattr(container_reconciler.cdb, "list_", lambda owner=None: [_container(node_id="node-a")])
+    monkeypatch.setattr(
+        container_reconciler.cdb, "update_state", lambda *args, **kwargs: updates.append((args, kwargs))
+    )
+
+    asyncio.run(container_reconciler.reconcile_once())
+
+    assert updates == []
+
+
+def test_vm_reconciler_ignores_nonlocal_or_non_qemu_resources(monkeypatch) -> None:
+    updates: list[tuple] = []
+    pid_checks: list[int | None] = []
+
+    monkeypatch.setattr(
+        vm_reconciler,
+        "list_vms",
+        lambda owner=None: [_vm(node_id="node-a"), _vm(runtime="incus")],
+    )
+    monkeypatch.setattr(vm_reconciler, "_pid_alive", lambda pid: pid_checks.append(pid) or False)
+    monkeypatch.setattr(vm_reconciler, "update_vm_state", lambda *args, **kwargs: updates.append((args, kwargs)))
+    monkeypatch.setattr(vm_reconciler.vnc, "cleanup_orphans", lambda tokens: None)
+
+    asyncio.run(vm_reconciler.reconcile_once())
+
+    assert pid_checks == []
+    assert updates == []
+
+
+def test_reconcilers_still_process_local_resources(monkeypatch) -> None:
+    container_updates: list[tuple] = []
+    vm_updates: list[tuple] = []
+
+    monkeypatch.setattr(container_reconciler.incus, "is_available", lambda: True)
+
+    async def running_names() -> set[str]:
+        return set()
+
+    monkeypatch.setattr(container_reconciler.incus, "list_running_names", running_names)
+    monkeypatch.setattr(container_reconciler.cdb, "list_", lambda owner=None: [_container()])
+    monkeypatch.setattr(
+        container_reconciler.cdb,
+        "update_state",
+        lambda *args, **kwargs: container_updates.append((args, kwargs)),
+    )
+    monkeypatch.setattr(vm_reconciler, "list_vms", lambda owner=None: [_vm()])
+    monkeypatch.setattr(vm_reconciler, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(
+        vm_reconciler,
+        "update_vm_state",
+        lambda *args, **kwargs: vm_updates.append((args, kwargs)),
+    )
+    monkeypatch.setattr(vm_reconciler.vnc, "cleanup_orphans", lambda tokens: None)
+
+    asyncio.run(container_reconciler.reconcile_once())
+    asyncio.run(vm_reconciler.reconcile_once())
+
+    assert len(container_updates) == 1
+    assert len(vm_updates) == 1
+
+
+@pytest.mark.parametrize("operation", ["create_and_start", "start", "stop", "restart_", "delete"])
+def test_container_local_lifecycle_rejects_remote_resources(monkeypatch, operation: str) -> None:
+    monkeypatch.setattr(container_lifecycle.cdb, "get", lambda container_id: _container(node_id="node-a"))
+
+    with pytest.raises(IncusError, match="container_not_local"):
+        asyncio.run(getattr(container_lifecycle, operation)("container-1"))
+
+
+@pytest.mark.parametrize("operation", ["start", "shutdown"])
+@pytest.mark.parametrize(("node_id", "runtime"), [("node-a", "qemu"), ("local", "incus")])
+def test_vm_local_lifecycle_rejects_remote_resources(monkeypatch, operation: str, node_id: str, runtime: str) -> None:
+    monkeypatch.setattr(
+        vm_lifecycle,
+        "get_vm",
+        lambda vm_id: _vm(node_id=node_id, runtime=runtime),
+    )
+
+    with pytest.raises(vm_lifecycle.VMLifecycleError, match="vm_not_local"):
+        asyncio.run(getattr(vm_lifecycle, operation)("vm-1"))

--- a/core/tests/test_compute_migration.py
+++ b/core/tests/test_compute_migration.py
@@ -8,11 +8,20 @@ from hydrahive.db.migrations import apply_migrations
 MIGRATIONS_DIR = Path(__file__).parents[1] / "src" / "hydrahive" / "db" / "migrations"
 
 
+def _migration_version(path: Path) -> int:
+    return int(path.name.split("_", 1)[0])
+
+
 def _apply_through_031(conn: sqlite3.Connection) -> None:
     for migration in sorted(MIGRATIONS_DIR.glob("*.sql")):
-        if migration.name.startswith("032_"):
-            continue
-        conn.executescript(migration.read_text())
+        if _migration_version(migration) <= 31:
+            conn.executescript(migration.read_text())
+
+
+def _apply_compute_migrations(conn: sqlite3.Connection) -> None:
+    for migration in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        if 32 <= _migration_version(migration) <= 39:
+            conn.executescript(migration.read_text())
 
 
 def test_migration_creates_compute_schema_and_local_node_once(tmp_path: Path) -> None:
@@ -100,6 +109,29 @@ def test_migration_creates_compute_schema_and_local_node_once(tmp_path: Path) ->
         conn.close()
 
 
+def test_compute_migrations_resume_after_legacy_columns_were_partially_applied(tmp_path: Path) -> None:
+    conn = sqlite3.connect(tmp_path / "partial.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_migrations(conn)
+        conn.execute("DELETE FROM schema_version WHERE version >= 33")
+        conn.execute("DROP INDEX idx_containers_node_id")
+        conn.execute("DROP INDEX idx_vms_node_id")
+        conn.execute("DROP TRIGGER compute_nodes_restrict_delete")
+        conn.commit()
+
+        apply_migrations(conn)
+
+        version = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        indexes = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'index'")}
+        triggers = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'trigger'")}
+        assert version >= 39
+        assert {"idx_containers_node_id", "idx_vms_node_id"} <= indexes
+        assert "compute_nodes_restrict_delete" in triggers
+    finally:
+        conn.close()
+
+
 def test_migration_backfills_existing_resources(tmp_path: Path) -> None:
     conn = sqlite3.connect(tmp_path / "backfill.db")
     conn.row_factory = sqlite3.Row
@@ -118,14 +150,17 @@ def test_migration_backfills_existing_resources(tmp_path: Path) -> None:
             ("vm-1", "owner", "existing-vm", 2, 2048, 20, "/tmp/vm.qcow2", "before", "before"),
         )
 
-        conn.executescript((MIGRATIONS_DIR / "032_compute_nodes.sql").read_text())
+        _apply_compute_migrations(conn)
 
         container = conn.execute(
             "SELECT node_id, generation FROM containers WHERE container_id = ?",
             ("container-1",),
         ).fetchone()
-        vm = conn.execute("SELECT node_id, generation FROM vms WHERE vm_id = ?", ("vm-1",)).fetchone()
+        vm = conn.execute(
+            "SELECT node_id, generation, runtime, runtime_ref FROM vms WHERE vm_id = ?",
+            ("vm-1",),
+        ).fetchone()
         assert tuple(container) == ("local", 0)
-        assert tuple(vm) == ("local", 0)
+        assert tuple(vm) == ("local", 0, "qemu", None)
     finally:
         conn.close()

--- a/core/tests/test_compute_migration.py
+++ b/core/tests/test_compute_migration.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from hydrahive.db.migrations import apply_migrations
+
+MIGRATIONS_DIR = Path(__file__).parents[1] / "src" / "hydrahive" / "db" / "migrations"
+
+
+def _apply_through_031(conn: sqlite3.Connection) -> None:
+    for migration in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        if migration.name.startswith("032_"):
+            continue
+        conn.executescript(migration.read_text())
+
+
+def test_migration_creates_compute_schema_and_local_node_once(tmp_path: Path) -> None:
+    database = tmp_path / "migration.db"
+    conn = sqlite3.connect(database)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_migrations(conn)
+        apply_migrations(conn)
+
+        tables = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        assert {
+            "compute_nodes",
+            "compute_enrollment_tokens",
+            "compute_jobs",
+            "compute_job_events",
+        } <= tables
+        expected_columns = {
+            "compute_nodes": {
+                "node_id",
+                "name",
+                "kind",
+                "status",
+                "certificate_fingerprint",
+                "protocol_version",
+                "agent_version",
+                "capabilities_json",
+                "resources_json",
+                "labels_json",
+                "last_seen_at",
+                "approved_at",
+                "approved_by",
+                "revoked_at",
+                "created_at",
+                "updated_at",
+            },
+            "compute_enrollment_tokens": {
+                "token_id",
+                "token_hmac",
+                "requested_name",
+                "expires_at",
+                "consumed_at",
+                "created_by",
+                "created_at",
+            },
+            "compute_jobs": {
+                "job_id",
+                "node_id",
+                "resource_kind",
+                "resource_id",
+                "operation",
+                "generation",
+                "payload_json",
+                "idempotency_key",
+                "status",
+                "lease_id",
+                "lease_until",
+                "attempts",
+                "progress",
+                "error_code",
+                "error_params_json",
+                "created_by",
+                "created_at",
+                "started_at",
+                "finished_at",
+            },
+            "compute_job_events": {
+                "event_id",
+                "job_id",
+                "sequence",
+                "event_type",
+                "data_json",
+                "created_at",
+            },
+        }
+        for table, columns in expected_columns.items():
+            actual = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+            assert actual == columns
+
+        local_nodes = conn.execute(
+            "SELECT node_id, name, kind, status FROM compute_nodes WHERE node_id = 'local'"
+        ).fetchall()
+        assert [tuple(row) for row in local_nodes] == [("local", "Local Host", "local", "online")]
+    finally:
+        conn.close()
+
+
+def test_migration_backfills_existing_resources(tmp_path: Path) -> None:
+    conn = sqlite3.connect(tmp_path / "backfill.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        _apply_through_031(conn)
+        conn.execute(
+            """INSERT INTO containers
+                   (container_id, owner, name, image, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("container-1", "owner", "existing-container", "images:debian/12", "before", "before"),
+        )
+        conn.execute(
+            """INSERT INTO vms
+                   (vm_id, owner, name, cpu, ram_mb, disk_gb, qcow2_path, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ("vm-1", "owner", "existing-vm", 2, 2048, 20, "/tmp/vm.qcow2", "before", "before"),
+        )
+
+        conn.executescript((MIGRATIONS_DIR / "032_compute_nodes.sql").read_text())
+
+        container = conn.execute(
+            "SELECT node_id, generation FROM containers WHERE container_id = ?",
+            ("container-1",),
+        ).fetchone()
+        vm = conn.execute("SELECT node_id, generation FROM vms WHERE vm_id = ?", ("vm-1",)).fetchone()
+        assert tuple(container) == ("local", 0)
+        assert tuple(vm) == ("local", 0)
+    finally:
+        conn.close()

--- a/core/tests/test_compute_nodes_db.py
+++ b/core/tests/test_compute_nodes_db.py
@@ -7,6 +7,7 @@ import pytest
 
 from hydrahive.compute import db as node_db
 from hydrahive.compute.models import MAX_NODE_JSON_BYTES, ComputeNode
+from hydrahive.containers import db as container_db
 from hydrahive.db.connection import init_db
 from hydrahive.settings import settings
 
@@ -66,12 +67,21 @@ def test_node_registry_validates_model_bounds(compute_db: Path, kwargs: dict[str
 
 
 def test_node_registry_updates_fields_and_validates_status_transitions(compute_db: Path) -> None:
-    node_db.create_node(node_id="node-a", name="Compute A")
+    node_db.create_node(
+        node_id="node-a",
+        name="Compute A",
+        certificate_fingerprint="ab" * 32,
+    )
 
+    with pytest.raises(ValueError, match="approval"):
+        node_db.transition_node_status("node-a", "online")
+    approved = node_db.approve_node("node-a", "admin")
+    assert approved is not None
+    assert approved.approved_at is not None
+    assert approved.approved_by == "admin"
     updated = node_db.update_node(
         "node-a",
         name="Compute Alpha",
-        status="online",
         agent_version="1.2.3",
         capabilities={"instances": ["container", "vm"]},
     )
@@ -81,7 +91,7 @@ def test_node_registry_updates_fields_and_validates_status_transitions(compute_d
     assert updated.agent_version == "1.2.3"
 
     with pytest.raises(ValueError, match="transition"):
-        node_db.update_node("node-a", status="pending")
+        node_db.transition_node_status("node-a", "pending")
 
 
 def test_node_registry_rejects_invalid_and_oversized_json(compute_db: Path) -> None:
@@ -103,7 +113,7 @@ def test_node_registry_persists_revoke_and_delete(compute_db: Path) -> None:
     assert revoked.status == "revoked"
     assert revoked.revoked_at is not None
     with pytest.raises(ValueError, match="transition"):
-        node_db.update_node("node-a", status="online")
+        node_db.transition_node_status("node-a", "online")
 
     node_db.create_node(node_id="node-b", name="Compute B")
     node_db.delete_node("node-b")
@@ -116,4 +126,41 @@ def test_local_node_cannot_be_deleted_or_revoked(compute_db: Path) -> None:
     with pytest.raises(ValueError, match="local"):
         node_db.revoke_node("local")
 
+    with pytest.raises(ValueError, match="local"):
+        node_db.transition_node_status("local", "offline")
+
     assert node_db.get_node("local") is not None
+
+
+def test_new_nodes_must_be_pending_and_fingerprints_are_canonical(compute_db: Path) -> None:
+    node_db.create_node(node_id="node-no-cert", name="No Certificate")
+    with pytest.raises(ValueError, match="certificate fingerprint"):
+        node_db.approve_node("node-no-cert", "admin")
+    node_db.transition_node_status("node-no-cert", "disabled")
+    with pytest.raises(ValueError, match="approval"):
+        node_db.transition_node_status("node-no-cert", "online")
+    with pytest.raises(ValueError, match="pending"):
+        node_db.create_node(node_id="node-online", name="Online", status="online")
+    with pytest.raises(ValueError, match="fingerprint"):
+        node_db.create_node(node_id="node-bad-cert", name="Bad Cert", certificate_fingerprint="invalid")
+
+    fingerprint = ":".join(["AB"] * 32)
+    node = node_db.create_node(
+        node_id="node-cert",
+        name="Certificate Node",
+        certificate_fingerprint=fingerprint,
+    )
+    assert node.certificate_fingerprint == "ab" * 32
+
+
+def test_node_with_placed_resources_cannot_be_deleted(compute_db: Path) -> None:
+    node_db.create_node(node_id="node-a", name="Compute A")
+    container_db.create(
+        owner="admin",
+        name="remote-container",
+        image="images:debian/12",
+        node_id="node-a",
+    )
+
+    with pytest.raises(ValueError, match="in use"):
+        node_db.delete_node("node-a")

--- a/core/tests/test_compute_nodes_db.py
+++ b/core/tests/test_compute_nodes_db.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hydrahive.compute import db as node_db
+from hydrahive.compute.models import MAX_NODE_JSON_BYTES, ComputeNode
+from hydrahive.db.connection import init_db
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def compute_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    database = tmp_path / "compute.db"
+    monkeypatch.setattr(settings, "sessions_db", database, raising=False)
+    init_db()
+    return database
+
+
+def test_node_registry_create_get_list_and_json_round_trip(compute_db: Path) -> None:
+    created = node_db.create_node(
+        node_id="node-a",
+        name="Compute A",
+        kind="agent",
+        status="pending",
+        protocol_version=1,
+        capabilities={"instances": ["container"]},
+        resources={"cpu_cores": 8},
+        labels={"zone": "lab"},
+    )
+
+    assert isinstance(created, ComputeNode)
+    assert node_db.get_node("node-a") == created
+    assert [node.node_id for node in node_db.list_nodes()] == ["local", "node-a"]
+    assert created.capabilities == {"instances": ["container"]}
+    assert created.resources == {"cpu_cores": 8}
+    assert created.labels == {"zone": "lab"}
+
+
+def test_node_registry_enforces_unique_names_and_reserved_local_identity(compute_db: Path) -> None:
+    node_db.create_node(node_id="node-a", name="Compute A")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        node_db.create_node(node_id="node-b", name="Compute A")
+    with pytest.raises(ValueError, match="reserved"):
+        node_db.create_node(node_id="local", name="Not Local")
+    with pytest.raises(ValueError, match="reserved"):
+        node_db.create_node(node_id="node-local", name="Another Local", kind="local")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"status": "unknown"}, "status"),
+        ({"kind": "unknown"}, "kind"),
+        ({"protocol_version": 0}, "protocol_version"),
+        ({"name": ""}, "name"),
+    ],
+)
+def test_node_registry_validates_model_bounds(compute_db: Path, kwargs: dict[str, object], message: str) -> None:
+    values = {"node_id": "node-a", "name": "Compute A"} | kwargs
+    with pytest.raises(ValueError, match=message):
+        node_db.create_node(**values)  # type: ignore[arg-type]
+
+
+def test_node_registry_updates_fields_and_validates_status_transitions(compute_db: Path) -> None:
+    node_db.create_node(node_id="node-a", name="Compute A")
+
+    updated = node_db.update_node(
+        "node-a",
+        name="Compute Alpha",
+        status="online",
+        agent_version="1.2.3",
+        capabilities={"instances": ["container", "vm"]},
+    )
+    assert updated is not None
+    assert updated.name == "Compute Alpha"
+    assert updated.status == "online"
+    assert updated.agent_version == "1.2.3"
+
+    with pytest.raises(ValueError, match="transition"):
+        node_db.update_node("node-a", status="pending")
+
+
+def test_node_registry_rejects_invalid_and_oversized_json(compute_db: Path) -> None:
+    with pytest.raises(ValueError, match="JSON"):
+        node_db.create_node(node_id="node-a", name="Compute A", labels={"bad": object()})
+
+    with pytest.raises(ValueError, match="too large"):
+        node_db.create_node(
+            node_id="node-b",
+            name="Compute B",
+            resources={"payload": "x" * MAX_NODE_JSON_BYTES},
+        )
+
+
+def test_node_registry_persists_revoke_and_delete(compute_db: Path) -> None:
+    node_db.create_node(node_id="node-a", name="Compute A")
+    revoked = node_db.revoke_node("node-a")
+    assert revoked is not None
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+    with pytest.raises(ValueError, match="transition"):
+        node_db.update_node("node-a", status="online")
+
+    node_db.create_node(node_id="node-b", name="Compute B")
+    node_db.delete_node("node-b")
+    assert node_db.get_node("node-b") is None
+
+
+def test_local_node_cannot_be_deleted_or_revoked(compute_db: Path) -> None:
+    with pytest.raises(ValueError, match="local"):
+        node_db.delete_node("local")
+    with pytest.raises(ValueError, match="local"):
+        node_db.revoke_node("local")
+
+    assert node_db.get_node("local") is not None

--- a/core/tests/test_compute_resource_placement.py
+++ b/core/tests/test_compute_resource_placement.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import asdict
+
+import pytest
+from fastapi import HTTPException
+
+from hydrahive.api.routes import containers_crud, vms_lifecycle
+from hydrahive.api.routes._container_helpers import ContainerCreate
+from hydrahive.api.routes._vm_lifecycle_schemas import VMCreate
+from hydrahive.compute import db as node_db
+from hydrahive.containers import db as cdb
+from hydrahive.containers.models import Container
+from hydrahive.vms import _passthrough_db as passthrough_db
+from hydrahive.vms import db as vmdb
+from hydrahive.vms.models import VM
+
+
+@pytest.fixture
+def resource_db(tmp_path, monkeypatch):
+    from hydrahive.db import init_db
+    from hydrahive.settings import settings
+
+    monkeypatch.setattr(settings, "sessions_db", tmp_path / "resources.db", raising=False)
+    init_db()
+
+
+def _container(*, node_id: str = "local") -> Container:
+    return Container(
+        container_id="container-1",
+        owner="admin",
+        name="placed-container",
+        image="images:debian/12",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+    )
+
+
+def _vm(*, node_id: str = "local", runtime: str = "qemu") -> VM:
+    return VM(
+        vm_id="vm-1",
+        owner="admin",
+        name="placed-vm",
+        cpu=2,
+        ram_mb=2048,
+        disk_gb=20,
+        qcow2_path="/tmp/placed-vm.qcow2",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+        runtime=runtime,
+    )
+
+
+def test_legacy_create_payloads_default_to_local() -> None:
+    container = ContainerCreate(name="container", image="debian/12")
+    vm = VMCreate(name="vm", cpu=1, ram_mb=512, disk_gb=5)
+
+    assert container.node_id == "local"
+    assert vm.node_id == "local"
+
+
+@pytest.mark.parametrize(
+    ("route", "payload", "db_module"),
+    [
+        (
+            containers_crud.create_container,
+            ContainerCreate(name="remote-container", image="debian/12", node_id="node-a"),
+            containers_crud.cdb,
+        ),
+        (
+            vms_lifecycle.create_vm,
+            VMCreate(name="remote-vm", cpu=1, ram_mb=512, disk_gb=5, node_id="node-a"),
+            vms_lifecycle.vmdb,
+        ),
+    ],
+)
+def test_create_routes_reject_remote_before_local_creation(monkeypatch, route, payload, db_module) -> None:
+    create_name = "create" if db_module is containers_crud.cdb else "create_vm"
+    monkeypatch.setattr(
+        db_module,
+        create_name,
+        lambda *args, **kwargs: pytest.fail("remote payload reached local persistence/execution path"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(route(payload, ("admin", "admin")))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_resource_serialization_includes_placement_and_runtime() -> None:
+    container = asdict(_container(node_id="node-a"))
+    vm = asdict(_vm(node_id="node-b", runtime="incus"))
+
+    assert (container["node_id"], container["generation"]) == ("node-a", 0)
+    assert (vm["node_id"], vm["generation"], vm["runtime"], vm["runtime_ref"]) == (
+        "node-b",
+        0,
+        "incus",
+        None,
+    )
+
+
+def test_container_db_mapper_persists_placement(resource_db) -> None:
+    node_db.create_node(node_id="node-a", name="Node A")
+    container = cdb.create(
+        owner="admin",
+        name="remote-container",
+        image="images:debian/12",
+        node_id="node-a",
+    )
+
+    assert (container.node_id, container.generation) == ("node-a", 0)
+
+
+def test_vm_db_mapper_persists_placement_and_runtime(resource_db) -> None:
+    node_db.create_node(node_id="node-a", name="Node A")
+    vm = vmdb.create_vm(
+        owner="admin",
+        name="remote-vm",
+        cpu=2,
+        ram_mb=2048,
+        disk_gb=20,
+        qcow2_path="",
+        node_id="node-a",
+        runtime="incus",
+        runtime_ref="instance-1",
+    )
+
+    assert (vm.node_id, vm.generation, vm.runtime, vm.runtime_ref) == (
+        "node-a",
+        0,
+        "incus",
+        "instance-1",
+    )
+
+
+def test_resource_placement_rejects_unknown_nodes_and_runtime_mismatches(resource_db) -> None:
+    with pytest.raises(sqlite3.IntegrityError, match="compute_node_not_found"):
+        cdb.create(owner="admin", name="orphan", image="images:debian/12", node_id="missing")
+    with pytest.raises(ValueError, match="local VMs require qemu"):
+        vmdb.create_vm(
+            owner="admin",
+            name="invalid-runtime",
+            cpu=1,
+            ram_mb=512,
+            disk_gb=5,
+            qcow2_path="",
+            runtime="incus",
+        )
+
+
+def test_resource_mutations_increment_generation(resource_db) -> None:
+    container = cdb.create(owner="admin", name="container", image="images:debian/12")
+    vm = vmdb.create_vm(owner="admin", name="vm", cpu=1, ram_mb=512, disk_gb=5, qcow2_path="")
+
+    cdb.update_container_config(container.container_id, description="changed")
+    cdb.update_state(container.container_id, desired="running")
+    vmdb.update_vm_config(vm.vm_id, description="changed")
+    vmdb.update_vm_state(vm.vm_id, desired="running")
+
+    assert cdb.get(container.container_id).generation == 2
+    assert vmdb.get_vm(vm.vm_id).generation == 2
+
+
+def test_passthrough_mutations_increment_vm_generation(resource_db) -> None:
+    vm = vmdb.create_vm(owner="admin", name="vm", cpu=1, ram_mb=512, disk_gb=5, qcow2_path="")
+
+    disk = passthrough_db.insert(vm.vm_id, "/dev/fake", "test")
+    assert vmdb.get_vm(vm.vm_id).generation == 1
+
+    assert passthrough_db.remove(vm.vm_id, disk.passthrough_id) is True
+    assert vmdb.get_vm(vm.vm_id).generation == 2

--- a/core/tests/test_compute_route_guards.py
+++ b/core/tests/test_compute_route_guards.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from hydrahive.api.routes import (
+    container_console,
+    containers_ops,
+    vms_ops,
+    vms_passthrough,
+    vms_snapshots,
+    vms_vnc,
+)
+from hydrahive.containers.models import Container
+from hydrahive.vms.models import VM
+
+
+def _container(*, node_id: str = "local") -> Container:
+    return Container(
+        container_id="container-1",
+        owner="admin",
+        name="placed-container",
+        image="images:debian/12",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+    )
+
+
+def _vm(*, node_id: str = "local", runtime: str = "qemu") -> VM:
+    return VM(
+        vm_id="vm-1",
+        owner="admin",
+        name="placed-vm",
+        cpu=2,
+        ram_mb=2048,
+        disk_gb=20,
+        qcow2_path="/tmp/placed-vm.qcow2",
+        network_mode="bridged",
+        desired_state="running",
+        actual_state="running",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        node_id=node_id,
+        runtime=runtime,
+    )
+
+
+@pytest.mark.parametrize(
+    ("route", "incus_operation"),
+    [
+        (containers_ops.container_log, "show_log"),
+        (containers_ops.container_config, "show_config"),
+        (containers_ops.container_info, "info"),
+    ],
+)
+def test_container_inspection_routes_reject_remote_before_incus(monkeypatch, route, incus_operation: str) -> None:
+    monkeypatch.setattr(
+        containers_ops,
+        "container_or_404",
+        lambda *args: _container(node_id="node-a"),
+    )
+
+    async def fail_local_call(*args, **kwargs):
+        pytest.fail("remote container reached local Incus")
+
+    monkeypatch.setattr(containers_ops.incus, incus_operation, fail_local_call)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(route("container-1", ("admin", "admin")))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_container_console_rejects_remote_before_session_start(monkeypatch) -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.closed: tuple[int, str | None] | None = None
+
+        async def close(self, code: int, reason: str | None = None) -> None:
+            self.closed = (code, reason)
+
+        async def accept(self) -> None:
+            pytest.fail("remote container console was accepted")
+
+    websocket = FakeWebSocket()
+    monkeypatch.setattr(container_console, "_authenticate", lambda token: ("admin", "admin"))
+    monkeypatch.setattr(
+        container_console.cdb,
+        "get",
+        lambda container_id: _container(node_id="node-a"),
+    )
+
+    asyncio.run(container_console.container_console(websocket, "container-1", "token"))
+
+    assert websocket.closed == (4409, "container_not_local")
+
+
+@pytest.mark.parametrize(
+    ("module", "route"),
+    [
+        (vms_ops, vms_ops.vm_stats),
+        (vms_ops, vms_ops.vm_log),
+        (vms_vnc, vms_vnc.vnc_info),
+    ],
+)
+def test_vm_local_data_routes_reject_remote(monkeypatch, module, route) -> None:
+    monkeypatch.setattr(module, "vm_or_404", lambda *args: _vm(node_id="node-a", runtime="incus"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        route("vm-1", ("admin", "admin"))
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("route", [vms_ops.stop_vm, vms_ops.poweroff_vm])
+def test_vm_stop_routes_return_coded_error_for_remote(monkeypatch, route) -> None:
+    monkeypatch.setattr(
+        vms_ops,
+        "vm_or_404",
+        lambda *args: _vm(node_id="node-a", runtime="incus"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(route("vm-1", ("admin", "admin")))
+
+    assert exc_info.value.status_code == 400
+
+
+def test_vm_snapshot_and_passthrough_routes_reject_remote_before_local_io(monkeypatch) -> None:
+    remote = _vm(node_id="node-a", runtime="incus")
+    monkeypatch.setattr(vms_snapshots, "vm_or_404", lambda *args: remote)
+    monkeypatch.setattr(vms_passthrough, "vm_or_404", lambda *args: remote)
+
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            vms_snapshots.create_snapshot(
+                "vm-1",
+                vms_snapshots.SnapshotCreate(name="snapshot"),
+                ("admin", "admin"),
+            )
+        )
+    with pytest.raises(HTTPException):
+        asyncio.run(
+            vms_passthrough.add_passthrough_disk(
+                "vm-1",
+                vms_passthrough.AddPassthroughBody(device_path="/dev/fake"),
+                ("admin", "admin"),
+            )
+        )

--- a/docs/specs/compute-cluster-v1-plan.md
+++ b/docs/specs/compute-cluster-v1-plan.md
@@ -1,0 +1,291 @@
+# Plan: HydraHive Compute Cluster V1
+
+## Ziel
+
+HydraHive verwaltet neben dem lokalen Host freigegebene Ubuntu-Compute-Nodes mit ausgehend verbundenem Node Agent und Incus. V1 liefert manuelle, feste Platzierung, Remote-Container und imagebasierte Remote-VMs ohne Live-Migration oder automatisches Failover.
+
+Verbindliche Grundlage: `docs/specs/compute-cluster-v1.md`.
+
+## Lieferstrategie
+
+Die Umsetzung erfolgt in getrennten, jeweils produktionsfähigen PRs. Kein PR darf bestehende lokale Container oder QEMU-VMs brechen.
+
+1. P1 — Compute-Node-Datenmodell und lokale Kompatibilität
+2. P2 — Enrollment, Identität und read-only Agentkanal
+3. P3 — Persistente Compute-Jobs
+4. P4 — Remote-Container
+5. P5 — Node-/Job-Frontend
+6. P6 — Imagebasierte Remote-VMs
+7. P7 — Console-Proxy, Hardening und V1-Abschluss
+
+## Neue Hauptbereiche
+
+### Master Backend
+
+- `core/src/hydrahive/compute/models.py` — Node-, Enrollment-, Job- und Eventtypen.
+- `core/src/hydrahive/compute/db.py` — parametrisierter Datenzugriff.
+- `core/src/hydrahive/compute/enrollment.py` — Token/HMAC, CSR, Zertifikat und Freigabe.
+- `core/src/hydrahive/compute/identity.py` — Compute-CA, Fingerprints, Signatur und Widerruf.
+- `core/src/hydrahive/compute/protocol.py` — versionierte Agentnachrichten.
+- `core/src/hydrahive/compute/jobs.py` — Jobzustandsmaschine, Lease und Idempotenz.
+- `core/src/hydrahive/compute/agent_channel.py` — authentisierter Agentkanal.
+- `core/src/hydrahive/compute/capabilities.py` — Capability-/Health-Normalisierung.
+- `core/src/hydrahive/api/routes/compute_nodes.py` — Admin-Node-API.
+- `core/src/hydrahive/api/routes/compute_jobs.py` — Admin-/User-Job-API.
+- `core/src/hydrahive/api/routes/compute_agent.py` — Enrollment und Agentkanal.
+- `core/src/hydrahive/db/migrations/032_compute_nodes.sql` — additive Clusterbasis.
+
+### Node Agent
+
+- `node-agent/pyproject.toml` — separates minimales Paket und CLI-Entrypoint.
+- `node-agent/src/hydrahive_node_agent/config.py` — restriktive Konfiguration.
+- `node-agent/src/hydrahive_node_agent/identity.py` — Schlüssel, CSR und Zertifikate.
+- `node-agent/src/hydrahive_node_agent/enroll.py` — Enrollment-CLI.
+- `node-agent/src/hydrahive_node_agent/client.py` — Reconnect-/ACK-Agentkanal.
+- `node-agent/src/hydrahive_node_agent/capabilities.py` — Host-/Incus-/KVM-Inventar.
+- `node-agent/src/hydrahive_node_agent/jobs.py` — lokale Idempotenz und Dispatcher.
+- `node-agent/src/hydrahive_node_agent/incus.py` — allowlisteter Incus-CLI-Adapter.
+- `node-agent/src/hydrahive_node_agent/main.py` — systemd-Prozess.
+- `installer/lib/node_agent.sh` — Installation, Benutzer, Rechte und systemd-Unit.
+
+### Frontend
+
+- `frontend/src/features/nodes/api.ts`
+- `frontend/src/features/nodes/types.ts`
+- `frontend/src/features/nodes/NodeStatusBadge.tsx`
+- `frontend/src/features/nodes/NodeSelector.tsx`
+- `frontend/src/features/cockpit/admin/NodesOverlay.tsx`
+- `frontend/src/features/cockpit/admin/NodeDetailOverlay.tsx`
+- `frontend/src/features/cockpit/admin/JobsOverlay.tsx`
+- `frontend/src/features/cockpit/admin/adminOverlayRegistry.ts`
+- bestehende Container-/VM-Create-Dialoge, Karten und Overlays.
+
+## Implementierungsreihenfolge
+
+## P1 — Compute-Node-Datenmodell und lokale Kompatibilität
+
+### Task 1.1: Migration und Modelle
+
+- [ ] Test schreiben: Migration erzeugt `compute_nodes`, `compute_enrollment_tokens`, `compute_jobs`, `compute_job_events`.
+- [ ] Test schreiben: `local` wird genau einmal angelegt.
+- [ ] Test schreiben: bestehende VMs/Container erhalten `node_id='local'` und `generation=0`.
+- [ ] Tests RED ausführen.
+- [ ] `032_compute_nodes.sql` additiv implementieren.
+- [ ] `compute/models.py` mit strikten Status-Literalen und Grenzen implementieren.
+- [ ] Tests GREEN ausführen.
+- [ ] Commit: `feat(compute): add node and job schema`.
+
+### Task 1.2: Node-Repository
+
+- [ ] Tests für Create/List/Get/Update, eindeutige Namen, Statusübergänge und JSON-Grenzen schreiben.
+- [ ] Tests RED.
+- [ ] `compute/db.py` mit ausschließlich parametrisierten Queries implementieren.
+- [ ] Reservierten `local`-Node gegen Delete/Revoke schützen.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(compute): add node registry persistence`.
+
+### Task 1.3: Bestehende Ressourcen nodefähig machen
+
+- [ ] Tests für Container-/VM-Serialisierung mit `node_id` schreiben.
+- [ ] Tests sichern, dass alte Create-Payloads ohne `node_id` lokal bleiben.
+- [ ] Dataclasses, DB-Mapper und API-Typen additiv erweitern.
+- [ ] Reconciler filtern strikt `node_id='local'`, damit Remote-Ressourcen nie lokal ausgeführt werden.
+- [ ] Bestehende Container-/VM-Suite GREEN.
+- [ ] Commit: `feat(compute): bind resources to local node`.
+
+**P1-Akzeptanz:** Alle Bestandsressourcen verhalten sich unverändert; API-Antworten enthalten zusätzlich den lokalen Node.
+
+## P2 — Enrollment, Identität und read-only Agentkanal
+
+### Task 2.1: Compute-CA und Enrollment-Token
+
+- [ ] Tests für 256-Bit-Token, HMAC-at-rest, TTL, Einmalverbrauch und generische Fehler schreiben.
+- [ ] Tests für sichere CA-Key-Dateirechte und stabile Fingerprints schreiben.
+- [ ] Tests RED.
+- [ ] `identity.py` und `enrollment.py` implementieren.
+- [ ] Keine privaten Schlüssel oder Tokens loggen.
+- [ ] Tests GREEN.
+- [ ] Security-Review.
+- [ ] Commit: `feat(compute): add secure node enrollment`.
+
+### Task 2.2: Enrollment-/Node-API
+
+- [ ] Auth-/Admin-/Rate-Limit-Tests schreiben.
+- [ ] Tests für pending → approved, disable und revoke schreiben.
+- [ ] Tests RED.
+- [ ] `compute_nodes.py` und öffentlichen, begrenzten Enroll-Endpunkt implementieren.
+- [ ] Audit für Token-Erzeugung, Enrollment, Approve und Revoke.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(compute): expose node administration api`.
+
+### Task 2.3: Minimales Agentpaket
+
+- [ ] Agenttests für Config-Dateirechte, Enrollment, Serverzertifikatprüfung und Fingerprintanzeige schreiben.
+- [ ] Tests RED.
+- [ ] Separates `node-agent`-Paket implementieren.
+- [ ] `hydrahive-node enroll` und `hydrahive-node run` bereitstellen.
+- [ ] systemd-Unit und Installer implementieren.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(node-agent): add enrollment and service`.
+
+### Task 2.4: Heartbeat und Capabilities
+
+- [ ] Protokolltests für Version, Sequenz, Nonce, Node-Bindung und Schemafehler schreiben.
+- [ ] Tests für online/degraded/offline und Dead-Detection schreiben.
+- [ ] Tests RED.
+- [ ] Agentkanal mit Reconnect/Jitter und read-only Heartbeats implementieren.
+- [ ] CPU/RAM/Storage/Incus/KVM-Capabilities implementieren.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(compute): connect node agent heartbeats`.
+
+**P2-Akzeptanz:** Ein neuer Ubuntu-Node kann sicher gekoppelt, freigegeben, angezeigt und widerrufen werden; noch keine Workloads.
+
+## P3 — Persistente Compute-Jobs
+
+### Task 3.1: Jobzustandsmaschine
+
+- [ ] Tests für erlaubte Übergänge, atomaren Claim, Lease, Timeout und Cancel schreiben.
+- [ ] Tests für doppelte Resultate und Idempotency-Key schreiben.
+- [ ] Tests RED.
+- [ ] `compute/jobs.py` und Event-Persistenz implementieren.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(compute): add durable job state machine`.
+
+### Task 3.2: Signierte Jobs und Agentdispatcher
+
+- [ ] Tests für manipulierte Signatur, falsche Node-ID, alte Generation und Ablauf schreiben.
+- [ ] Tests RED.
+- [ ] kanonische Job-Signatur auf Master und Prüfung im Agent implementieren.
+- [ ] Agent persistiert lokale Idempotency-Keys.
+- [ ] Nur typisierte Operationen; unbekannte Operation fail-closed.
+- [ ] Tests GREEN.
+- [ ] Security-Review.
+- [ ] Commit: `feat(node-agent): execute signed compute jobs`.
+
+### Task 3.3: Job-API
+
+- [ ] Ownership-/Admin-/Filter-/Cancel-Tests schreiben.
+- [ ] Tests RED.
+- [ ] `compute_jobs.py` implementieren.
+- [ ] Ausgabe strikt begrenzen und keine Payload-Secrets zurückgeben.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(compute): expose job status api`.
+
+**P3-Akzeptanz:** Ein Testjob übersteht Agent-Reconnect ohne doppelte Ausführung und besitzt vollständigen Auditverlauf.
+
+## P4 — Remote-Container
+
+### Task 4.1: Incus-Allowlist im Agent
+
+- [ ] Tests für Name/Image/CPU/RAM/Netzwerk-Validierung und Flag-Injection schreiben.
+- [ ] Tests für create/start/stop/restart/delete/inspect schreiben, Incus mocken.
+- [ ] Tests RED.
+- [ ] `node-agent/.../incus.py` mit `create_subprocess_exec` und festen argv implementieren.
+- [ ] Output-, Zeit- und Parallelitätslimits implementieren.
+- [ ] Tests GREEN.
+- [ ] Security-Review.
+- [ ] Commit: `feat(node-agent): manage incus containers`.
+
+### Task 4.2: Container-Execution-Routing
+
+- [ ] Tests schreiben: local nutzt bisherigen Pfad, agent erzeugt Job, offline wird abgelehnt.
+- [ ] Reconciler-Test: Remote-Container wird nie lokal inspiziert/gestartet.
+- [ ] Tests RED.
+- [ ] lokalen und Agent-Execution-Adapter einführen.
+- [ ] Create/Lifecycle-Routen nodefähig machen.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(containers): route workloads to compute nodes`.
+
+**P4-Akzeptanz:** Ein Remote-Container kann über HydraHive vollständig verwaltet werden; lokale Container bleiben kompatibel.
+
+## P5 — Node-/Job-Frontend
+
+### Task 5.1: Nodes-Overlay
+
+- [ ] API-/Mappertests und Komponentenfälle pending/online/degraded/offline/revoked schreiben.
+- [ ] NodesOverlay, Detail, Enrollment und Fingerprint-Approve implementieren.
+- [ ] Admin-Registry und Help ergänzen.
+- [ ] Frontend-Typecheck/Build GREEN.
+- [ ] Commit: `feat(admin): add compute node cockpit`.
+
+### Task 5.2: Job-Overlay
+
+- [ ] Zustands-/Fortschritts-/Fehlerfälle testen.
+- [ ] JobsOverlay und Jobdetail implementieren.
+- [ ] Cancel nur in zulässigen Zuständen anbieten.
+- [ ] Build GREEN.
+- [ ] Commit: `feat(admin): add compute job monitoring`.
+
+### Task 5.3: Container-Node-Auswahl
+
+- [ ] NodeSelector-Fälle online/offline/ungeeignet testen.
+- [ ] CreateContainerDialog um Pflichtauswahl mit Default `local` erweitern.
+- [ ] Karten/Details um Node-Badge ergänzen.
+- [ ] Build GREEN.
+- [ ] Commit: `feat(containers): select target compute node`.
+
+## P6 — Imagebasierte Remote-VMs
+
+### Task 6.1: Incus-VM-Operationen
+
+- [ ] Agenttests für KVM-Capability und `--vm`-Erstellung schreiben.
+- [ ] create/start/stop/restart/delete/inspect implementieren.
+- [ ] ISO, Import, Hostpfade und Passthrough auf Agent-Nodes explizit ablehnen.
+- [ ] Tests GREEN.
+- [ ] Commit: `feat(node-agent): manage incus virtual machines`.
+
+### Task 6.2: VM-Execution-Routing
+
+- [ ] Tests local QEMU vs. remote Incus schreiben.
+- [ ] VM-Modelle um `runtime`/`runtime_ref` erweitern.
+- [ ] Remote-Lifecycle und Snapshots nodegebunden implementieren.
+- [ ] Reconciler filtert strikt nach Node/Runtime.
+- [ ] Bestehende VM-Suite GREEN.
+- [ ] Commit: `feat(vms): route image vms to compute nodes`.
+
+### Task 6.3: VM-Frontend
+
+- [ ] NodeSelector und Capability-Erklärung integrieren.
+- [ ] Auf Agent-Nodes ausschließlich kuratierte Images anbieten.
+- [ ] ISO/Import/Passthrough disabled mit verständlicher Begründung.
+- [ ] Node-Badge und Offline-Semantik ergänzen.
+- [ ] Build GREEN.
+- [ ] Commit: `feat(vms): select target compute node`.
+
+## P7 — Console-Proxy und V1-Abschluss
+
+### Task 7.1: Ressourcengebundene Console-Tickets
+
+- [ ] Auth-, Ownership-, TTL-, Einmal- und Origin-Tests schreiben.
+- [ ] Keine direkten Node-Ports; binärer Stream über authentisierten Master-Proxy.
+- [ ] Revoke/Disconnect trennt Sessions.
+- [ ] Security-Review und Tests GREEN.
+- [ ] Commit: `feat(compute): proxy remote instance consoles`.
+
+### Task 7.2: Hardening und Updatepfad
+
+- [ ] Revocation-E2E-Test.
+- [ ] kompromittierter/falscher Node kann keine fremden Jobs lesen.
+- [ ] signiertes Agent-Update-Manifest und Hashprüfung implementieren.
+- [ ] Last-/Reconnect-/Lease-Tests.
+- [ ] Auditprüfung.
+- [ ] Commit: `feat(node-agent): harden revocation and updates`.
+
+### Task 7.3: Abschluss
+
+- [ ] vollständige Backend-, Agent- und Frontendtests.
+- [ ] Installer-Test auf frischem Ubuntu-Node.
+- [ ] realer E2E-Test mit einem separaten Compute-Node.
+- [ ] Security-Audit ohne Critical/High-Findings.
+- [ ] Betriebs-, Recovery- und Deinstallationsdoku.
+- [ ] PRs mergen und Tasks schließen.
+
+## Globale Akzeptanzkriterien
+
+- [ ] Kein Remote-Agent akzeptiert freie Shell-Befehle.
+- [ ] Jeder Node hat eine eigene widerrufbare Identität.
+- [ ] Bestehende lokale Instanzen funktionieren ohne manuelle Migration.
+- [ ] Jobs sind persistent, idempotent und auditierbar.
+- [ ] Node-Ausfall wird korrekt dargestellt und löst keine Doppelstarts aus.
+- [ ] Remote-Container und imagebasierte Remote-VMs sind über HydraHive steuerbar.
+- [ ] Keine Live-Migration, kein HA und kein automatischer Scheduler in V1.

--- a/docs/specs/compute-cluster-v1-plan.md
+++ b/docs/specs/compute-cluster-v1-plan.md
@@ -33,7 +33,7 @@ Die Umsetzung erfolgt in getrennten, jeweils produktionsfähigen PRs. Kein PR da
 - `core/src/hydrahive/api/routes/compute_nodes.py` — Admin-Node-API.
 - `core/src/hydrahive/api/routes/compute_jobs.py` — Admin-/User-Job-API.
 - `core/src/hydrahive/api/routes/compute_agent.py` — Enrollment und Agentkanal.
-- `core/src/hydrahive/db/migrations/032_compute_nodes.sql` — additive Clusterbasis.
+- `core/src/hydrahive/db/migrations/032_compute_nodes.sql` bis `039_compute_placement_integrity.sql` — additive, wiederaufnehmbare Clusterbasis.
 
 ### Node Agent
 
@@ -66,32 +66,32 @@ Die Umsetzung erfolgt in getrennten, jeweils produktionsfähigen PRs. Kein PR da
 
 ### Task 1.1: Migration und Modelle
 
-- [ ] Test schreiben: Migration erzeugt `compute_nodes`, `compute_enrollment_tokens`, `compute_jobs`, `compute_job_events`.
-- [ ] Test schreiben: `local` wird genau einmal angelegt.
-- [ ] Test schreiben: bestehende VMs/Container erhalten `node_id='local'` und `generation=0`.
-- [ ] Tests RED ausführen.
-- [ ] `032_compute_nodes.sql` additiv implementieren.
-- [ ] `compute/models.py` mit strikten Status-Literalen und Grenzen implementieren.
-- [ ] Tests GREEN ausführen.
-- [ ] Commit: `feat(compute): add node and job schema`.
+- [x] Test schreiben: Migration erzeugt `compute_nodes`, `compute_enrollment_tokens`, `compute_jobs`, `compute_job_events`.
+- [x] Test schreiben: `local` wird genau einmal angelegt.
+- [x] Test schreiben: bestehende VMs/Container erhalten `node_id='local'` und `generation=0`.
+- [x] Tests RED ausführen.
+- [x] Migrationsserie `032` bis `039` additiv und nach Teilfehlern wiederaufnehmbar implementieren.
+- [x] `compute/models.py` mit strikten Status-Literalen und Grenzen implementieren.
+- [x] Tests GREEN ausführen.
+- [x] Commit: `feat(compute): add node and job schema`.
 
 ### Task 1.2: Node-Repository
 
-- [ ] Tests für Create/List/Get/Update, eindeutige Namen, Statusübergänge und JSON-Grenzen schreiben.
-- [ ] Tests RED.
-- [ ] `compute/db.py` mit ausschließlich parametrisierten Queries implementieren.
-- [ ] Reservierten `local`-Node gegen Delete/Revoke schützen.
-- [ ] Tests GREEN.
-- [ ] Commit: `feat(compute): add node registry persistence`.
+- [x] Tests für Create/List/Get/Update, eindeutige Namen, Statusübergänge und JSON-Grenzen schreiben.
+- [x] Tests RED.
+- [x] `compute/db.py` mit ausschließlich parametrisierten Queries implementieren.
+- [x] Reservierten `local`-Node gegen Delete/Revoke schützen.
+- [x] Tests GREEN.
+- [x] Commit: `feat(compute): add node registry persistence`.
 
 ### Task 1.3: Bestehende Ressourcen nodefähig machen
 
-- [ ] Tests für Container-/VM-Serialisierung mit `node_id` schreiben.
-- [ ] Tests sichern, dass alte Create-Payloads ohne `node_id` lokal bleiben.
-- [ ] Dataclasses, DB-Mapper und API-Typen additiv erweitern.
-- [ ] Reconciler filtern strikt `node_id='local'`, damit Remote-Ressourcen nie lokal ausgeführt werden.
-- [ ] Bestehende Container-/VM-Suite GREEN.
-- [ ] Commit: `feat(compute): bind resources to local node`.
+- [x] Tests für Container-/VM-Serialisierung mit `node_id` schreiben.
+- [x] Tests sichern, dass alte Create-Payloads ohne `node_id` lokal bleiben.
+- [x] Dataclasses, DB-Mapper und API-Typen additiv erweitern.
+- [x] Reconciler filtern strikt `node_id='local'`, damit Remote-Ressourcen nie lokal ausgeführt werden.
+- [x] Bestehende Container-/VM-Suite GREEN.
+- [x] Commit: `feat(compute): bind resources to local node`.
 
 **P1-Akzeptanz:** Alle Bestandsressourcen verhalten sich unverändert; API-Antworten enthalten zusätzlich den lokalen Node.
 

--- a/docs/specs/compute-cluster-v1.md
+++ b/docs/specs/compute-cluster-v1.md
@@ -1,0 +1,404 @@
+# HydraHive Compute Cluster V1 — Node Agent + Incus
+
+Status: **Design freigegeben**
+
+Datum: 2026-07-19
+
+## 1. Was
+
+HydraHive wird um ein zentrales Compute-Control-Plane erweitert. Eine HydraHive-Hauptinstallation verwaltet mehrere Ubuntu-Server, auf denen ausschließlich ein schlanker HydraHive Node Agent und Incus laufen. Von der bestehenden HydraHive-Oberfläche aus können Administratoren Container und virtuelle Maschinen auf einem ausgewählten Compute-Node erstellen und verwalten.
+
+V1 verwendet eine **manuelle Node-Auswahl** und eine **feste Platzierung**. Es gibt keine Live-Migration, kein automatisches Failover und keine automatische Lastverteilung.
+
+## 2. Warum
+
+Container und VMs werden heute implizit auf dem HydraHive-Host ausgeführt:
+
+- Container über die lokale `incus`-CLI (`core/src/hydrahive/containers/incus_client.py`).
+- VMs als lokale QEMU-Prozesse (`core/src/hydrahive/vms/lifecycle.py`).
+
+Dadurch sind CPU, RAM und Storage an einen einzelnen Host gebunden. Compute-Nodes sollen zusätzliche Kapazität bereitstellen, ohne auf jedem Node eine vollständige HydraHive-Installation betreiben zu müssen.
+
+## 3. Verbindliche Architekturentscheidungen
+
+### 3.1 Control Plane und Worker
+
+- Die bestehende HydraHive-Installation ist das einzige Control Plane.
+- Worker sind normale Ubuntu-Server mit `hydrahive-node-agent` und Incus.
+- Der Agent baut Verbindungen ausschließlich **ausgehend** zum Master auf.
+- Auf Worker-Nodes wird keine HydraHive-Weboberfläche, keine LLM-Runtime und keine Projektdatenbank installiert.
+- Der Master öffnet keine SSH-Sitzungen zu Nodes und führt dort keine freien Shell-Befehle aus.
+
+### 3.2 Runtime
+
+- Remote-Container laufen als Incus-Container.
+- Remote-VMs laufen als Incus-VMs (`incus ... --vm`) mit KVM.
+- Bestehende lokale Container bleiben über den bisherigen Incus-Pfad lauffähig.
+- Bestehende lokale VMs bleiben in V1 über den bisherigen direkten QEMU-Pfad lauffähig.
+- Der bestehende Host wird als reservierter Compute-Node `local` modelliert.
+
+### 3.3 Platzierung
+
+- Jede VM und jeder Container besitzt genau ein `node_id`.
+- Bestehende Ressourcen werden auf `node_id='local'` migriert.
+- Die Platzierung ändert sich in V1 nach der Erstellung nicht.
+- Ein Node-Ausfall ändert den Ressourcenstatus nicht künstlich zu `stopped`; die UI zeigt zusätzlich den Node als `offline`.
+
+### 3.4 V1-Grenze
+
+V1 unterstützt keine:
+
+- Live-Migration;
+- automatische Neuplatzierung oder Hochverfügbarkeit;
+- automatische Node-Auswahl;
+- Shared-Storage-Orchestrierung;
+- Ceph-Verwaltung;
+- Cross-Node-Snapshots oder Backups;
+- Remote-PCI-/USB-/Block-Device-Passthroughs;
+- freie Remote-Shell;
+- Docker-Socket-, libvirt- oder Incus-API-Freigabe im Netzwerk.
+
+## 4. Komponenten
+
+```text
+┌─────────────────────────────────────────────────────┐
+│ HydraHive Master                                    │
+│                                                     │
+│ Admin-UI · Node Registry · Job Queue · Audit · DB   │
+└───────────────────────┬─────────────────────────────┘
+                        │ ausgehender, gegenseitig
+                        │ authentisierter Agentkanal
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+┌────────────────┐ ┌────────────────┐ ┌────────────────┐
+│ Compute Node A │ │ Compute Node B │ │ Compute Node C │
+│ Node Agent     │ │ Node Agent     │ │ Node Agent     │
+│ Incus          │ │ Incus          │ │ Incus          │
+│ Container/VMs  │ │ Container/VMs  │ │ Container/VMs  │
+└────────────────┘ └────────────────┘ └────────────────┘
+```
+
+### 4.1 Master
+
+Der Master stellt bereit:
+
+- Admin-only Node-Registry;
+- Enrollment-Tokens und Zertifikatsausstellung;
+- Node-Freigabe, Sperrung und Widerruf;
+- Heartbeat-/Capability-Verarbeitung;
+- persistente Compute-Jobs mit Lease und Idempotenz;
+- typisierte Command-Erzeugung;
+- Agent-Protokoll und Versionsaushandlung;
+- Ressourcen-/Node-Zuordnung;
+- Audit-Events;
+- später einen autorisierten Console-Proxy.
+
+### 4.2 Node Agent
+
+Der Node Agent ist ein separates, minimales Python-Paket im Repository unter `node-agent/`. Er wird als systemd-Dienst betrieben und enthält keine HydraHive-LLM- oder Frontend-Abhängigkeiten.
+
+Aufgaben:
+
+- Enrollment und lokale Schlüsselgenerierung;
+- ausgehender Agentkanal;
+- Heartbeats und Capability-Inventar;
+- atomarer Claim genau eines passenden Jobs;
+- Ausführung ausschließlich allowlisteter Incus-Operationen;
+- Fortschritt und strukturierte Resultate;
+- idempotente Wiederaufnahme nach Reconnect;
+- lokale Parallelitäts- und Ressourcenlimits;
+- sichere Agent-Aktualisierung in einer späteren V1-Etappe.
+
+Der Dienst läuft als eigener Benutzer `hydrahive-node`, erhält ausschließlich die für Incus notwendigen Gruppenrechte und speichert Identität unter `/var/lib/hydrahive-node/` mit restriktiven Dateirechten.
+
+## 5. Datenmodell
+
+Neue Migration: `core/src/hydrahive/db/migrations/032_compute_nodes.sql`.
+
+### 5.1 `compute_nodes`
+
+- `node_id TEXT PRIMARY KEY`
+- `name TEXT NOT NULL UNIQUE`
+- `kind TEXT NOT NULL` — `local|agent`
+- `status TEXT NOT NULL` — `pending|online|degraded|offline|draining|disabled|revoked`
+- `certificate_fingerprint TEXT UNIQUE`
+- `protocol_version INTEGER NOT NULL`
+- `agent_version TEXT`
+- `capabilities_json TEXT NOT NULL`
+- `resources_json TEXT NOT NULL`
+- `labels_json TEXT NOT NULL`
+- `last_seen_at TEXT`
+- `approved_at TEXT`
+- `approved_by TEXT`
+- `revoked_at TEXT`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+Die Migration legt den reservierten Node an:
+
+```text
+node_id = local
+name = Local Host
+kind = local
+status = online
+```
+
+### 5.2 `compute_enrollment_tokens`
+
+- `token_id TEXT PRIMARY KEY`
+- `token_hmac TEXT NOT NULL UNIQUE`
+- `requested_name TEXT NOT NULL`
+- `expires_at TEXT NOT NULL`
+- `consumed_at TEXT`
+- `created_by TEXT NOT NULL`
+- `created_at TEXT NOT NULL`
+
+Es wird ausschließlich ein HMAC gespeichert. Token: mindestens 256 Bit Entropie, zehn Minuten TTL, einmaliger Verbrauch, Rate-Limit.
+
+### 5.3 `compute_jobs`
+
+- `job_id TEXT PRIMARY KEY`
+- `node_id TEXT NOT NULL`
+- `resource_kind TEXT NOT NULL` — `container|vm|node`
+- `resource_id TEXT`
+- `operation TEXT NOT NULL`
+- `generation INTEGER NOT NULL`
+- `payload_json TEXT NOT NULL`
+- `idempotency_key TEXT NOT NULL UNIQUE`
+- `status TEXT NOT NULL` — `queued|leased|running|succeeded|failed|cancelled|expired`
+- `lease_id TEXT`
+- `lease_until TEXT`
+- `attempts INTEGER NOT NULL DEFAULT 0`
+- `progress INTEGER NOT NULL DEFAULT 0`
+- `error_code TEXT`
+- `error_params_json TEXT`
+- `created_by TEXT NOT NULL`
+- `created_at TEXT NOT NULL`
+- `started_at TEXT`
+- `finished_at TEXT`
+
+### 5.4 `compute_job_events`
+
+Append-only Fortschritts- und Auditverlauf:
+
+- `event_id INTEGER PRIMARY KEY AUTOINCREMENT`
+- `job_id TEXT NOT NULL`
+- `sequence INTEGER NOT NULL`
+- `event_type TEXT NOT NULL`
+- `data_json TEXT NOT NULL`
+- `created_at TEXT NOT NULL`
+- `UNIQUE(job_id, sequence)`
+
+### 5.5 Bestehende Ressourcen
+
+Additiv:
+
+- `containers.node_id TEXT NOT NULL DEFAULT 'local'`
+- `containers.generation INTEGER NOT NULL DEFAULT 0`
+- `vms.node_id TEXT NOT NULL DEFAULT 'local'`
+- `vms.generation INTEGER NOT NULL DEFAULT 0`
+- `vms.runtime TEXT NOT NULL DEFAULT 'qemu'` — `qemu|incus`
+- `vms.runtime_ref TEXT`
+
+Bestehende lokale VMs bleiben `runtime='qemu'`. Neue Agent-VMs erhalten `runtime='incus'` und einen node-lokalen, serverseitig erzeugten `runtime_ref`.
+
+## 6. Agent-Protokoll
+
+### 6.1 Enrollment
+
+1. Admin erzeugt in HydraHive einen kurzlebigen Enrollment-Token für einen Node-Namen.
+2. Agent erzeugt lokal privaten Schlüssel und CSR.
+3. Agent sendet Token, CSR, Agent-/Protokollversion und initiale Capabilities über den normalen serverauthentisierten HTTPS-Endpunkt.
+4. Master verbraucht den Token atomar, stellt ein individuelles Clientzertifikat aus und registriert den Node als `pending`.
+5. CLI und UI zeigen denselben Zertifikatsfingerprint.
+6. Admin bestätigt den Fingerprint und aktiviert den Node.
+7. Erst danach werden Heartbeats und Jobs akzeptiert.
+
+### 6.2 Laufender Kanal
+
+- TLS 1.3 mit individueller Node-Identität; Reverse Proxy und Backend müssen die verifizierte Clientidentität fail-closed an den Agent-Endpunkt binden.
+- Protokollnachrichten sind streng typisiert und versionsgebunden.
+- Jede Nachricht enthält Node-ID, Sequenz, Zeitfenster und Nonce.
+- Der Master signiert kanonische Jobs; der Agent kennt nur den öffentlichen Job-Signaturschlüssel.
+- Der Agent darf ausschließlich Jobs für seine eigene Node-ID claimen.
+- Reconnect verwendet ACK-/Resume-Semantik; Jobs werden nicht allein wegen eines Verbindungsabbruchs erneut ausgeführt.
+
+V1-Nachrichtentypen:
+
+- `hello`
+- `heartbeat`
+- `capabilities`
+- `job_offer`
+- `job_accept`
+- `job_started`
+- `job_progress`
+- `job_succeeded`
+- `job_failed`
+- `job_cancelled`
+- `ack`
+
+### 6.3 Job-Lease und Idempotenz
+
+- Claim erfolgt atomar mit eindeutiger `lease_id` und Ablaufzeit.
+- Agent persistiert zuletzt verarbeitete Idempotency-Keys lokal.
+- Ein Job enthält Node-ID, Ressource, Generation, Ablaufzeit und Signatur.
+- Veraltete Generationen und abgelaufene Jobs werden abgelehnt.
+- Wiederholte Resultate sind serverseitig idempotent.
+- Nach Lease-Ablauf entscheidet der Master anhand des Agentstatus über erneutes Leasing; laufende create/delete-Operationen werden nicht blind doppelt gestartet.
+
+## 7. Erlaubte Operationen
+
+Keine Operation enthält freie Shell-Befehle. V1-Allowlist:
+
+### Container
+
+- `container.create`
+- `container.start`
+- `container.stop`
+- `container.restart`
+- `container.delete`
+- `container.inspect`
+
+### VM
+
+- `vm.create_from_image`
+- `vm.start`
+- `vm.stop`
+- `vm.restart`
+- `vm.delete`
+- `vm.inspect`
+
+V1-Remote-VMs werden ausschließlich aus kuratierten Incus-Images erstellt. ISO-Upload, Disk-Import, Passthrough und direkte Hostpfade bleiben auf `local` begrenzt.
+
+## 8. Capabilities und Ressourcen
+
+Ein Agent meldet unter anderem:
+
+- Hostname und Betriebssystem;
+- Agent-, Incus- und Protokollversion;
+- Architektur;
+- CPU-Kerne und aktuelle Auslastung;
+- RAM gesamt/verfügbar;
+- Storage-Pools und freie Bytes;
+- KVM-Verfügbarkeit;
+- unterstützte Instanztypen;
+- verfügbare Netzwerkprofile;
+- Health-Fehler.
+
+Diese Angaben dienen in V1 zur Validierung und Anzeige, nicht zur automatischen Platzierung.
+
+## 9. API
+
+Admin-/User-API über bestehende HydraHive-Authentifizierung:
+
+- `GET /api/compute/nodes`
+- `GET /api/compute/nodes/{node_id}`
+- `POST /api/compute/enrollments`
+- `POST /api/compute/nodes/{node_id}/approve`
+- `POST /api/compute/nodes/{node_id}/drain`
+- `POST /api/compute/nodes/{node_id}/enable`
+- `DELETE /api/compute/nodes/{node_id}` — Widerruf, keine implizite Workload-Löschung
+- `GET /api/compute/jobs`
+- `GET /api/compute/jobs/{job_id}`
+- `POST /api/compute/jobs/{job_id}/cancel`
+
+Öffentlicher, tokenautorisierter Bootstrap-Endpunkt:
+
+- `POST /api/compute/agent/enroll`
+
+Agent-Endpunkt mit Node-Identität:
+
+- `WSS /api/compute/agent/connect`
+
+Bestehende Create-Payloads erhalten `node_id`. Ohne Angabe wird aus Kompatibilitätsgründen `local` verwendet.
+
+## 10. UI
+
+### 10.1 Compute-Nodes
+
+Neuer admin-only Cockpit-Bereich:
+
+- `/admin?section=nodes`
+- `/admin?section=nodes&node=<id>`
+- `/admin?section=jobs`
+
+Node-Karte und Detail zeigen:
+
+- Status und letzte Verbindung;
+- CPU, RAM und Storage;
+- Agent-/Incus-Version;
+- KVM- und Container-Capability;
+- Anzahl zugeordneter VMs/Container;
+- Wartungsmodus;
+- letzte Jobs und strukturierte Fehler;
+- Approve, Drain, Disable und Revoke.
+
+### 10.2 Create-Dialoge
+
+`CreateContainerDialog` und `CreateVMDialog` erhalten eine Node-Auswahl.
+
+- Default ist `local`.
+- Nur online Nodes mit passender Capability sind auswählbar.
+- Offline/ungeeignete Nodes bleiben sichtbar, aber deaktiviert und begründet.
+- V1 enthält keine Option „automatisch auswählen“.
+- Remote-VM-Dialog bietet nur Image-basierte Erstellung; ISO, Import und Passthrough werden deaktiviert und erklärt.
+
+### 10.3 Ressourcenstatus
+
+Container- und VM-Karten zeigen zusätzlich Node-Name und Node-Status. Ein offline Node überlagert die Erreichbarkeit, überschreibt aber nicht den zuletzt bekannten Instanzstatus.
+
+## 11. Sicherheitsanforderungen
+
+### Critical
+
+- Individuelle Node-Identität, kein Shared Cluster Secret.
+- Einmaliger Enrollment-Token mit HMAC-at-rest, TTL und Rate-Limit.
+- Gegenseitig authentisierter, fail-closed Agentkanal.
+- Kein beliebiger Shell-, Pfad- oder Argument-Input.
+- Jobs sind signiert, nodegebunden, zeitbegrenzt, generationsgebunden und idempotent.
+- Secrets erscheinen nie in URL, Kommandozeile, Logs, Events oder Jobresultaten.
+- Keine direkten VNC-, TTY-, Incus-, Docker- oder libvirt-Ports.
+- Widerruf trennt aktive Agent-/Console-Kanäle und verhindert Reconnect.
+- Agent-Updates werden nur mit signiertem Manifest und geprüftem Hash akzeptiert.
+
+### High
+
+- Admin-Freigabe mit sichtbarem Fingerprint.
+- Audit für Enrollment, Approve, Revocation und jeden Jobzustandswechsel.
+- Heartbeat, Dead-Detection und Reconnect mit Jitter.
+- Leases, Timeouts, Parallelitäts- und Outputlimits.
+- Ein kompromittierter Node kann keine Jobs oder Secrets anderer Nodes lesen.
+- Console-Tickets sind kurzlebig, einmalig und ressourcengebunden.
+
+## 12. Fehler- und Offline-Semantik
+
+- `offline`: Heartbeat-Frist überschritten; keine neuen Jobs.
+- `degraded`: Agent erreichbar, aber Capability-/Storage-/Incus-Health eingeschränkt.
+- `draining`: keine neuen Creates; Lifecycle bestehender Ressourcen bleibt möglich.
+- `disabled`: keine neuen Jobs; bestehende Verbindung wird kontrolliert abgewiesen.
+- `revoked`: Zertifikat gesperrt, aktive Kanäle getrennt, keine Reaktivierung ohne neues Enrollment.
+
+Master-Ausfall stoppt keine laufenden Workloads. Der Agent startet während eines Master-Ausfalls keine neuen Jobs und führt nur bereits eindeutig akzeptierte Operationen zu Ende.
+
+## 13. Rollout und Rückwärtskompatibilität
+
+1. Migration legt `local` an und backfillt alle Ressourcen.
+2. Bestehende Container-/VM-Endpunkte verhalten sich ohne `node_id` unverändert lokal.
+3. Node-Registry und read-only Heartbeats werden zuerst ausgeliefert.
+4. Remote-Container werden vor Remote-VMs aktiviert.
+5. Remote-VMs sind zunächst ausschließlich imagebasiert.
+6. Legacy-QEMU-VMs werden in V1 nicht automatisch konvertiert.
+
+## 14. Akzeptanzkriterien V1
+
+- Ein Ubuntu-Node kann mit einem einmaligen Token registriert und durch einen Admin freigegeben werden.
+- Der Agent benötigt keinen eingehenden Verwaltungsport.
+- HydraHive zeigt Node-Status, Ressourcen und Capabilities korrekt an.
+- Ein Administrator kann beim Erstellen eines Containers oder einer imagebasierten VM einen online Node auswählen.
+- Jobs sind persistent, idempotent, abbrechbar und nach Reconnect nachvollziehbar.
+- Container und VMs lassen sich remote erstellen, starten, stoppen, neu starten, inspizieren und löschen.
+- Ein offline Node erhält keine neuen Jobs und verändert nicht den zuletzt bekannten Instanzstatus.
+- Bestehende lokale Container und QEMU-VMs funktionieren unverändert weiter.
+- Ein widerrufener Node kann sich nicht erneut verbinden oder Jobs claimen.
+- Kein Agent-Endpunkt akzeptiert freie Shell-Befehle.
+- Audit, Backendtests, Agenttests und Frontend-Build sind grün.

--- a/docs/specs/compute-cluster-v1.md
+++ b/docs/specs/compute-cluster-v1.md
@@ -113,7 +113,7 @@ Der Dienst läuft als eigener Benutzer `hydrahive-node`, erhält ausschließlich
 
 ## 5. Datenmodell
 
-Neue Migration: `core/src/hydrahive/db/migrations/032_compute_nodes.sql`.
+Neue additive Migrationsserie: `032_compute_nodes.sql` bis `039_compute_placement_integrity.sql`. Die Registry-/Jobtabellen sind idempotent; jede Legacy-Tabellenerweiterung liegt in einer eigenen Migration, damit ein Teilfehler sicher wiederaufgenommen werden kann.
 
 ### 5.1 `compute_nodes`
 


### PR DESCRIPTION
## Summary
- specify Compute Cluster V1 architecture and implementation sequence
- add resumable compute-node, enrollment, job, placement and integrity migrations
- add strict compute-node registry persistence with atomic approval/status invariants
- bind legacy containers and VMs to the reserved `local` node with monotonic generations
- prevent remote resources from reaching any local Incus/QEMU, console, snapshot, VNC or passthrough path
- enforce node-placement and VM-runtime integrity while preserving legacy create payloads

## Verification
- `cd core && PYTHONPATH=src python -m pytest -q` — 1787 passed
- `cd core && PYTHONPATH=src python -m ruff check src tests` — passed
- focused code review and security review — no remaining blocker/high findings

## Scope
This PR completes P1 only. Enrollment APIs, node agent transport, remote jobs and UI remain in subsequent phases.
