### PR TITLE
feat(compute): secure node enrollment and heartbeat channel

### DIFF
--- a/core/src/hydrahive/api/lifespan.py
+++ b/core/src/hydrahive/api/lifespan.py
@@ -27,6 +27,7 @@ from hydrahive.communication.whatsapp import (
     ensure_secret,
 )
 from hydrahive.containers import reconciler as container_reconciler
+from hydrahive.compute import channel_monitor
 from hydrahive.zahnfee import scheduler as zahnfee_scheduler
 from hydrahive.db import init_db
 from hydrahive.db import mirror as pg_mirror
@@ -162,6 +163,8 @@ async def lifespan(app: FastAPI):
     container_reconciler_task = asyncio.create_task(
         container_reconciler.run_loop(container_reconciler_stop)
     )
+    compute_monitor_stop = asyncio.Event()
+    compute_monitor_task = asyncio.create_task(channel_monitor.run_loop(compute_monitor_stop))
     from hydrahive.modules import jobs as module_jobs
     module_jobs_stop = asyncio.Event()
     module_job_tasks = module_jobs.start_all(module_jobs_stop)
@@ -252,11 +255,19 @@ async def lifespan(app: FastAPI):
     butler_cron_stop.set()
     vm_reconciler_stop.set()
     container_reconciler_stop.set()
+    compute_monitor_stop.set()
     module_jobs_stop.set()
     if mail_stop is not None:
         mail_stop.set()
     await agentlink_client.stop_listener()
-    shutdown_tasks = [zahnfee_task, butler_cron_task, vm_reconciler_task, container_reconciler_task, *module_job_tasks]
+    shutdown_tasks = [
+        zahnfee_task,
+        butler_cron_task,
+        vm_reconciler_task,
+        container_reconciler_task,
+        compute_monitor_task,
+        *module_job_tasks,
+    ]
     if mail_task is not None:
         shutdown_tasks.append(mail_task)
     for task in shutdown_tasks:

--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -25,6 +25,8 @@ from hydrahive.api.routes.communication_whatsapp import router as communication_
 from hydrahive.api.routes.communication_discord import router as communication_discord_router
 from hydrahive.api.routes.container_console import router as container_console_router
 from hydrahive.api.routes.containers import router as containers_router
+from hydrahive.api.routes.compute_agent import router as compute_agent_router
+from hydrahive.api.routes.compute_nodes import router as compute_nodes_router
 from hydrahive.api.routes.credentials import router as credentials_router
 from hydrahive.api.routes.research_apis import router as research_apis_router
 from hydrahive.api.routes.extensions import router as extensions_router
@@ -147,6 +149,8 @@ app.include_router(stt_router)
 app.include_router(tts_router)
 app.include_router(vms_router)
 app.include_router(containers_router)
+app.include_router(compute_agent_router)
+app.include_router(compute_nodes_router)
 app.include_router(credentials_router)
 app.include_router(research_apis_router)
 app.include_router(extensions_router)

--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -26,6 +26,7 @@ from hydrahive.api.routes.communication_discord import router as communication_d
 from hydrahive.api.routes.container_console import router as container_console_router
 from hydrahive.api.routes.containers import router as containers_router
 from hydrahive.api.routes.compute_agent import router as compute_agent_router
+from hydrahive.api.routes.compute_channel import router as compute_channel_router
 from hydrahive.api.routes.compute_nodes import router as compute_nodes_router
 from hydrahive.api.routes.credentials import router as credentials_router
 from hydrahive.api.routes.research_apis import router as research_apis_router
@@ -150,6 +151,7 @@ app.include_router(tts_router)
 app.include_router(vms_router)
 app.include_router(containers_router)
 app.include_router(compute_agent_router)
+app.include_router(compute_channel_router)
 app.include_router(compute_nodes_router)
 app.include_router(credentials_router)
 app.include_router(research_apis_router)

--- a/core/src/hydrahive/api/middleware/auth.py
+++ b/core/src/hydrahive/api/middleware/auth.py
@@ -54,6 +54,7 @@ def require_auth(
     token = creds.credentials
     if token.startswith("hhk_"):
         from hydrahive.api.middleware.api_keys import verify as verify_key
+
         user = verify_key(token)
         if not user:
             raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
@@ -78,6 +79,7 @@ def require_principal(
     credential: dict
     if token.startswith("hhk_"):
         from hydrahive.api.middleware.api_keys import verify as verify_key
+
         credential = verify_key(token) or {}
         user_id = credential.get("user_id")
     else:
@@ -88,6 +90,7 @@ def require_principal(
         raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
 
     from hydrahive.api.middleware.users import get_by_id
+
     current = get_by_id(user_id)
     if not current or current["username"] != credential.get("sub", credential.get("username")):
         raise coded(status.HTTP_401_UNAUTHORIZED, "invalid_token")
@@ -114,6 +117,15 @@ def require_admin(
     return username, role
 
 
+def require_admin_principal(
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
+) -> AuthPrincipal:
+    """Require a currently existing principal whose current role is admin."""
+    if principal.role != "admin":
+        raise coded(status.HTTP_403_FORBIDDEN, "admin_only")
+    return principal
+
+
 def get_current_user_optional(
     creds: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)],
 ) -> tuple[str, str] | None:
@@ -124,6 +136,7 @@ def get_current_user_optional(
         token = creds.credentials
         if token.startswith("hhk_"):
             from hydrahive.api.middleware.api_keys import verify as verify_key
+
             user = verify_key(token)
             if not user:
                 return None

--- a/core/src/hydrahive/api/middleware/inbound_ratelimit.py
+++ b/core/src/hydrahive/api/middleware/inbound_ratelimit.py
@@ -5,6 +5,7 @@ Sliding-Window-Zähler, analog zu lockout.py. Reset bei Backend-Restart ist
 akzeptabel (Backstop gegen Kosten-DoS / Sample-Flooding, nicht das primäre
 Auth-Gate). Schlüssel ist typischerweise '<endpoint>:<client-ip>'.
 """
+
 from __future__ import annotations
 
 import time
@@ -13,6 +14,7 @@ from threading import Lock
 
 WINDOW_SECONDS = 60
 DEFAULT_LIMIT = 120
+MAX_TRACKED_KEYS = 10_000
 
 _lock = Lock()
 _hits: dict[str, list[float]] = defaultdict(list)
@@ -22,6 +24,13 @@ def check_rate(key: str, *, limit: int = DEFAULT_LIMIT, window: int = WINDOW_SEC
     """Returns (allowed, retry_after_seconds). Zählt den Treffer nur, wenn erlaubt."""
     now = time.time()
     with _lock:
+        if key not in _hits and len(_hits) >= MAX_TRACKED_KEYS:
+            cutoff = now - window
+            stale_keys = [tracked for tracked, hits in _hits.items() if not hits or hits[-1] <= cutoff]
+            for stale in stale_keys:
+                _hits.pop(stale, None)
+            if len(_hits) >= MAX_TRACKED_KEYS:
+                return False, max(1, window)
         entries = [t for t in _hits[key] if t > now - window]
         if len(entries) >= limit:
             _hits[key] = entries

--- a/core/src/hydrahive/api/routes/compute_agent.py
+++ b/core/src/hydrahive/api/routes/compute_agent.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import asdict
 
 from fastapi import APIRouter, Request, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api.middleware.inbound_ratelimit import check_rate
@@ -17,9 +17,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/compute/agent", tags=["compute-agent"])
 ENROLL_IP_RATE_LIMIT = 60
 ENROLL_TOKEN_RATE_LIMIT = 5
+MAX_ENROLL_BODY_BYTES = 96 * 1024
 
 
 class AgentEnrollmentRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     token: str = Field(min_length=32, max_length=128)
     csr_pem: str = Field(min_length=1, max_length=20_000)
     protocol_version: int = Field(default=1, ge=1, le=1)
@@ -34,8 +36,19 @@ def _client_key(request: Request) -> str:
 
 
 @router.post("/enroll", status_code=status.HTTP_201_CREATED)
-def enroll_agent(body: AgentEnrollmentRequest, request: Request) -> dict:
+async def enroll_agent(request: Request) -> dict:
     allowed, retry_after = check_rate(_client_key(request), limit=ENROLL_IP_RATE_LIMIT)
+    if not allowed:
+        raise coded(status.HTTP_429_TOO_MANY_REQUESTS, "rate_limited", retry_after=retry_after)
+    content = bytearray()
+    async for chunk in request.stream():
+        content.extend(chunk)
+        if len(content) > MAX_ENROLL_BODY_BYTES:
+            raise coded(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, "compute_enrollment_body_too_large")
+    try:
+        body = AgentEnrollmentRequest.model_validate_json(bytes(content))
+    except ValidationError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_enrollment_invalid")
     token_key = f"compute-enroll-token:{hashlib.sha256(body.token.encode('utf-8')).hexdigest()}"
     token_allowed, token_retry_after = check_rate(token_key, limit=ENROLL_TOKEN_RATE_LIMIT)
     if not allowed or not token_allowed:

--- a/core/src/hydrahive/api/routes/compute_agent.py
+++ b/core/src/hydrahive/api/routes/compute_agent.py
@@ -1,0 +1,63 @@
+"""Public, rate-limited bootstrap endpoint for compute-node agents."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import asdict
+
+from fastapi import APIRouter, Request, status
+from pydantic import BaseModel, Field
+
+from hydrahive.api.middleware.errors import coded
+from hydrahive.api.middleware.inbound_ratelimit import check_rate
+from hydrahive.compute import enroll_service, enrollment
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/compute/agent", tags=["compute-agent"])
+ENROLL_IP_RATE_LIMIT = 60
+ENROLL_TOKEN_RATE_LIMIT = 5
+
+
+class AgentEnrollmentRequest(BaseModel):
+    token: str = Field(min_length=32, max_length=128)
+    csr_pem: str = Field(min_length=1, max_length=20_000)
+    protocol_version: int = Field(default=1, ge=1, le=1)
+    agent_version: str = Field(min_length=1, max_length=64)
+    capabilities: dict[str, object] = Field(default_factory=dict)
+    resources: dict[str, object] = Field(default_factory=dict)
+
+
+def _client_key(request: Request) -> str:
+    host = request.client.host if request.client else "unknown"
+    return f"compute-enroll:{host}"
+
+
+@router.post("/enroll", status_code=status.HTTP_201_CREATED)
+def enroll_agent(body: AgentEnrollmentRequest, request: Request) -> dict:
+    allowed, retry_after = check_rate(_client_key(request), limit=ENROLL_IP_RATE_LIMIT)
+    token_key = f"compute-enroll-token:{hashlib.sha256(body.token.encode('utf-8')).hexdigest()}"
+    token_allowed, token_retry_after = check_rate(token_key, limit=ENROLL_TOKEN_RATE_LIMIT)
+    if not allowed or not token_allowed:
+        raise coded(
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            "rate_limited",
+            retry_after=max(retry_after, token_retry_after),
+        )
+    try:
+        result = enroll_service.enroll_node(
+            token=body.token,
+            csr_pem=body.csr_pem,
+            protocol_version=body.protocol_version,
+            agent_version=body.agent_version,
+            capabilities=body.capabilities,
+            resources=body.resources,
+        )
+    except enrollment.EnrollmentError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_enrollment_invalid")
+    except ValueError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_enrollment_invalid")
+    except Exception:
+        logger.exception("compute enrollment failed after input validation")
+        raise coded(status.HTTP_503_SERVICE_UNAVAILABLE, "compute_enrollment_unavailable")
+    return asdict(result)

--- a/core/src/hydrahive/api/routes/compute_channel.py
+++ b/core/src/hydrahive/api/routes/compute_channel.py
@@ -1,0 +1,40 @@
+"""Authenticated WebSocket channel for read-only compute-agent reports."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from hydrahive.compute import channel
+
+router = APIRouter(tags=["compute-agent"])
+MAX_AGENT_MESSAGE_BYTES = 64 * 1024
+
+
+@router.websocket("/api/compute/agent/connect")
+async def connect_agent(websocket: WebSocket) -> None:
+    node_id = websocket.headers.get("x-hydrahive-node-id", "")
+    client_certificate = websocket.headers.get("x-hydrahive-client-cert", "")
+    proxy_secret = websocket.headers.get("x-hydrahive-proxy-secret", "")
+    try:
+        channel.authenticate_node(node_id, client_certificate, proxy_secret)
+    except channel.ProtocolError:
+        await websocket.close(code=4403, reason="agent_identity_invalid")
+        return
+
+    await websocket.accept()
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            if len(raw.encode("utf-8")) > MAX_AGENT_MESSAGE_BYTES:
+                await websocket.close(code=4400, reason="agent_message_too_large")
+                return
+            try:
+                message = channel.parse_message(raw)
+                acknowledgement = channel.accept_message(node_id, message)
+            except channel.ProtocolError as exc:
+                await websocket.send_json({"type": "error", "code": exc.code})
+                await websocket.close(code=4400, reason=exc.code)
+                return
+            await websocket.send_json(acknowledgement)
+    except WebSocketDisconnect:
+        return

--- a/core/src/hydrahive/api/routes/compute_nodes.py
+++ b/core/src/hydrahive/api/routes/compute_nodes.py
@@ -1,0 +1,150 @@
+"""Authenticated administration API for compute nodes and enrollments."""
+
+from __future__ import annotations
+
+import hmac
+from dataclasses import asdict
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+
+from hydrahive.api.middleware.auth import AuthPrincipal, require_admin_principal
+from hydrahive.api.middleware.errors import coded
+from hydrahive.compute import enrollment
+from hydrahive.compute import db as node_db
+from hydrahive.compute._node_codec import normalize_certificate_fingerprint
+
+router = APIRouter(prefix="/api/compute", tags=["compute"])
+
+
+class EnrollmentCreate(BaseModel):
+    requested_name: str = Field(min_length=1, max_length=128)
+    ttl_seconds: int = Field(default=900, ge=30, le=3600)
+
+
+class ApprovalRequest(BaseModel):
+    certificate_fingerprint: str = Field(min_length=64, max_length=95)
+
+
+def _node_or_404(node_id: str):
+    node = node_db.get_node(node_id)
+    if node is None:
+        raise coded(status.HTTP_404_NOT_FOUND, "compute_node_not_found")
+    return node
+
+
+def _transition(node_id: str, target: str, actor: str):
+    current = _node_or_404(node_id)
+    if current.status == "pending" and target == "disabled":
+        raise coded(status.HTTP_409_CONFLICT, "compute_pending_node_must_be_approved_or_revoked")
+    try:
+        node = node_db.transition_node_status(
+            node_id,
+            target,  # type: ignore[arg-type]
+            actor=actor,
+        )
+    except ValueError as exc:
+        raise coded(status.HTTP_409_CONFLICT, "compute_node_transition_invalid", reason=str(exc))
+    return asdict(node)
+
+
+@router.get("/nodes")
+def list_compute_nodes(
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> list[dict]:
+    return [asdict(node) for node in node_db.list_nodes()]
+
+
+@router.get("/nodes/{node_id}")
+def get_compute_node(
+    node_id: str,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    return asdict(_node_or_404(node_id))
+
+
+@router.post("/enrollments", status_code=status.HTTP_201_CREATED)
+def create_enrollment(
+    body: EnrollmentCreate,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    actor = auth.user_id
+    requested_name = body.requested_name.strip()
+    if any(node.name == requested_name for node in node_db.list_nodes()):
+        raise coded(status.HTTP_409_CONFLICT, "compute_node_name_exists")
+    try:
+        created = enrollment.create_token(
+            requested_name=requested_name,
+            created_by=actor,
+            ttl_seconds=body.ttl_seconds,
+        )
+    except ValueError as exc:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_enrollment_invalid", reason=str(exc))
+    return asdict(created)
+
+
+@router.post("/nodes/{node_id}/approve")
+def approve_compute_node(
+    node_id: str,
+    body: ApprovalRequest,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    actor = auth.user_id
+    node = _node_or_404(node_id)
+    try:
+        supplied = normalize_certificate_fingerprint(body.certificate_fingerprint)
+    except ValueError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_fingerprint_invalid")
+    if (
+        node.certificate_fingerprint is None
+        or supplied is None
+        or not hmac.compare_digest(
+            node.certificate_fingerprint,
+            supplied,
+        )
+    ):
+        raise coded(status.HTTP_409_CONFLICT, "compute_fingerprint_mismatch")
+    try:
+        approved = node_db.approve_node(node_id, actor)
+    except ValueError as exc:
+        raise coded(status.HTTP_409_CONFLICT, "compute_node_approval_invalid", reason=str(exc))
+    return asdict(approved)
+
+
+@router.post("/nodes/{node_id}/drain")
+def drain_compute_node(
+    node_id: str,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    return _transition(node_id, "draining", auth.user_id)
+
+
+@router.post("/nodes/{node_id}/disable")
+def disable_compute_node(
+    node_id: str,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    return _transition(node_id, "disabled", auth.user_id)
+
+
+@router.post("/nodes/{node_id}/enable")
+def enable_compute_node(
+    node_id: str,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    return _transition(node_id, "online", auth.user_id)
+
+
+@router.delete("/nodes/{node_id}")
+def revoke_compute_node(
+    node_id: str,
+    auth: Annotated[AuthPrincipal, Depends(require_admin_principal)],
+) -> dict:
+    actor = auth.user_id
+    _node_or_404(node_id)
+    try:
+        node = node_db.revoke_node(node_id, actor=actor)
+    except ValueError as exc:
+        raise coded(status.HTTP_409_CONFLICT, "compute_node_revoke_invalid", reason=str(exc))
+    return asdict(node)

--- a/core/src/hydrahive/api/routes/compute_nodes.py
+++ b/core/src/hydrahive/api/routes/compute_nodes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hmac
+import sqlite3
 from dataclasses import asdict
 from typing import Annotated
 
@@ -79,6 +80,8 @@ def create_enrollment(
             created_by=actor,
             ttl_seconds=body.ttl_seconds,
         )
+    except sqlite3.IntegrityError:
+        raise coded(status.HTTP_409_CONFLICT, "compute_node_name_exists")
     except ValueError as exc:
         raise coded(status.HTTP_400_BAD_REQUEST, "compute_enrollment_invalid", reason=str(exc))
     return asdict(created)

--- a/core/src/hydrahive/compute/_identity_store.py
+++ b/core/src/hydrahive/compute/_identity_store.py
@@ -1,0 +1,137 @@
+"""Locked storage and validation for the local compute CA."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import secrets
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Iterator
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from hydrahive.settings import settings
+
+
+@dataclass(frozen=True)
+class CAState:
+    key: ec.EllipticCurvePrivateKey
+    certificate_pem: bytes
+    certificate: x509.Certificate
+
+
+def _fsync_directory(directory: Path) -> None:
+    descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_file(path: Path, content: bytes, mode: int) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, mode)
+        published = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(published)
+        finally:
+            os.close(published)
+        _fsync_directory(path.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@contextmanager
+def ca_lock() -> Iterator[None]:
+    directory = settings.compute_pki_dir
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(directory, 0o700)
+    lock_path = directory / ".ca.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        os.chmod(lock_path, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _validate_ca(key: object, certificate: x509.Certificate) -> ec.EllipticCurvePrivateKey:
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        raise ValueError("compute CA key type is invalid")
+    if certificate.subject != certificate.issuer:
+        raise ValueError("compute CA is not self-issued")
+    key_public = key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    cert_public = certificate.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    if key_public != cert_public:
+        raise ValueError("compute CA key and certificate do not match")
+    public_key = certificate.public_key()
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise ValueError("compute CA certificate key type is invalid")
+    try:
+        public_key.verify(
+            certificate.signature,
+            certificate.tbs_certificate_bytes,
+            ec.ECDSA(certificate.signature_hash_algorithm),
+        )
+        constraints = certificate.extensions.get_extension_for_class(x509.BasicConstraints).value
+        usage = certificate.extensions.get_extension_for_class(x509.KeyUsage).value
+    except (ValueError, x509.ExtensionNotFound) as exc:
+        raise ValueError("compute CA certificate profile is invalid") from exc
+    if not constraints.ca or constraints.path_length != 0 or not usage.key_cert_sign or not usage.crl_sign:
+        raise ValueError("compute CA certificate profile is invalid")
+    now = datetime.now(UTC)
+    if certificate.not_valid_before_utc > now or certificate.not_valid_after_utc <= now:
+        raise ValueError("compute CA certificate is not currently valid")
+    return key
+
+
+def load_ca() -> CAState | None:
+    key_path = settings.compute_ca_key_path
+    cert_path = settings.compute_ca_cert_path
+    marker = settings.compute_pki_dir / ".initializing"
+    if marker.exists() and (not key_path.is_file() or not cert_path.is_file()):
+        key_path.unlink(missing_ok=True)
+        cert_path.unlink(missing_ok=True)
+        marker.unlink(missing_ok=True)
+    if not key_path.exists() and not cert_path.exists():
+        return None
+    if not key_path.is_file() or not cert_path.is_file():
+        raise ValueError("compute CA files are incomplete")
+    try:
+        key = serialization.load_pem_private_key(key_path.read_bytes(), password=None)
+        certificate_pem = cert_path.read_bytes()
+        certificate = x509.load_pem_x509_certificate(certificate_pem)
+        validated_key = _validate_ca(key, certificate)
+    except (OSError, ValueError, TypeError) as exc:
+        raise ValueError("compute CA files are invalid") from exc
+    os.chmod(key_path, 0o600)
+    marker.unlink(missing_ok=True)
+    return CAState(validated_key, certificate_pem, certificate)
+
+
+def write_ca_pair(key_pem: bytes, certificate_pem: bytes) -> None:
+    marker = settings.compute_pki_dir / ".initializing"
+    _write_file(marker, b"initializing\n", 0o600)
+    _write_file(settings.compute_ca_key_path, key_pem, 0o600)
+    _write_file(settings.compute_ca_cert_path, certificate_pem, 0o644)
+    marker.unlink()
+    _fsync_directory(settings.compute_pki_dir)

--- a/core/src/hydrahive/compute/_node_codec.py
+++ b/core/src/hydrahive/compute/_node_codec.py
@@ -85,6 +85,13 @@ def load_json(value: str, field_name: str) -> JSONObject:
     return cast(JSONObject, decoded)
 
 
+def _load_health_errors(value: str) -> list[str]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, list) or not all(isinstance(item, str) for item in decoded):
+        raise ValueError("stored health_errors must be a string list")
+    return decoded
+
+
 def row_to_node(row: sqlite3.Row) -> ComputeNode:
     return ComputeNode(
         node_id=row["node_id"],
@@ -97,10 +104,12 @@ def row_to_node(row: sqlite3.Row) -> ComputeNode:
         capabilities=load_json(row["capabilities_json"], "capabilities"),
         resources=load_json(row["resources_json"], "resources"),
         labels=load_json(row["labels_json"], "labels"),
+        health_errors=(_load_health_errors(row["health_errors_json"]) if "health_errors_json" in row.keys() else []),
         last_seen_at=row["last_seen_at"],
         approved_at=row["approved_at"],
         approved_by=row["approved_by"],
         revoked_at=row["revoked_at"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        last_sequence=row["last_sequence"] if "last_sequence" in row.keys() else 0,
     )

--- a/core/src/hydrahive/compute/_node_codec.py
+++ b/core/src/hydrahive/compute/_node_codec.py
@@ -64,7 +64,13 @@ def dump_json(value: JSONObject, field_name: str) -> str:
     if not isinstance(value, dict):
         raise ValueError(f"{field_name} must be a JSON object")
     try:
-        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        )
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{field_name} must contain valid JSON") from exc
     if len(encoded.encode("utf-8")) > MAX_NODE_JSON_BYTES:

--- a/core/src/hydrahive/compute/_node_status.py
+++ b/core/src/hydrahive/compute/_node_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from hydrahive.compute import audit
 from hydrahive.compute._node_codec import ALLOWED_STATUS_TRANSITIONS, row_to_node, validate_status
 from hydrahive.compute.models import ComputeNode, NodeStatus
 from hydrahive.db._utils import now_iso
@@ -37,10 +38,21 @@ def approve_node(node_id: str, approved_by: str) -> ComputeNode | None:
                WHERE node_id = ? AND status = 'pending'""",
             (timestamp, approved_by, timestamp, node_id),
         )
+        audit.record_in_connection(
+            conn,
+            actor=approved_by,
+            action="node.approved",
+            node_id=node_id,
+        )
     return _read_node(node_id)
 
 
-def transition_node_status(node_id: str, status: NodeStatus) -> ComputeNode | None:
+def transition_node_status(
+    node_id: str,
+    status: NodeStatus,
+    *,
+    actor: str | None = None,
+) -> ComputeNode | None:
     if node_id == LOCAL_NODE_ID:
         raise ValueError("local node status is managed by the control plane")
     validate_status(status)
@@ -64,10 +76,17 @@ def transition_node_status(node_id: str, status: NodeStatus) -> ComputeNode | No
         )
         if result.rowcount != 1:  # pragma: no cover - protected by BEGIN IMMEDIATE
             raise RuntimeError("compute node status changed concurrently")
+        if actor is not None:
+            audit.record_in_connection(
+                conn,
+                actor=actor,
+                action=f"node.{status}",
+                node_id=node_id,
+            )
     return _read_node(node_id)
 
 
-def revoke_node(node_id: str) -> ComputeNode | None:
+def revoke_node(node_id: str, *, actor: str | None = None) -> ComputeNode | None:
     if node_id == LOCAL_NODE_ID:
         raise ValueError("local node cannot be revoked")
     timestamp = now_iso()
@@ -84,4 +103,11 @@ def revoke_node(node_id: str) -> ComputeNode | None:
                WHERE node_id = ? AND status = ?""",
             ("revoked", timestamp, timestamp, node_id, current.status),
         )
+        if actor is not None:
+            audit.record_in_connection(
+                conn,
+                actor=actor,
+                action="node.revoked",
+                node_id=node_id,
+            )
     return _read_node(node_id)

--- a/core/src/hydrahive/compute/_node_status.py
+++ b/core/src/hydrahive/compute/_node_status.py
@@ -34,7 +34,7 @@ def approve_node(node_id: str, approved_by: str) -> ComputeNode | None:
             raise ValueError("node requires a certificate fingerprint before approval")
         conn.execute(
             """UPDATE compute_nodes
-               SET status = 'online', approved_at = ?, approved_by = ?, updated_at = ?
+               SET status = 'offline', approved_at = ?, approved_by = ?, updated_at = ?
                WHERE node_id = ? AND status = 'pending'""",
             (timestamp, approved_by, timestamp, node_id),
         )

--- a/core/src/hydrahive/compute/audit.py
+++ b/core/src/hydrahive/compute/audit.py
@@ -1,0 +1,82 @@
+"""Append-only audit records for compute security operations."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+
+MAX_AUDIT_JSON_BYTES = 16 * 1024
+
+
+def record_in_connection(
+    conn: sqlite3.Connection,
+    *,
+    actor: str,
+    action: str,
+    node_id: str | None = None,
+    details: dict | None = None,
+) -> None:
+    details_json = None
+    if details is not None:
+        details_json = json.dumps(
+            details,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        )
+        if len(details_json.encode("utf-8")) > MAX_AUDIT_JSON_BYTES:
+            raise ValueError("compute audit details are too large")
+    conn.execute(
+        """INSERT INTO compute_audit_log
+               (audit_id, actor, action, node_id, details_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (uuid7(), actor, action, node_id, details_json, now_iso()),
+    )
+
+
+def record(
+    *,
+    actor: str,
+    action: str,
+    node_id: str | None = None,
+    details: dict | None = None,
+) -> None:
+    with db() as conn:
+        record_in_connection(
+            conn,
+            actor=actor,
+            action=action,
+            node_id=node_id,
+            details=details,
+        )
+
+
+def list_records(*, node_id: str | None = None, limit: int = 200) -> list[dict]:
+    limit = max(1, min(limit, 500))
+    with db() as conn:
+        if node_id is None:
+            rows = conn.execute(
+                "SELECT * FROM compute_audit_log ORDER BY created_at DESC, audit_id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT * FROM compute_audit_log WHERE node_id = ?
+                   ORDER BY created_at DESC, audit_id DESC LIMIT ?""",
+                (node_id, limit),
+            ).fetchall()
+    return [
+        {
+            "audit_id": row["audit_id"],
+            "actor": row["actor"],
+            "action": row["action"],
+            "node_id": row["node_id"],
+            "details": json.loads(row["details_json"]) if row["details_json"] else None,
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]

--- a/core/src/hydrahive/compute/channel.py
+++ b/core/src/hydrahive/compute/channel.py
@@ -1,0 +1,184 @@
+"""Authenticated, replay-safe read-only agent protocol handling."""
+
+from __future__ import annotations
+
+import hmac
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from urllib.parse import unquote
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from hydrahive.compute import audit, identity
+from hydrahive.compute._node_codec import dump_json, normalize_certificate_fingerprint
+from hydrahive.db._utils import now_iso
+from hydrahive.db.connection import db
+from hydrahive.settings import settings
+
+MAX_CLOCK_SKEW_SECONDS = 120
+NONCE_TTL_MINUTES = 10
+CONNECTED_STATUSES = {"online", "degraded", "offline", "draining"}
+
+
+class ProtocolError(ValueError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class AgentMessage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["hello", "heartbeat", "capabilities"]
+    protocol_version: Literal[1]
+    node_id: str = Field(min_length=1, max_length=128)
+    sequence: int = Field(ge=1, le=9_223_372_036_854_775_807)
+    nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
+    sent_at: datetime
+    payload: dict[str, object] = Field(default_factory=dict)
+
+
+def parse_message(raw: str) -> AgentMessage:
+    try:
+        message = AgentMessage.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ProtocolError("agent_message_invalid") from exc
+    sent_at = message.sent_at
+    if sent_at.tzinfo is None:
+        raise ProtocolError("agent_timestamp_invalid")
+    if abs((datetime.now(UTC) - sent_at.astimezone(UTC)).total_seconds()) > MAX_CLOCK_SKEW_SECONDS:
+        raise ProtocolError("agent_timestamp_invalid")
+    return message
+
+
+def proxy_certificate_fingerprint(escaped_certificate: str) -> str:
+    if not escaped_certificate or len(escaped_certificate) > 20_000:
+        raise ProtocolError("agent_identity_invalid")
+    try:
+        certificate_pem = unquote(escaped_certificate).encode("ascii")
+        return identity.certificate_fingerprint(certificate_pem)
+    except (UnicodeError, identity.IdentityError) as exc:
+        raise ProtocolError("agent_identity_invalid") from exc
+
+
+def authenticate_node(node_id: str, escaped_certificate: str, proxy_secret: str) -> None:
+    expected_proxy_secret = settings.compute_proxy_secret
+    if not expected_proxy_secret or not hmac.compare_digest(proxy_secret, expected_proxy_secret):
+        raise ProtocolError("agent_identity_invalid")
+    normalized = normalize_certificate_fingerprint(proxy_certificate_fingerprint(escaped_certificate))
+    with db() as conn:
+        row = conn.execute(
+            "SELECT certificate_fingerprint, status FROM compute_nodes WHERE node_id = ?",
+            (node_id,),
+        ).fetchone()
+    if (
+        row is None
+        or row["status"] not in CONNECTED_STATUSES
+        or row["certificate_fingerprint"] is None
+        or normalized is None
+        or not hmac.compare_digest(row["certificate_fingerprint"], normalized)
+    ):
+        raise ProtocolError("agent_identity_invalid")
+
+
+def _json_object(value: dict, field_name: str) -> str:
+    try:
+        return dump_json(value, field_name)
+    except ValueError as exc:
+        raise ProtocolError("agent_payload_invalid") from exc
+
+
+def _health_errors(payload: dict[str, object]) -> list[str]:
+    value = payload.get("health_errors", [])
+    if not isinstance(value, list) or len(value) > 32:
+        raise ProtocolError("agent_payload_invalid")
+    errors = [item for item in value if isinstance(item, str) and 0 < len(item) <= 256]
+    if len(errors) != len(value):
+        raise ProtocolError("agent_payload_invalid")
+    return errors
+
+
+def accept_message(authenticated_node_id: str, message: AgentMessage) -> dict:
+    if message.node_id != authenticated_node_id:
+        raise ProtocolError("agent_node_mismatch")
+    now = now_iso()
+    nonce_expiry = (datetime.now(UTC) + timedelta(minutes=NONCE_TTL_MINUTES)).isoformat().replace("+00:00", "Z")
+    with db(immediate=True) as conn:
+        conn.execute("DELETE FROM compute_agent_nonces WHERE expires_at <= ?", (now,))
+        node = conn.execute(
+            "SELECT status, last_sequence FROM compute_nodes WHERE node_id = ?",
+            (authenticated_node_id,),
+        ).fetchone()
+        if node is None or node["status"] not in CONNECTED_STATUSES:
+            raise ProtocolError("agent_identity_invalid")
+        if message.sequence <= node["last_sequence"]:
+            raise ProtocolError("agent_sequence_replayed")
+        try:
+            conn.execute(
+                "INSERT INTO compute_agent_nonces (node_id, nonce, expires_at) VALUES (?, ?, ?)",
+                (authenticated_node_id, message.nonce, nonce_expiry),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ProtocolError("agent_nonce_replayed") from exc
+
+        updates = ["last_sequence = ?", "last_seen_at = ?", "updated_at = ?"]
+        values: list[object] = [message.sequence, now, now]
+        if message.type == "hello":
+            agent_version = message.payload.get("agent_version")
+            if not isinstance(agent_version, str) or not 0 < len(agent_version) <= 64:
+                raise ProtocolError("agent_payload_invalid")
+            updates.append("agent_version = ?")
+            values.append(agent_version)
+            audit.record_in_connection(
+                conn,
+                actor=f"node:{authenticated_node_id}",
+                action="node.connected",
+                node_id=authenticated_node_id,
+                details={"sequence": message.sequence},
+            )
+        elif message.type == "capabilities":
+            capabilities = message.payload.get("capabilities")
+            resources = message.payload.get("resources")
+            if not isinstance(capabilities, dict) or not isinstance(resources, dict):
+                raise ProtocolError("agent_payload_invalid")
+            updates.extend(("capabilities_json = ?", "resources_json = ?"))
+            values.extend((_json_object(capabilities, "capabilities"), _json_object(resources, "resources")))
+        else:
+            capabilities = message.payload.get("capabilities")
+            resources = message.payload.get("resources")
+            if not isinstance(capabilities, dict) or not isinstance(resources, dict):
+                raise ProtocolError("agent_payload_invalid")
+            errors = _health_errors(message.payload)
+            status = "draining" if node["status"] == "draining" else ("degraded" if errors else "online")
+            if status != node["status"]:
+                audit.record_in_connection(
+                    conn,
+                    actor=f"node:{authenticated_node_id}",
+                    action=f"node.{status}",
+                    node_id=authenticated_node_id,
+                    details={"from": node["status"], "reason": "heartbeat"},
+                )
+            updates.extend(
+                (
+                    "capabilities_json = ?",
+                    "resources_json = ?",
+                    "health_errors_json = ?",
+                    "status = ?",
+                )
+            )
+            values.extend(
+                (
+                    _json_object(capabilities, "capabilities"),
+                    _json_object(resources, "resources"),
+                    json.dumps(errors, separators=(",", ":")),
+                    status,
+                )
+            )
+        values.append(authenticated_node_id)
+        conn.execute(
+            f"UPDATE compute_nodes SET {', '.join(updates)} WHERE node_id = ?",
+            values,
+        )
+    return {"type": "ack", "sequence": message.sequence, "accepted_at": now}

--- a/core/src/hydrahive/compute/channel_monitor.py
+++ b/core/src/hydrahive/compute/channel_monitor.py
@@ -1,0 +1,72 @@
+"""Background dead-node detection with audited health transitions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from hydrahive.compute import audit
+from hydrahive.db._utils import now_iso
+from hydrahive.db.connection import db
+
+logger = logging.getLogger(__name__)
+
+
+def _cutoff(now: datetime, seconds: int) -> str:
+    return (now - timedelta(seconds=seconds)).isoformat().replace("+00:00", "Z")
+
+
+def _audit_rows(conn, rows, target: str) -> None:
+    for row in rows:
+        audit.record_in_connection(
+            conn,
+            actor="system:compute-monitor",
+            action=f"node.{target}",
+            node_id=row["node_id"],
+            details={"from": row["status"], "reason": "heartbeat_timeout"},
+        )
+
+
+def mark_stale_nodes(*, degraded_after: int = 45, offline_after: int = 90) -> tuple[int, int]:
+    if degraded_after <= 0 or offline_after <= degraded_after:
+        raise ValueError("invalid stale-node thresholds")
+    now = datetime.now(UTC)
+    timestamp = now_iso()
+    with db(immediate=True) as conn:
+        offline_rows = conn.execute(
+            """SELECT node_id, status FROM compute_nodes
+               WHERE kind = 'agent' AND status IN ('online', 'degraded')
+                 AND last_seen_at IS NOT NULL AND last_seen_at < ?""",
+            (_cutoff(now, offline_after),),
+        ).fetchall()
+        conn.executemany(
+            "UPDATE compute_nodes SET status = 'offline', updated_at = ? WHERE node_id = ?",
+            ((timestamp, row["node_id"]) for row in offline_rows),
+        )
+        _audit_rows(conn, offline_rows, "offline")
+
+        degraded_rows = conn.execute(
+            """SELECT node_id, status FROM compute_nodes
+               WHERE kind = 'agent' AND status = 'online'
+                 AND last_seen_at IS NOT NULL AND last_seen_at < ?""",
+            (_cutoff(now, degraded_after),),
+        ).fetchall()
+        conn.executemany(
+            "UPDATE compute_nodes SET status = 'degraded', updated_at = ? WHERE node_id = ?",
+            ((timestamp, row["node_id"]) for row in degraded_rows),
+        )
+        _audit_rows(conn, degraded_rows, "degraded")
+    return len(degraded_rows), len(offline_rows)
+
+
+async def run_loop(stop: asyncio.Event, interval: float = 15.0) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.to_thread(mark_stale_nodes)
+        except Exception:
+            logger.exception("compute node dead-detection failed")
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass

--- a/core/src/hydrahive/compute/enroll_service.py
+++ b/core/src/hydrahive/compute/enroll_service.py
@@ -1,0 +1,162 @@
+"""Atomic and retry-safe compute-node enrollment orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+
+from hydrahive.compute import audit, enrollment, identity
+from hydrahive.compute._node_codec import dump_json, row_to_node
+from hydrahive.compute.models import ComputeNode
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+
+
+@dataclass(frozen=True)
+class EnrollmentResult:
+    node: ComputeNode
+    certificate_pem: str
+    ca_certificate_pem: str
+    certificate_fingerprint: str
+    certificate_expires_at: str
+
+
+def _token_row(conn: sqlite3.Connection, digest: str):
+    return conn.execute(
+        """SELECT token_id, requested_name, expires_at, consumed_at
+           FROM compute_enrollment_tokens WHERE token_hmac = ?""",
+        (digest,),
+    ).fetchone()
+
+
+def _recovered_result(
+    conn: sqlite3.Connection,
+    *,
+    token_id: str,
+    csr_sha256: str,
+) -> EnrollmentResult | None:
+    row = conn.execute(
+        """SELECT r.csr_sha256, r.certificate_pem, r.certificate_expires_at,
+                  n.*
+           FROM compute_enrollment_results r
+           JOIN compute_nodes n ON n.node_id = r.node_id
+           WHERE r.token_id = ?""",
+        (token_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    if row["csr_sha256"] != csr_sha256:
+        raise enrollment.EnrollmentError()
+    ca = identity.ensure_compute_ca()
+    node = row_to_node(row)
+    return EnrollmentResult(
+        node=node,
+        certificate_pem=row["certificate_pem"],
+        ca_certificate_pem=ca.certificate_pem.decode("ascii"),
+        certificate_fingerprint=node.certificate_fingerprint or "",
+        certificate_expires_at=row["certificate_expires_at"],
+    )
+
+
+def enroll_node(
+    *,
+    token: str,
+    csr_pem: str,
+    protocol_version: int,
+    agent_version: str,
+    capabilities: dict[str, object],
+    resources: dict[str, object],
+) -> EnrollmentResult:
+    digest = enrollment.token_digest(token)
+    csr_bytes = csr_pem.encode("utf-8")
+    csr_sha256 = hashlib.sha256(csr_bytes).hexdigest()
+    timestamp = now_iso()
+    with db() as conn:
+        token_row = _token_row(conn, digest)
+        if token_row is None:
+            raise enrollment.EnrollmentError()
+        if token_row["consumed_at"] is not None:
+            recovered = _recovered_result(conn, token_id=token_row["token_id"], csr_sha256=csr_sha256)
+            if recovered is None:
+                raise enrollment.EnrollmentError()
+            return recovered
+        if token_row["expires_at"] <= timestamp:
+            raise enrollment.EnrollmentError()
+        requested_name = token_row["requested_name"]
+
+    if protocol_version != 1:
+        raise enrollment.EnrollmentError()
+    if not agent_version or len(agent_version) > 64 or not agent_version.isprintable():
+        raise enrollment.EnrollmentError()
+    capabilities_json = dump_json(capabilities, "capabilities")
+    resources_json = dump_json(resources, "resources")
+    node_id = uuid7()
+    issued = identity.issue_node_certificate(
+        csr_bytes,
+        node_id=node_id,
+        expected_common_name=requested_name,
+    )
+
+    with db(immediate=True) as conn:
+        token_row = _token_row(conn, digest)
+        if token_row is None:
+            raise enrollment.EnrollmentError()
+        if token_row["consumed_at"] is not None:
+            recovered = _recovered_result(conn, token_id=token_row["token_id"], csr_sha256=csr_sha256)
+            if recovered is None:
+                raise enrollment.EnrollmentError()
+            return recovered
+        if token_row["expires_at"] <= now_iso():
+            raise enrollment.EnrollmentError()
+        timestamp = now_iso()
+        conn.execute(
+            """INSERT INTO compute_nodes (
+                   node_id, name, kind, status, certificate_fingerprint,
+                   protocol_version, agent_version, capabilities_json,
+                   resources_json, labels_json, created_at, updated_at
+               ) VALUES (?, ?, 'agent', 'pending', ?, ?, ?, ?, ?, '{}', ?, ?)""",
+            (
+                node_id,
+                requested_name,
+                issued.fingerprint,
+                protocol_version,
+                agent_version,
+                capabilities_json,
+                resources_json,
+                timestamp,
+                timestamp,
+            ),
+        )
+        conn.execute(
+            "UPDATE compute_enrollment_tokens SET consumed_at = ? WHERE token_id = ? AND consumed_at IS NULL",
+            (timestamp, token_row["token_id"]),
+        )
+        conn.execute(
+            """INSERT INTO compute_enrollment_results
+                   (token_id, csr_sha256, node_id, certificate_pem, certificate_expires_at, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                token_row["token_id"],
+                csr_sha256,
+                node_id,
+                issued.certificate_pem.decode("ascii"),
+                issued.expires_at,
+                timestamp,
+            ),
+        )
+        audit.record_in_connection(
+            conn,
+            actor=f"enrollment:{token_row['token_id']}",
+            action="node.enrolled",
+            node_id=node_id,
+            details={"agent_version": agent_version, "protocol_version": protocol_version},
+        )
+        node = row_to_node(conn.execute("SELECT * FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone())
+    return EnrollmentResult(
+        node=node,
+        certificate_pem=issued.certificate_pem.decode("ascii"),
+        ca_certificate_pem=issued.ca_certificate_pem.decode("ascii"),
+        certificate_fingerprint=issued.fingerprint,
+        certificate_expires_at=issued.expires_at,
+    )

--- a/core/src/hydrahive/compute/enroll_service.py
+++ b/core/src/hydrahive/compute/enroll_service.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 
 from hydrahive.compute import audit, enrollment, identity
 from hydrahive.compute._node_codec import dump_json, row_to_node
 from hydrahive.compute.models import ComputeNode
 from hydrahive.db._utils import now_iso, uuid7
 from hydrahive.db.connection import db
+
+RECOVERY_WINDOW_MINUTES = 10
 
 
 @dataclass(frozen=True)
@@ -38,7 +41,7 @@ def _recovered_result(
 ) -> EnrollmentResult | None:
     row = conn.execute(
         """SELECT r.csr_sha256, r.certificate_pem, r.certificate_expires_at,
-                  n.*
+                  r.recovery_until, n.*
            FROM compute_enrollment_results r
            JOIN compute_nodes n ON n.node_id = r.node_id
            WHERE r.token_id = ?""",
@@ -46,7 +49,7 @@ def _recovered_result(
     ).fetchone()
     if row is None:
         return None
-    if row["csr_sha256"] != csr_sha256:
+    if row["recovery_until"] <= now_iso() or row["csr_sha256"] != csr_sha256:
         raise enrollment.EnrollmentError()
     ca = identity.ensure_compute_ca()
     node = row_to_node(row)
@@ -110,6 +113,9 @@ def enroll_node(
         if token_row["expires_at"] <= now_iso():
             raise enrollment.EnrollmentError()
         timestamp = now_iso()
+        recovery_until = (
+            (datetime.now(UTC) + timedelta(minutes=RECOVERY_WINDOW_MINUTES)).isoformat().replace("+00:00", "Z")
+        )
         conn.execute(
             """INSERT INTO compute_nodes (
                    node_id, name, kind, status, certificate_fingerprint,
@@ -134,14 +140,16 @@ def enroll_node(
         )
         conn.execute(
             """INSERT INTO compute_enrollment_results
-                   (token_id, csr_sha256, node_id, certificate_pem, certificate_expires_at, created_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
+                   (token_id, csr_sha256, node_id, certificate_pem,
+                    certificate_expires_at, recovery_until, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (
                 token_row["token_id"],
                 csr_sha256,
                 node_id,
                 issued.certificate_pem.decode("ascii"),
                 issued.expires_at,
+                recovery_until,
                 timestamp,
             ),
         )

--- a/core/src/hydrahive/compute/enrollment.py
+++ b/core/src/hydrahive/compute/enrollment.py
@@ -1,0 +1,110 @@
+"""Opaque, one-time enrollment tokens for compute nodes."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+from hydrahive.settings import settings
+
+MIN_TTL_SECONDS = 30
+MAX_TTL_SECONDS = 3600
+MAX_TOKEN_LENGTH = 128
+MAX_NAME_LENGTH = 128
+MAX_ACTOR_LENGTH = 128
+TOKEN_RETENTION_DAYS = 7
+
+
+class EnrollmentError(RuntimeError):
+    def __init__(self) -> None:
+        self.code = "enrollment_invalid"
+        super().__init__(self.code)
+
+
+@dataclass(frozen=True)
+class CreatedEnrollmentToken:
+    token_id: str
+    token: str
+    requested_name: str
+    expires_at: str
+
+
+@dataclass(frozen=True)
+class ConsumedEnrollmentToken:
+    token_id: str
+    requested_name: str
+    created_by: str
+
+
+def _validate_text(value: str, field: str, maximum: int) -> str:
+    value = value.strip()
+    if not value or len(value) > maximum or not value.isprintable():
+        raise ValueError(f"{field} must contain 1-{maximum} printable characters")
+    return value
+
+
+def _token_hmac(token: str) -> str:
+    return hmac.new(
+        settings.secret_key.encode("utf-8"),
+        b"hydrahive-compute-enrollment-v1\0" + token.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def create_token(
+    *,
+    requested_name: str,
+    created_by: str,
+    ttl_seconds: int = 900,
+) -> CreatedEnrollmentToken:
+    requested_name = _validate_text(requested_name, "requested_name", MAX_NAME_LENGTH)
+    created_by = _validate_text(created_by, "created_by", MAX_ACTOR_LENGTH)
+    if not MIN_TTL_SECONDS <= ttl_seconds <= MAX_TTL_SECONDS:
+        raise ValueError(f"ttl_seconds must be between {MIN_TTL_SECONDS} and {MAX_TTL_SECONDS}")
+
+    token = secrets.token_urlsafe(32)
+    token_id = uuid7()
+    expires_at = (datetime.now(UTC) + timedelta(seconds=ttl_seconds)).isoformat().replace("+00:00", "Z")
+    with db() as conn:
+        retention_cutoff = (datetime.now(UTC) - timedelta(days=TOKEN_RETENTION_DAYS)).isoformat().replace("+00:00", "Z")
+        conn.execute(
+            """DELETE FROM compute_enrollment_tokens
+               WHERE expires_at < ? AND (consumed_at IS NULL OR consumed_at < ?)""",
+            (retention_cutoff, retention_cutoff),
+        )
+        conn.execute(
+            """INSERT INTO compute_enrollment_tokens
+                   (token_id, token_hmac, requested_name, expires_at, created_by, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (token_id, _token_hmac(token), requested_name, expires_at, created_by, now_iso()),
+        )
+    return CreatedEnrollmentToken(token_id, token, requested_name, expires_at)
+
+
+def consume_token(token: str) -> ConsumedEnrollmentToken:
+    if not isinstance(token, str) or not 32 <= len(token) <= MAX_TOKEN_LENGTH or not token.isascii():
+        raise EnrollmentError()
+    digest = _token_hmac(token)
+    consumed_at = now_iso()
+    with db(immediate=True) as conn:
+        row = conn.execute(
+            """SELECT token_id, requested_name, created_by
+               FROM compute_enrollment_tokens
+               WHERE token_hmac = ? AND consumed_at IS NULL AND expires_at > ?""",
+            (digest, consumed_at),
+        ).fetchone()
+        if row is None:
+            raise EnrollmentError()
+        result = conn.execute(
+            """UPDATE compute_enrollment_tokens SET consumed_at = ?
+               WHERE token_id = ? AND consumed_at IS NULL AND expires_at > ?""",
+            (consumed_at, row["token_id"], consumed_at),
+        )
+        if result.rowcount != 1:  # pragma: no cover - BEGIN IMMEDIATE serializes consumers
+            raise EnrollmentError()
+    return ConsumedEnrollmentToken(row["token_id"], row["requested_name"], row["created_by"])

--- a/core/src/hydrahive/compute/enrollment.py
+++ b/core/src/hydrahive/compute/enrollment.py
@@ -8,6 +8,7 @@ import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
+from hydrahive.compute import audit
 from hydrahive.db._utils import now_iso, uuid7
 from hydrahive.db.connection import db
 from hydrahive.settings import settings
@@ -48,7 +49,14 @@ def _validate_text(value: str, field: str, maximum: int) -> str:
     return value
 
 
-def _token_hmac(token: str) -> str:
+def validate_token(token: str) -> str:
+    if not isinstance(token, str) or not 32 <= len(token) <= MAX_TOKEN_LENGTH or not token.isascii():
+        raise EnrollmentError()
+    return token
+
+
+def token_digest(token: str) -> str:
+    validate_token(token)
     return hmac.new(
         settings.secret_key.encode("utf-8"),
         b"hydrahive-compute-enrollment-v1\0" + token.encode("ascii"),
@@ -81,15 +89,19 @@ def create_token(
             """INSERT INTO compute_enrollment_tokens
                    (token_id, token_hmac, requested_name, expires_at, created_by, created_at)
                VALUES (?, ?, ?, ?, ?, ?)""",
-            (token_id, _token_hmac(token), requested_name, expires_at, created_by, now_iso()),
+            (token_id, token_digest(token), requested_name, expires_at, created_by, now_iso()),
+        )
+        audit.record_in_connection(
+            conn,
+            actor=created_by,
+            action="enrollment.created",
+            details={"token_id": token_id, "requested_name": requested_name},
         )
     return CreatedEnrollmentToken(token_id, token, requested_name, expires_at)
 
 
 def consume_token(token: str) -> ConsumedEnrollmentToken:
-    if not isinstance(token, str) or not 32 <= len(token) <= MAX_TOKEN_LENGTH or not token.isascii():
-        raise EnrollmentError()
-    digest = _token_hmac(token)
+    digest = token_digest(token)
     consumed_at = now_iso()
     with db(immediate=True) as conn:
         row = conn.execute(

--- a/core/src/hydrahive/compute/enrollment.py
+++ b/core/src/hydrahive/compute/enrollment.py
@@ -81,6 +81,14 @@ def create_token(
     with db() as conn:
         retention_cutoff = (datetime.now(UTC) - timedelta(days=TOKEN_RETENTION_DAYS)).isoformat().replace("+00:00", "Z")
         conn.execute(
+            """DELETE FROM compute_enrollment_results
+               WHERE token_id IN (
+                   SELECT token_id FROM compute_enrollment_tokens
+                   WHERE expires_at < ? AND (consumed_at IS NULL OR consumed_at < ?)
+               )""",
+            (retention_cutoff, retention_cutoff),
+        )
+        conn.execute(
             """DELETE FROM compute_enrollment_tokens
                WHERE expires_at < ? AND (consumed_at IS NULL OR consumed_at < ?)""",
             (retention_cutoff, retention_cutoff),

--- a/core/src/hydrahive/compute/identity.py
+++ b/core/src/hydrahive/compute/identity.py
@@ -1,0 +1,171 @@
+"""Local compute CA and constrained node-client certificate issuance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from hydrahive.compute import _identity_store as identity_store
+from hydrahive.compute._node_codec import validate_identity
+
+MAX_CSR_BYTES = 16 * 1024
+CA_VALID_DAYS = 3650
+NODE_CERT_VALID_DAYS = 90
+
+
+class IdentityError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ComputeCA:
+    certificate_pem: bytes
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class IssuedNodeCertificate:
+    certificate_pem: bytes
+    ca_certificate_pem: bytes
+    fingerprint: str
+    expires_at: str
+
+
+def certificate_fingerprint(certificate_pem: bytes) -> str:
+    try:
+        certificate = x509.load_pem_x509_certificate(certificate_pem)
+    except ValueError as exc:
+        raise IdentityError("invalid certificate") from exc
+    return certificate.fingerprint(hashes.SHA256()).hex()
+
+
+def _load_ca_state() -> identity_store.CAState | None:
+    try:
+        return identity_store.load_ca()
+    except ValueError as exc:
+        raise IdentityError(str(exc)) from exc
+
+
+def ensure_compute_ca() -> ComputeCA:
+    with identity_store.ca_lock():
+        loaded = _load_ca_state()
+        if loaded is None:
+            key = ec.generate_private_key(ec.SECP384R1())
+            now = datetime.now(UTC)
+            subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "HydraHive Compute CA")])
+            certificate = (
+                x509.CertificateBuilder()
+                .subject_name(subject)
+                .issuer_name(subject)
+                .public_key(key.public_key())
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(now - timedelta(minutes=5))
+                .not_valid_after(now + timedelta(days=CA_VALID_DAYS))
+                .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+                .add_extension(
+                    x509.KeyUsage(True, False, False, False, False, True, True, False, False),
+                    critical=True,
+                )
+                .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)
+                .sign(key, hashes.SHA384())
+            )
+            key_pem = key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+            identity_store.write_ca_pair(key_pem, certificate.public_bytes(serialization.Encoding.PEM))
+            loaded = _load_ca_state()
+        if loaded is None:  # pragma: no cover - write_ca_pair is validated above
+            raise IdentityError("compute CA is unavailable")
+        return ComputeCA(
+            loaded.certificate_pem,
+            certificate_fingerprint(loaded.certificate_pem),
+        )
+
+
+def _validated_csr(csr_pem: bytes, expected_common_name: str) -> x509.CertificateSigningRequest:
+    if not isinstance(csr_pem, bytes) or not csr_pem or len(csr_pem) > MAX_CSR_BYTES:
+        raise IdentityError("CSR size is invalid")
+    try:
+        csr = x509.load_pem_x509_csr(csr_pem)
+    except ValueError as exc:
+        raise IdentityError("CSR is invalid") from exc
+    if not csr.is_signature_valid:
+        raise IdentityError("CSR signature is invalid")
+    names = csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if len(names) != 1 or names[0].value != expected_common_name or len(csr.subject) != 1:
+        raise IdentityError("CSR common name does not match enrollment")
+    if list(csr.extensions):
+        raise IdentityError("CSR extensions are not allowed")
+    public_key = csr.public_key()
+    valid_ec = isinstance(public_key, ec.EllipticCurvePublicKey) and public_key.key_size >= 256
+    valid_rsa = isinstance(public_key, rsa.RSAPublicKey) and public_key.key_size >= 2048
+    if not valid_ec and not valid_rsa:
+        raise IdentityError("CSR public key is not allowed")
+    return csr
+
+
+def issue_node_certificate(
+    csr_pem: bytes,
+    *,
+    node_id: str,
+    expected_common_name: str,
+) -> IssuedNodeCertificate:
+    validate_identity(node_id, expected_common_name)
+    csr = _validated_csr(csr_pem, expected_common_name)
+    ensure_compute_ca()
+    with identity_store.ca_lock():
+        loaded = _load_ca_state()
+    if loaded is None:  # pragma: no cover - ensure_compute_ca creates it
+        raise IdentityError("compute CA is unavailable")
+    ca_key = loaded.key
+    ca_pem = loaded.certificate_pem
+    ca_certificate = loaded.certificate
+    now = datetime.now(UTC)
+    expires_at = min(now + timedelta(days=NODE_CERT_VALID_DAYS), ca_certificate.not_valid_after_utc)
+    if expires_at <= now + timedelta(days=1):
+        raise IdentityError("compute CA expires too soon to issue a node certificate")
+    public_key = csr.public_key()
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, node_id)]))
+        .issuer_name(ca_certificate.subject)
+        .public_key(public_key)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(expires_at)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=isinstance(public_key, rsa.RSAPublicKey),
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(f"urn:hydrahive:node:{node_id}")]), False
+        )
+        .add_extension(x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), False)
+        .sign(ca_key, hashes.SHA384())
+    )
+    certificate_pem = certificate.public_bytes(serialization.Encoding.PEM)
+    return IssuedNodeCertificate(
+        certificate_pem,
+        ca_pem,
+        certificate_fingerprint(certificate_pem),
+        expires_at.isoformat().replace("+00:00", "Z"),
+    )

--- a/core/src/hydrahive/compute/models.py
+++ b/core/src/hydrahive/compute/models.py
@@ -31,9 +31,11 @@ class ComputeNode:
     protocol_version: int
     created_at: str
     updated_at: str
+    last_sequence: int = 0
     capabilities: JSONObject = field(default_factory=dict)
     resources: JSONObject = field(default_factory=dict)
     labels: JSONObject = field(default_factory=dict)
+    health_errors: list[str] = field(default_factory=list)
     certificate_fingerprint: str | None = None
     agent_version: str | None = None
     last_seen_at: str | None = None

--- a/core/src/hydrahive/db/migrations/040_compute_audit.sql
+++ b/core/src/hydrahive/db/migrations/040_compute_audit.sql
@@ -1,0 +1,24 @@
+-- 040: Append-only security audit for compute-cluster administration.
+CREATE TABLE IF NOT EXISTS compute_audit_log (
+    audit_id       TEXT PRIMARY KEY,
+    actor          TEXT NOT NULL,
+    action         TEXT NOT NULL,
+    node_id        TEXT,
+    details_json   TEXT,
+    created_at     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_compute_audit_created ON compute_audit_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compute_audit_node ON compute_audit_log(node_id, created_at DESC);
+
+CREATE TRIGGER IF NOT EXISTS compute_audit_no_update
+BEFORE UPDATE ON compute_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'compute_audit_is_append_only');
+END;
+
+CREATE TRIGGER IF NOT EXISTS compute_audit_no_delete
+BEFORE DELETE ON compute_audit_log
+BEGIN
+    SELECT RAISE(ABORT, 'compute_audit_is_append_only');
+END;

--- a/core/src/hydrahive/db/migrations/041_compute_enrollment_results.sql
+++ b/core/src/hydrahive/db/migrations/041_compute_enrollment_results.sql
@@ -1,0 +1,9 @@
+-- 041: Idempotent recovery records for successful agent enrollments.
+CREATE TABLE IF NOT EXISTS compute_enrollment_results (
+    token_id                TEXT PRIMARY KEY REFERENCES compute_enrollment_tokens(token_id) ON DELETE RESTRICT,
+    csr_sha256              TEXT NOT NULL,
+    node_id                 TEXT NOT NULL UNIQUE REFERENCES compute_nodes(node_id) ON DELETE RESTRICT,
+    certificate_pem         TEXT NOT NULL,
+    certificate_expires_at  TEXT NOT NULL,
+    created_at              TEXT NOT NULL
+);

--- a/core/src/hydrahive/db/migrations/042_compute_enrollment_recovery_window.sql
+++ b/core/src/hydrahive/db/migrations/042_compute_enrollment_recovery_window.sql
@@ -1,0 +1,3 @@
+-- 042: Bound retry-safe certificate recovery for completed enrollments.
+ALTER TABLE compute_enrollment_results
+ADD COLUMN recovery_until TEXT NOT NULL DEFAULT '1970-01-01T00:00:00Z';

--- a/core/src/hydrahive/db/migrations/043_compute_pending_enrollment_name.sql
+++ b/core/src/hydrahive/db/migrations/043_compute_pending_enrollment_name.sql
@@ -1,0 +1,4 @@
+-- 043: Allow at most one live enrollment token for a requested node name.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_compute_enrollment_pending_name
+ON compute_enrollment_tokens(requested_name)
+WHERE consumed_at IS NULL;

--- a/core/src/hydrahive/db/migrations/044_compute_node_sequence.sql
+++ b/core/src/hydrahive/db/migrations/044_compute_node_sequence.sql
@@ -1,0 +1,3 @@
+-- 044: Persist agent protocol sequence across reconnects.
+ALTER TABLE compute_nodes
+ADD COLUMN last_sequence INTEGER NOT NULL DEFAULT 0 CHECK (last_sequence >= 0);

--- a/core/src/hydrahive/db/migrations/045_compute_agent_nonces.sql
+++ b/core/src/hydrahive/db/migrations/045_compute_agent_nonces.sql
@@ -1,0 +1,10 @@
+-- 045: Bounded replay protection for agent protocol messages.
+CREATE TABLE IF NOT EXISTS compute_agent_nonces (
+    node_id     TEXT NOT NULL REFERENCES compute_nodes(node_id) ON DELETE CASCADE,
+    nonce       TEXT NOT NULL,
+    expires_at  TEXT NOT NULL,
+    PRIMARY KEY (node_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS idx_compute_agent_nonces_expiry
+ON compute_agent_nonces(expires_at);

--- a/core/src/hydrahive/db/migrations/046_compute_node_health_errors.sql
+++ b/core/src/hydrahive/db/migrations/046_compute_node_health_errors.sql
@@ -1,0 +1,3 @@
+-- 046: Persist bounded structured health errors reported by agents.
+ALTER TABLE compute_nodes
+ADD COLUMN health_errors_json TEXT NOT NULL DEFAULT '[]';

--- a/core/src/hydrahive/settings/_compute.py
+++ b/core/src/hydrahive/settings/_compute.py
@@ -19,3 +19,7 @@ class _ComputeMixin:
     @cached_property
     def compute_ca_cert_path(self) -> Path:
         return self.compute_pki_dir / "ca-cert.pem"
+
+    @cached_property
+    def compute_proxy_secret(self) -> str:
+        return os.environ.get("HH_COMPUTE_PROXY_SECRET", "").strip()

--- a/core/src/hydrahive/settings/_compute.py
+++ b/core/src/hydrahive/settings/_compute.py
@@ -1,0 +1,21 @@
+"""Compute-cluster PKI paths."""
+
+from __future__ import annotations
+
+import os
+from functools import cached_property
+from pathlib import Path
+
+
+class _ComputeMixin:
+    @cached_property
+    def compute_pki_dir(self) -> Path:
+        return Path(os.environ.get("HH_COMPUTE_PKI_DIR", str(self.config_dir / "compute-pki")))
+
+    @cached_property
+    def compute_ca_key_path(self) -> Path:
+        return self.compute_pki_dir / "ca-key.pem"
+
+    @cached_property
+    def compute_ca_cert_path(self) -> Path:
+        return self.compute_pki_dir / "ca-cert.pem"

--- a/core/src/hydrahive/settings/settings.py
+++ b/core/src/hydrahive/settings/settings.py
@@ -9,8 +9,10 @@ Properties sind in Mixins gruppiert:
 - `_services.py`: Server, JWT, AgentLink, Communication
 - `_infra.py`: Samba, VMs, Extensions, Butler
 """
+
 from __future__ import annotations
 
+from hydrahive.settings._compute import _ComputeMixin
 from hydrahive.settings._infra import (
     _ButlerMixin,
     _ExtensionsMixin,
@@ -35,6 +37,7 @@ class Settings(
     _CommunicationMixin,
     _MailMixin,
     _TeamchatMixin,
+    _ComputeMixin,
     _SambaMixin,
     _VmsMixin,
     _ExtensionsMixin,

--- a/core/tests/test_compute_agent_enroll_api.py
+++ b/core/tests/test_compute_agent_enroll_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from hydrahive.api.middleware import inbound_ratelimit
+from hydrahive.compute import audit
+from tests.conftest import error_code
+
+
+def _csr(common_name: str) -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+        .sign(key, hashes.SHA256())
+        .public_bytes(serialization.Encoding.PEM)
+        .decode("ascii")
+    )
+
+
+def test_full_node_enrollment_approval_disable_enable_and_revoke(client, admin_headers) -> None:
+    inbound_ratelimit.reset()
+    token_response = client.post(
+        "/api/compute/enrollments",
+        headers=admin_headers,
+        json={"requested_name": "API Flow Node", "ttl_seconds": 300},
+    )
+    assert token_response.status_code == 201
+    token = token_response.json()["token"]
+
+    csr_pem = _csr("API Flow Node")
+    enrollment_payload = {
+        "token": token,
+        "csr_pem": csr_pem,
+        "protocol_version": 1,
+        "agent_version": "1.0.0",
+        "capabilities": {"instances": ["container", "vm"]},
+        "resources": {"cpu_cores": 8},
+    }
+    enrolled = client.post("/api/compute/agent/enroll", json=enrollment_payload)
+    assert enrolled.status_code == 201
+    result = enrolled.json()
+    node_id = result["node"]["node_id"]
+    fingerprint = result["certificate_fingerprint"]
+    assert result["node"]["status"] == "pending"
+    assert x509.load_pem_x509_certificate(result["certificate_pem"].encode("ascii"))
+
+    recovered = client.post("/api/compute/agent/enroll", json=enrollment_payload)
+    assert recovered.status_code == 201
+    assert recovered.json()["node"]["node_id"] == node_id
+    assert recovered.json()["certificate_pem"] == result["certificate_pem"]
+
+    changed_csr = enrollment_payload | {"csr_pem": _csr("API Flow Node")}
+    reused = client.post("/api/compute/agent/enroll", json=changed_csr)
+    assert reused.status_code == 400
+    assert error_code(reused) == "compute_enrollment_invalid"
+
+    mismatch = client.post(
+        f"/api/compute/nodes/{node_id}/approve",
+        headers=admin_headers,
+        json={"certificate_fingerprint": "00" * 32},
+    )
+    assert mismatch.status_code == 409
+    assert error_code(mismatch) == "compute_fingerprint_mismatch"
+
+    approved = client.post(
+        f"/api/compute/nodes/{node_id}/approve",
+        headers=admin_headers,
+        json={"certificate_fingerprint": fingerprint},
+    )
+    assert approved.status_code == 200
+    assert approved.json()["status"] == "online"
+
+    disabled = client.post(f"/api/compute/nodes/{node_id}/disable", headers=admin_headers)
+    assert disabled.status_code == 200
+    assert disabled.json()["status"] == "disabled"
+    enabled = client.post(f"/api/compute/nodes/{node_id}/enable", headers=admin_headers)
+    assert enabled.status_code == 200
+    assert enabled.json()["status"] == "online"
+    revoked = client.delete(f"/api/compute/nodes/{node_id}", headers=admin_headers)
+    assert revoked.status_code == 200
+    assert revoked.json()["status"] == "revoked"
+
+    actions = {record["action"] for record in audit.list_records(node_id=node_id)}
+    assert {"node.enrolled", "node.approved", "node.disabled", "node.online", "node.revoked"} <= actions
+
+
+def test_agent_enrollment_is_rate_limited(client, monkeypatch) -> None:
+    from hydrahive.api.routes import compute_agent
+
+    inbound_ratelimit.reset()
+    monkeypatch.setattr(compute_agent, "ENROLL_IP_RATE_LIMIT", 2)
+    monkeypatch.setattr(compute_agent, "ENROLL_TOKEN_RATE_LIMIT", 10)
+    payload = {"token": "x" * 43, "csr_pem": _csr("Rate Node"), "agent_version": "1.0.0"}
+
+    assert client.post("/api/compute/agent/enroll", json=payload).status_code == 400
+    assert client.post("/api/compute/agent/enroll", json=payload).status_code == 400
+    limited = client.post("/api/compute/agent/enroll", json=payload)
+    assert limited.status_code == 429
+    assert error_code(limited) == "rate_limited"

--- a/core/tests/test_compute_agent_enroll_api.py
+++ b/core/tests/test_compute_agent_enroll_api.py
@@ -72,7 +72,7 @@ def test_full_node_enrollment_approval_disable_enable_and_revoke(client, admin_h
         json={"certificate_fingerprint": fingerprint},
     )
     assert approved.status_code == 200
-    assert approved.json()["status"] == "online"
+    assert approved.json()["status"] == "offline"
 
     disabled = client.post(f"/api/compute/nodes/{node_id}/disable", headers=admin_headers)
     assert disabled.status_code == 200

--- a/core/tests/test_compute_agent_enroll_api.py
+++ b/core/tests/test_compute_agent_enroll_api.py
@@ -88,6 +88,20 @@ def test_full_node_enrollment_approval_disable_enable_and_revoke(client, admin_h
     assert {"node.enrolled", "node.approved", "node.disabled", "node.online", "node.revoked"} <= actions
 
 
+def test_agent_enrollment_rejects_oversized_body_before_json_parsing(client) -> None:
+    inbound_ratelimit.reset()
+    oversized = b"{" + b"x" * (97 * 1024)
+
+    response = client.post(
+        "/api/compute/agent/enroll",
+        content=oversized,
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert error_code(response) == "compute_enrollment_body_too_large"
+
+
 def test_agent_enrollment_is_rate_limited(client, monkeypatch) -> None:
     from hydrahive.api.routes import compute_agent
 

--- a/core/tests/test_compute_channel.py
+++ b/core/tests/test_compute_channel.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from hydrahive.compute import channel, channel_monitor
+from hydrahive.compute import db as node_db
+from hydrahive.db.connection import db, init_db
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def connected_node(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(settings, "sessions_db", tmp_path / "channel.db", raising=False)
+    monkeypatch.setattr(settings, "compute_proxy_secret", "proxy-secret", raising=False)
+    monkeypatch.setattr(
+        channel,
+        "proxy_certificate_fingerprint",
+        lambda certificate: "00" * 32 if certificate == "wrong-cert" else "ab" * 32,
+    )
+    init_db()
+    node = node_db.create_node(
+        node_id="node-channel",
+        name="Channel Node",
+        certificate_fingerprint="ab" * 32,
+    )
+    node_db.approve_node(node.node_id, "admin-id")
+    return node.node_id
+
+
+def _raw(node_id: str, *, sequence: int, nonce: str, kind: str = "heartbeat", payload=None) -> str:
+    return json.dumps(
+        {
+            "type": kind,
+            "protocol_version": 1,
+            "node_id": node_id,
+            "sequence": sequence,
+            "nonce": nonce,
+            "sent_at": datetime.now(UTC).isoformat(),
+            "payload": (payload if payload is not None else {"capabilities": {}, "resources": {}, "health_errors": []}),
+        }
+    )
+
+
+def test_agent_identity_requires_proxy_secret_fingerprint_and_online_status(connected_node: str) -> None:
+    channel.authenticate_node(connected_node, "valid-cert", "proxy-secret")
+
+    for certificate, secret in (("wrong-cert", "proxy-secret"), ("valid-cert", "wrong")):
+        with pytest.raises(channel.ProtocolError, match="agent_identity_invalid"):
+            channel.authenticate_node(connected_node, certificate, secret)
+
+    node_db.revoke_node(connected_node, actor="admin-id")
+    with pytest.raises(channel.ProtocolError, match="agent_identity_invalid"):
+        channel.authenticate_node(connected_node, "valid-cert", "proxy-secret")
+
+
+def test_protocol_rejects_replayed_sequence_nonce_and_wrong_node(connected_node: str) -> None:
+    first = channel.parse_message(_raw(connected_node, sequence=1, nonce="nonce-0000000001"))
+    assert channel.accept_message(connected_node, first)["sequence"] == 1
+
+    with pytest.raises(channel.ProtocolError, match="sequence_replayed"):
+        channel.accept_message(connected_node, first)
+
+    repeated_nonce = channel.parse_message(_raw(connected_node, sequence=2, nonce="nonce-0000000001"))
+    with pytest.raises(channel.ProtocolError, match="nonce_replayed"):
+        channel.accept_message(connected_node, repeated_nonce)
+
+    wrong_node = channel.parse_message(_raw("other-node", sequence=2, nonce="nonce-0000000002"))
+    with pytest.raises(channel.ProtocolError, match="node_mismatch"):
+        channel.accept_message(connected_node, wrong_node)
+
+
+def test_protocol_validates_timestamp_schema_and_payload(connected_node: str) -> None:
+    stale = json.loads(_raw(connected_node, sequence=1, nonce="nonce-0000000001"))
+    stale["sent_at"] = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+    with pytest.raises(channel.ProtocolError, match="timestamp_invalid"):
+        channel.parse_message(json.dumps(stale))
+
+    invalid = json.loads(_raw(connected_node, sequence=1, nonce="nonce-0000000002"))
+    invalid["unexpected"] = True
+    with pytest.raises(channel.ProtocolError, match="message_invalid"):
+        channel.parse_message(json.dumps(invalid))
+
+    bad_payload = channel.parse_message(
+        _raw(connected_node, sequence=1, nonce="nonce-0000000003", payload={"resources": [], "health_errors": []})
+    )
+    with pytest.raises(channel.ProtocolError, match="payload_invalid"):
+        channel.accept_message(connected_node, bad_payload)
+
+
+def test_capabilities_and_heartbeats_update_node_health(connected_node: str) -> None:
+    hello = channel.parse_message(
+        _raw(
+            connected_node,
+            sequence=1,
+            nonce="nonce-0000000001",
+            kind="hello",
+            payload={"agent_version": "0.1.0"},
+        )
+    )
+    channel.accept_message(connected_node, hello)
+    capabilities = channel.parse_message(
+        _raw(
+            connected_node,
+            sequence=2,
+            nonce="nonce-0000000002",
+            kind="capabilities",
+            payload={"capabilities": {"kvm": True}, "resources": {"cpu_cores": 8}},
+        )
+    )
+    channel.accept_message(connected_node, capabilities)
+    degraded = channel.parse_message(
+        _raw(
+            connected_node,
+            sequence=3,
+            nonce="nonce-0000000003",
+            payload={
+                "capabilities": {"kvm": False},
+                "resources": {"cpu_load_1m": 1.5},
+                "health_errors": ["incus_unavailable"],
+            },
+        )
+    )
+    channel.accept_message(connected_node, degraded)
+
+    node = node_db.get_node(connected_node)
+    assert node.agent_version == "0.1.0"
+    assert node.capabilities == {"kvm": False}
+    assert node.resources == {"cpu_load_1m": 1.5}
+    assert node.health_errors == ["incus_unavailable"]
+    assert node.status == "degraded"
+    assert node.last_sequence == 3
+    assert node.last_seen_at is not None
+    with db() as conn:
+        actions = [
+            row["action"]
+            for row in conn.execute(
+                "SELECT action FROM compute_audit_log WHERE node_id = ? ORDER BY created_at, audit_id",
+                (connected_node,),
+            )
+        ]
+    assert "node.degraded" in actions
+
+
+def test_websocket_channel_requires_bound_identity_and_acknowledges(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "compute_proxy_secret", "proxy-secret", raising=False)
+    monkeypatch.setattr(channel, "proxy_certificate_fingerprint", lambda certificate: "cd" * 32)
+    node = node_db.create_node(
+        node_id="node-websocket",
+        name="WebSocket Node",
+        certificate_fingerprint="cd" * 32,
+    )
+    node_db.approve_node(node.node_id, "admin-id")
+    headers = {
+        "x-hydrahive-node-id": node.node_id,
+        "x-hydrahive-client-cert": "valid-cert",
+        "x-hydrahive-proxy-secret": "proxy-secret",
+    }
+    with client.websocket_connect("/api/compute/agent/connect", headers=headers) as websocket:
+        websocket.send_text(_raw(node.node_id, sequence=1, nonce="nonce-websocket01"))
+        assert websocket.receive_json()["sequence"] == 1
+
+
+def test_dead_detection_marks_degraded_then_offline(connected_node: str) -> None:
+    node_db.transition_node_status(connected_node, "online")
+    old = (datetime.now(UTC) - timedelta(seconds=60)).isoformat().replace("+00:00", "Z")
+    with db() as conn:
+        conn.execute("UPDATE compute_nodes SET last_seen_at = ? WHERE node_id = ?", (old, connected_node))
+    assert channel_monitor.mark_stale_nodes(degraded_after=45, offline_after=90) == (1, 0)
+    assert node_db.get_node(connected_node).status == "degraded"
+
+    older = (datetime.now(UTC) - timedelta(seconds=120)).isoformat().replace("+00:00", "Z")
+    with db() as conn:
+        conn.execute("UPDATE compute_nodes SET last_seen_at = ? WHERE node_id = ?", (older, connected_node))
+    assert channel_monitor.mark_stale_nodes(degraded_after=45, offline_after=90) == (0, 1)
+    assert node_db.get_node(connected_node).status == "offline"
+    with db() as conn:
+        monitor_actions = [
+            row["action"]
+            for row in conn.execute(
+                "SELECT action FROM compute_audit_log WHERE actor = 'system:compute-monitor' ORDER BY created_at"
+            )
+        ]
+    assert monitor_actions == ["node.degraded", "node.offline"]

--- a/core/tests/test_compute_enrollment.py
+++ b/core/tests/test_compute_enrollment.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import base64
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from hydrahive.compute import enrollment
+from hydrahive.db.connection import init_db
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def enrollment_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    database = tmp_path / "enrollment.db"
+    monkeypatch.setattr(settings, "sessions_db", database, raising=False)
+    monkeypatch.setattr(settings, "secret_key", "test-secret-with-more-than-thirty-two-bytes", raising=False)
+    init_db()
+    return database
+
+
+def _decode_token(token: str) -> bytes:
+    return base64.urlsafe_b64decode(token + "=" * (-len(token) % 4))
+
+
+def test_enrollment_token_has_256_bits_and_only_hmac_is_stored(enrollment_db: Path) -> None:
+    created = enrollment.create_token(requested_name="Node A", created_by="admin", ttl_seconds=600)
+
+    assert len(_decode_token(created.token)) == 32
+    with sqlite3.connect(enrollment_db) as conn:
+        row = conn.execute(
+            "SELECT token_hmac, requested_name, consumed_at FROM compute_enrollment_tokens WHERE token_id = ?",
+            (created.token_id,),
+        ).fetchone()
+    assert row is not None
+    assert row[0] != created.token
+    assert len(row[0]) == 64
+    assert row[1:] == ("Node A", None)
+
+
+def test_enrollment_token_is_consumed_exactly_once(enrollment_db: Path) -> None:
+    created = enrollment.create_token(requested_name="Node A", created_by="admin", ttl_seconds=600)
+
+    consumed = enrollment.consume_token(created.token)
+    assert consumed.token_id == created.token_id
+    assert consumed.requested_name == "Node A"
+
+    with pytest.raises(enrollment.EnrollmentError) as reused:
+        enrollment.consume_token(created.token)
+    assert reused.value.code == "enrollment_invalid"
+
+
+def test_wrong_and_expired_tokens_return_same_generic_error(enrollment_db: Path) -> None:
+    created = enrollment.create_token(requested_name="Node A", created_by="admin", ttl_seconds=60)
+    expired_at = (datetime.now(UTC) - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    with sqlite3.connect(enrollment_db) as conn:
+        conn.execute(
+            "UPDATE compute_enrollment_tokens SET expires_at = ? WHERE token_id = ?",
+            (expired_at, created.token_id),
+        )
+        conn.commit()
+
+    errors: list[str] = []
+    for token in (created.token, "x" * 43):
+        with pytest.raises(enrollment.EnrollmentError) as exc_info:
+            enrollment.consume_token(token)
+        errors.append(exc_info.value.code)
+    assert errors == ["enrollment_invalid", "enrollment_invalid"]
+
+
+@pytest.mark.parametrize("ttl", [0, 3601])
+def test_enrollment_token_ttl_is_bounded(enrollment_db: Path, ttl: int) -> None:
+    with pytest.raises(ValueError, match="ttl"):
+        enrollment.create_token(requested_name="Node A", created_by="admin", ttl_seconds=ttl)

--- a/core/tests/test_compute_identity.py
+++ b/core/tests/test_compute_identity.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from hydrahive.compute import identity
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def pki_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    directory = tmp_path / "compute-pki"
+    monkeypatch.setattr(settings, "compute_pki_dir", directory, raising=False)
+    monkeypatch.setattr(settings, "compute_ca_key_path", directory / "ca-key.pem", raising=False)
+    monkeypatch.setattr(settings, "compute_ca_cert_path", directory / "ca-cert.pem", raising=False)
+    return directory
+
+
+def _csr(common_name: str = "Node A") -> bytes:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)]))
+        .sign(key, hashes.SHA256())
+        .public_bytes(serialization.Encoding.PEM)
+    )
+
+
+def test_compute_ca_is_stable_and_private_key_is_mode_0600(pki_dir: Path) -> None:
+    first = identity.ensure_compute_ca()
+    second = identity.ensure_compute_ca()
+
+    assert first.fingerprint == second.fingerprint
+    assert first.certificate_pem == second.certificate_pem
+    assert os.stat(settings.compute_ca_key_path).st_mode & 0o777 == 0o600
+    assert settings.compute_ca_key_path.read_bytes().startswith(b"-----BEGIN PRIVATE KEY-----")
+
+
+def test_compute_ca_initialization_is_serialized(pki_dir: Path) -> None:
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        fingerprints = list(executor.map(lambda _: identity.ensure_compute_ca().fingerprint, range(16)))
+
+    assert len(set(fingerprints)) == 1
+
+
+def test_compute_ca_rejects_mismatched_key_and_certificate(pki_dir: Path) -> None:
+    identity.ensure_compute_ca()
+    unrelated_key = ec.generate_private_key(ec.SECP384R1())
+    settings.compute_ca_key_path.write_bytes(
+        unrelated_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+
+    with pytest.raises(identity.IdentityError, match="invalid"):
+        identity.ensure_compute_ca()
+
+
+def test_issue_node_certificate_has_client_auth_and_stable_fingerprint(pki_dir: Path) -> None:
+    issued = identity.issue_node_certificate(
+        _csr(),
+        node_id="018f-node-a",
+        expected_common_name="Node A",
+    )
+    certificate = x509.load_pem_x509_certificate(issued.certificate_pem)
+
+    assert issued.fingerprint == identity.certificate_fingerprint(issued.certificate_pem)
+    assert certificate.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == "018f-node-a"
+    assert certificate.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value == x509.ExtendedKeyUsage(
+        [ExtendedKeyUsageOID.CLIENT_AUTH]
+    )
+    assert certificate.extensions.get_extension_for_class(x509.BasicConstraints).value.ca is False
+    key_usage = certificate.extensions.get_extension_for_class(x509.KeyUsage).value
+    assert key_usage.digital_signature is True
+    assert key_usage.key_cert_sign is False
+
+
+@pytest.mark.parametrize(
+    ("csr_pem", "message"),
+    [
+        (b"not a csr", "CSR"),
+        (b"x" * 20000, "CSR"),
+        (_csr("Wrong Node"), "common name"),
+    ],
+)
+def test_issue_node_certificate_rejects_invalid_csr(pki_dir: Path, csr_pem: bytes, message: str) -> None:
+    with pytest.raises(identity.IdentityError, match=message):
+        identity.issue_node_certificate(
+            csr_pem,
+            node_id="018f-node-a",
+            expected_common_name="Node A",
+        )

--- a/core/tests/test_compute_migration.py
+++ b/core/tests/test_compute_migration.py
@@ -52,6 +52,8 @@ def test_migration_creates_compute_schema_and_local_node_once(tmp_path: Path) ->
                 "resources_json",
                 "labels_json",
                 "last_seen_at",
+                "last_sequence",
+                "health_errors_json",
                 "approved_at",
                 "approved_by",
                 "revoked_at",

--- a/core/tests/test_compute_migration.py
+++ b/core/tests/test_compute_migration.py
@@ -132,6 +132,28 @@ def test_compute_migrations_resume_after_legacy_columns_were_partially_applied(t
         conn.close()
 
 
+def test_enrollment_recovery_migration_upgrades_existing_041_schema(tmp_path: Path) -> None:
+    conn = sqlite3.connect(tmp_path / "enrollment-upgrade.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        _apply_through_031(conn)
+        for migration in sorted(MIGRATIONS_DIR.glob("*.sql")):
+            if 32 <= _migration_version(migration) <= 41:
+                conn.executescript(migration.read_text())
+        before = {row["name"] for row in conn.execute("PRAGMA table_info(compute_enrollment_results)")}
+        assert "recovery_until" not in before
+
+        conn.executescript((MIGRATIONS_DIR / "042_compute_enrollment_recovery_window.sql").read_text())
+        conn.executescript((MIGRATIONS_DIR / "043_compute_pending_enrollment_name.sql").read_text())
+
+        after = {row["name"] for row in conn.execute("PRAGMA table_info(compute_enrollment_results)")}
+        indexes = {row["name"] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'index'")}
+        assert "recovery_until" in after
+        assert "idx_compute_enrollment_pending_name" in indexes
+    finally:
+        conn.close()
+
+
 def test_migration_backfills_existing_resources(tmp_path: Path) -> None:
     conn = sqlite3.connect(tmp_path / "backfill.db")
     conn.row_factory = sqlite3.Row

--- a/core/tests/test_compute_nodes_api.py
+++ b/core/tests/test_compute_nodes_api.py
@@ -60,6 +60,14 @@ def test_enrollment_token_creation_requires_admin_and_is_audited(client, auth_he
     assert record["details"]["token_id"] == body["token_id"]
     assert "token" not in record["details"]
 
+    duplicate = client.post(
+        "/api/compute/enrollments",
+        headers=admin_headers,
+        json={"requested_name": " API Auth Node ", "ttl_seconds": 300},
+    )
+    assert duplicate.status_code == 409
+    assert error_code(duplicate) == "compute_node_name_exists"
+
     with pytest.raises(sqlite3.IntegrityError, match="append_only"):
         with db() as conn:
             conn.execute(

--- a/core/tests/test_compute_nodes_api.py
+++ b/core/tests/test_compute_nodes_api.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hydrahive.compute import audit
+from hydrahive.db.connection import db
+from tests.conftest import error_code
+
+
+def test_compute_nodes_require_admin(client, auth_headers, admin_headers) -> None:
+    assert client.get("/api/compute/nodes").status_code == 401
+
+    denied = client.get("/api/compute/nodes", headers=auth_headers)
+    assert denied.status_code == 403
+    assert error_code(denied) == "admin_only"
+
+    allowed = client.get("/api/compute/nodes", headers=admin_headers)
+    assert allowed.status_code == 200
+    assert allowed.json()[0]["node_id"] == "local"
+
+
+def test_compute_admin_uses_current_role(client, admin_headers, monkeypatch) -> None:
+    from hydrahive.api.middleware import users
+
+    monkeypatch.setattr(
+        users,
+        "get_by_id",
+        lambda user_id: {"user_id": user_id, "username": "admin", "role": "user"},
+    )
+
+    denied = client.get("/api/compute/nodes", headers=admin_headers)
+    assert denied.status_code == 403
+    assert error_code(denied) == "admin_only"
+
+
+def test_enrollment_token_creation_requires_admin_and_is_audited(client, auth_headers, admin_headers) -> None:
+    denied = client.post(
+        "/api/compute/enrollments",
+        headers=auth_headers,
+        json={"requested_name": "API Auth Node"},
+    )
+    assert denied.status_code == 403
+
+    created = client.post(
+        "/api/compute/enrollments",
+        headers=admin_headers,
+        json={"requested_name": "API Auth Node", "ttl_seconds": 300},
+    )
+    assert created.status_code == 201
+    body = created.json()
+    assert len(body["token"]) >= 43
+    assert body["requested_name"] == "API Auth Node"
+
+    records = audit.list_records(limit=10)
+    record = next(item for item in records if item["action"] == "enrollment.created")
+    assert record["actor"]
+    assert record["actor"] != "admin"
+    assert record["details"]["token_id"] == body["token_id"]
+    assert "token" not in record["details"]
+
+    with pytest.raises(sqlite3.IntegrityError, match="append_only"):
+        with db() as conn:
+            conn.execute(
+                "UPDATE compute_audit_log SET action = 'tampered' WHERE audit_id = ?",
+                (record["audit_id"],),
+            )

--- a/core/tests/test_compute_nodes_db.py
+++ b/core/tests/test_compute_nodes_db.py
@@ -79,6 +79,8 @@ def test_node_registry_updates_fields_and_validates_status_transitions(compute_d
     assert approved is not None
     assert approved.approved_at is not None
     assert approved.approved_by == "admin"
+    assert approved.status == "offline"
+    node_db.transition_node_status("node-a", "online")
     updated = node_db.update_node(
         "node-a",
         name="Compute Alpha",

--- a/core/tests/test_compute_nodes_db.py
+++ b/core/tests/test_compute_nodes_db.py
@@ -97,6 +97,8 @@ def test_node_registry_updates_fields_and_validates_status_transitions(compute_d
 def test_node_registry_rejects_invalid_and_oversized_json(compute_db: Path) -> None:
     with pytest.raises(ValueError, match="JSON"):
         node_db.create_node(node_id="node-a", name="Compute A", labels={"bad": object()})
+    with pytest.raises(ValueError, match="JSON"):
+        node_db.create_node(node_id="node-nan", name="Compute NaN", resources={"load": float("nan")})
 
     with pytest.raises(ValueError, match="too large"):
         node_db.create_node(

--- a/core/tests/test_update_sh_compute_agent.py
+++ b/core/tests/test_update_sh_compute_agent.py
@@ -1,0 +1,29 @@
+"""Regression guards for rolling compute-agent transport security to existing installs."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATE = (ROOT / "installer" / "update.sh").read_text(encoding="utf-8")
+SYSTEMD = (ROOT / "installer" / "modules" / "50-systemd.sh").read_text(encoding="utf-8")
+NGINX = (ROOT / "installer" / "modules" / "60-nginx.sh").read_text(encoding="utf-8")
+
+
+def test_update_rewrites_old_systemd_unit_for_compute_channel_security() -> None:
+    assert "EnvironmentFile=$COMPUTE_PROXY_ENV" in SYSTEMD
+    assert "--ws-max-size 65536" in SYSTEMD
+    assert 'grep -Fq "EnvironmentFile=$HH_CONFIG_DIR/compute-proxy.env"' in UPDATE
+    assert 'grep -q -- "--ws-max-size 65536"' in UPDATE
+
+
+def test_update_rewrites_old_nginx_config_for_compute_mtls() -> None:
+    assert "/api/compute/agent/connect" in NGINX
+    assert "ssl_verify_client optional" in NGINX
+    assert "hydrahive-compute-secret.conf" in NGINX
+    assert 'grep -q "/api/compute/agent/connect"' in UPDATE
+    assert 'grep -q "ssl_verify_client optional"' in UPDATE
+    assert 'grep -q "hydrahive-compute-secret.conf"' in UPDATE
+
+
+def test_update_passes_required_compute_paths_to_nginx_module() -> None:
+    assert UPDATE.count('HH_USER="$HH_USER" HH_DATA_DIR="$HH_DATA_DIR" HH_CONFIG_DIR="$HH_CONFIG_DIR"') >= 3

--- a/installer/modules/50-systemd.sh
+++ b/installer/modules/50-systemd.sh
@@ -28,6 +28,24 @@ if [ ! -f "$SECRET_FILE" ]; then
 fi
 SECRET_KEY="$(cat "$SECRET_FILE")"
 
+COMPUTE_PROXY_SECRET_FILE="$HH_CONFIG_DIR/compute_proxy_secret"
+if [ ! -f "$COMPUTE_PROXY_SECRET_FILE" ]; then
+  log "Generiere Compute-Proxy-Secret"
+  python3 -c "import secrets; print(secrets.token_urlsafe(48))" > "$COMPUTE_PROXY_SECRET_FILE"
+  chmod 600 "$COMPUTE_PROXY_SECRET_FILE"
+  chown root:root "$COMPUTE_PROXY_SECRET_FILE"
+fi
+COMPUTE_PROXY_SECRET="$(cat "$COMPUTE_PROXY_SECRET_FILE")"
+COMPUTE_PROXY_ENV="$HH_CONFIG_DIR/compute-proxy.env"
+printf 'HH_COMPUTE_PROXY_SECRET=%s\n' "$COMPUTE_PROXY_SECRET" > "$COMPUTE_PROXY_ENV"
+chmod 600 "$COMPUTE_PROXY_ENV"
+chown root:root "$COMPUTE_PROXY_ENV"
+
+case "$HH_HOST" in
+  127.0.0.1|::1|localhost) ;;
+  *) echo "Compute-Agent-Proxy erfordert einen nur lokal gebundenen Backend-Host (HH_HOST=$HH_HOST)" >&2; exit 1 ;;
+esac
+
 # Optionale Nutzer-Konfig-Datei anlegen falls nicht vorhanden
 ENV_EXTRA="$HH_CONFIG_DIR/env"
 if [ ! -f "$ENV_EXTRA" ]; then
@@ -64,7 +82,8 @@ Environment=HH_SECRET_KEY=$SECRET_KEY
 Environment=HOME=/home/$HH_USER
 Environment=PATH=$HH_REPO_DIR/.venv/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=-$ENV_EXTRA
-ExecStart=$HH_REPO_DIR/.venv/bin/uvicorn hydrahive.api.main:app --host $HH_HOST --port $HH_PORT
+EnvironmentFile=$COMPUTE_PROXY_ENV
+ExecStart=$HH_REPO_DIR/.venv/bin/uvicorn hydrahive.api.main:app --host $HH_HOST --port $HH_PORT --ws-max-size 65536
 Restart=on-failure
 RestartSec=5
 

--- a/installer/modules/60-nginx.sh
+++ b/installer/modules/60-nginx.sh
@@ -39,6 +39,20 @@ if [ ! -f "$TLS_DIR/hydrahive.crt" ]; then
   chmod 644 "$TLS_DIR/hydrahive.crt"
 fi
 
+COMPUTE_PKI_DIR="$HH_CONFIG_DIR/compute-pki"
+log "Initialisiere Compute-CA für mTLS"
+env HH_CONFIG_DIR="$HH_CONFIG_DIR" HH_DATA_DIR="$HH_DATA_DIR" \
+  "$HH_REPO_DIR/.venv/bin/python" -c "from hydrahive.compute.identity import ensure_compute_ca; ensure_compute_ca()"
+chown -R "$HH_USER:$HH_USER" "$COMPUTE_PKI_DIR"
+chmod 700 "$COMPUTE_PKI_DIR"
+chmod 600 "$COMPUTE_PKI_DIR/ca-key.pem"
+chmod 644 "$COMPUTE_PKI_DIR/ca-cert.pem"
+COMPUTE_PROXY_SECRET="$(cat "$HH_CONFIG_DIR/compute_proxy_secret")"
+COMPUTE_PROXY_SNIPPET=/etc/nginx/snippets/hydrahive-compute-secret.conf
+install -d -m 0755 /etc/nginx/snippets
+printf 'proxy_set_header X-HydraHive-Proxy-Secret "%s";\n' "$COMPUTE_PROXY_SECRET" > "$COMPUTE_PROXY_SNIPPET"
+chmod 600 "$COMPUTE_PROXY_SNIPPET"
+
 CONF_FILE=/etc/nginx/sites-available/hydrahive2
 log "Schreibe $CONF_FILE (HTTPS)"
 cat > "$CONF_FILE" <<EOF
@@ -88,6 +102,9 @@ server {
     ssl_certificate_key $TLS_DIR/hydrahive.key;
     ssl_protocols       TLSv1.2 TLSv1.3;
     ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_client_certificate $COMPUTE_PKI_DIR/ca-cert.pem;
+    ssl_verify_client optional;
+    ssl_verify_depth 1;
 
     root $HH_REPO_DIR/frontend/dist;
     index index.html;
@@ -108,6 +125,21 @@ server {
 
     location / {
         try_files \$uri \$uri/ /index.html;
+    }
+
+    location = /api/compute/agent/connect {
+        if (\$ssl_client_verify != SUCCESS) { return 403; }
+        proxy_pass http://$HH_HOST:$HH_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-HydraHive-Node-ID \$http_x_hydrahive_node_id;
+        proxy_set_header X-HydraHive-Client-Cert \$ssl_client_escaped_cert;
+        include $COMPUTE_PROXY_SNIPPET;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+        client_max_body_size 64k;
     }
 
     location /api/ {

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -473,6 +473,8 @@ if [ -f "$SERVICE_FILE" ]; then
   # sie via Group-Membership ändern kann (Workspace-Schreibzugriff über Samba).
   grep -q "^UMask=0002" "$SERVICE_FILE" || NEEDS_REWRITE=1
   grep -q "^EnvironmentFile=" "$SERVICE_FILE" || NEEDS_REWRITE=1
+  grep -Fq "EnvironmentFile=$HH_CONFIG_DIR/compute-proxy.env" "$SERVICE_FILE" || NEEDS_REWRITE=1
+  grep -q -- "--ws-max-size 65536" "$SERVICE_FILE" || NEEDS_REWRITE=1
   if [ "$NEEDS_REWRITE" = "1" ]; then
     log "Service-File braucht Update — neu schreiben"
     HH_USER="$HH_USER" HH_DATA_DIR="$HH_DATA_DIR" HH_CONFIG_DIR="$HH_CONFIG_DIR" \
@@ -486,7 +488,8 @@ log "nginx-Config prüfen"
 NGINX_CONF=/etc/nginx/sites-available/hydrahive2
 if ! command -v nginx >/dev/null 2>&1 || [ ! -f "$NGINX_CONF" ]; then
   log "nginx fehlt oder nicht konfiguriert — starte 60-nginx.sh"
-  HH_HOST="${HH_HOST:-127.0.0.1}" HH_PORT="${HH_PORT:-8001}" \
+  HH_USER="$HH_USER" HH_DATA_DIR="$HH_DATA_DIR" HH_CONFIG_DIR="$HH_CONFIG_DIR" \
+    HH_HOST="${HH_HOST:-127.0.0.1}" HH_PORT="${HH_PORT:-8001}" \
     HH_REPO_DIR="$HH_REPO_DIR" \
     bash "$HH_REPO_DIR/installer/modules/60-nginx.sh" || log "nginx-setup failed — weiter"
 else
@@ -502,11 +505,15 @@ else
   grep -q "assets.coingecko.com"         "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "resources.cryptocompare.com" "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "hh_cache_control"            "$NGINX_CONF" || NEEDS_REWRITE=1
+  grep -q "/api/compute/agent/connect"   "$NGINX_CONF" || NEEDS_REWRITE=1
+  grep -q "ssl_verify_client optional"   "$NGINX_CONF" || NEEDS_REWRITE=1
+  grep -q "hydrahive-compute-secret.conf" "$NGINX_CONF" || NEEDS_REWRITE=1
   if [ "$NEEDS_REWRITE" = "1" ]; then
     log "nginx: Config braucht Update (HTTPS / VNC-Proxy / ISO-Upload-Limit) — neu schreiben"
     HH_HOST="${HH_HOST:-127.0.0.1}"
     HH_PORT="${HH_PORT:-8001}"
-    HH_REPO_DIR="$HH_REPO_DIR" HH_HOST="$HH_HOST" HH_PORT="$HH_PORT" \
+    HH_USER="$HH_USER" HH_DATA_DIR="$HH_DATA_DIR" HH_CONFIG_DIR="$HH_CONFIG_DIR" \
+      HH_REPO_DIR="$HH_REPO_DIR" HH_HOST="$HH_HOST" HH_PORT="$HH_PORT" \
       bash "$HH_REPO_DIR/installer/modules/60-nginx.sh" || log "nginx-rewrite failed — weiter"
   fi
 fi

--- a/node-agent/pyproject.toml
+++ b/node-agent/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hydrahive-node-agent"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "cryptography>=41.0",
+    "httpx>=0.27",
+    "websockets>=13",
+]
+
+[project.scripts]
+hydrahive-node = "hydrahive_node.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hydrahive_node"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["F"]

--- a/node-agent/scripts/install.sh
+++ b/node-agent/scripts/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "install.sh must run as root" >&2
+    exit 1
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+if ! getent group hydrahive-node >/dev/null 2>&1; then
+    groupadd --system hydrahive-node
+fi
+if ! id hydrahive-node >/dev/null 2>&1; then
+    useradd --system --gid hydrahive-node --home-dir /var/lib/hydrahive-node --shell /usr/sbin/nologin hydrahive-node
+fi
+install -d -m 0700 -o hydrahive-node -g hydrahive-node /var/lib/hydrahive-node
+python3 -m pip install --disable-pip-version-check "$SCRIPT_DIR"
+install -m 0644 "$SCRIPT_DIR/systemd/hydrahive-node.service" /etc/systemd/system/hydrahive-node.service
+systemctl daemon-reload
+systemctl enable hydrahive-node.service
+
+echo "Installed. Enroll interactively with: hydrahive-node enroll --server https://HOST --name NODE"

--- a/node-agent/src/hydrahive_node/__init__.py
+++ b/node-agent/src/hydrahive_node/__init__.py
@@ -1,0 +1,3 @@
+"""HydraHive compute-node agent."""
+
+__version__ = "0.1.0"

--- a/node-agent/src/hydrahive_node/capabilities.py
+++ b/node-agent/src/hydrahive_node/capabilities.py
@@ -1,0 +1,56 @@
+"""Bounded local capability and resource collection without shell execution."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import socket
+from pathlib import Path
+
+INCUS_SOCKET = Path("/var/lib/incus/unix.socket")
+
+
+def _memory() -> tuple[int, int]:
+    values: dict[str, int] = {}
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="ascii").splitlines():
+            key, raw = line.split(":", 1)
+            if key in {"MemTotal", "MemAvailable"}:
+                values[key] = int(raw.strip().split()[0]) * 1024
+    except (OSError, ValueError, IndexError):
+        return 0, 0
+    return values.get("MemTotal", 0), values.get("MemAvailable", 0)
+
+
+def collect() -> tuple[dict[str, object], dict[str, object], list[str]]:
+    memory_total, memory_available = _memory()
+    disk = shutil.disk_usage("/")
+    kvm = Path("/dev/kvm")
+    kvm_available = kvm.exists() and os.access(kvm, os.R_OK | os.W_OK)
+    incus_available = INCUS_SOCKET.exists() and os.access(INCUS_SOCKET, os.R_OK | os.W_OK)
+    health_errors: list[str] = []
+    if not incus_available:
+        health_errors.append("incus_unavailable")
+    capabilities: dict[str, object] = {
+        "hostname": socket.gethostname()[:255],
+        "os": platform.platform()[:512],
+        "architecture": platform.machine()[:64],
+        "kvm": kvm_available,
+        "incus": incus_available,
+        "instance_types": ["container"] + (["vm"] if kvm_available else []),
+        "network_profiles": [],
+    }
+    try:
+        load_1m = os.getloadavg()[0]
+    except OSError:
+        load_1m = 0.0
+    resources: dict[str, object] = {
+        "cpu_cores": os.cpu_count() or 1,
+        "cpu_load_1m": round(load_1m, 3),
+        "memory_total_bytes": memory_total,
+        "memory_available_bytes": memory_available,
+        "storage_total_bytes": disk.total,
+        "storage_free_bytes": disk.free,
+    }
+    return capabilities, resources, health_errors

--- a/node-agent/src/hydrahive_node/cli.py
+++ b/node-agent/src/hydrahive_node/cli.py
@@ -1,0 +1,64 @@
+"""Command-line entry point for the HydraHive node agent."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import sys
+from pathlib import Path
+
+from hydrahive_node.enrollment import AgentEnrollmentError, enroll
+from hydrahive_node.storage import StatePaths, load_identity
+
+DEFAULT_STATE_DIR = Path(os.environ.get("HYDRAHIVE_NODE_STATE_DIR", "/var/lib/hydrahive-node"))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hydrahive-node")
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
+    commands = parser.add_subparsers(dest="command", required=True)
+    enroll_command = commands.add_parser("enroll", help="enroll this host with a HydraHive control plane")
+    enroll_command.add_argument("--server", required=True)
+    token_source = enroll_command.add_mutually_exclusive_group()
+    token_source.add_argument("--token-file", type=Path)
+    token_source.add_argument("--token-stdin", action="store_true")
+    enroll_command.add_argument("--name", required=True)
+    enroll_command.add_argument("--ca-file", type=Path)
+    commands.add_parser("run", help="run the persistent node-agent channel")
+    return parser
+
+
+def _read_token(args: argparse.Namespace) -> str:
+    if args.token_file:
+        if args.token_file.stat().st_mode & 0o077:
+            raise AgentEnrollmentError("token file permissions must be 0600")
+        return args.token_file.read_text(encoding="utf-8").strip()
+    if args.token_stdin:
+        return sys.stdin.readline().strip()
+    return getpass.getpass("Enrollment token: ").strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    paths = StatePaths(args.state_dir)
+    if args.command == "enroll":
+        try:
+            identity = enroll(
+                server_url=args.server,
+                token=_read_token(args),
+                node_name=args.name,
+                paths=paths,
+                ca_file=args.ca_file,
+            )
+        except AgentEnrollmentError as exc:
+            print(f"Enrollment failed: {exc}")
+            return 1
+        print(f"Node ID: {identity.node_id}")
+        print(f"Certificate fingerprint: {identity.certificate_fingerprint}")
+        return 0
+    identity = load_identity(paths)
+    from hydrahive_node.runtime import run_forever
+
+    run_forever(paths, identity)
+    return 0

--- a/node-agent/src/hydrahive_node/enrollment.py
+++ b/node-agent/src/hydrahive_node/enrollment.py
@@ -1,0 +1,148 @@
+"""HTTPS enrollment client and response verification."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from hydrahive_node.storage import AgentIdentity, StatePaths, save_identity
+
+
+class AgentEnrollmentError(RuntimeError):
+    pass
+
+
+def _verify_signature(certificate: x509.Certificate, issuer: x509.Certificate) -> None:
+    public_key = issuer.public_key()
+    try:
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                ec.ECDSA(certificate.signature_hash_algorithm),
+            )
+        elif isinstance(public_key, rsa.RSAPublicKey):
+            from cryptography.hazmat.primitives.asymmetric import padding
+
+            public_key.verify(
+                certificate.signature,
+                certificate.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                certificate.signature_hash_algorithm,
+            )
+        else:
+            raise AgentEnrollmentError("unsupported compute CA key")
+    except ValueError as exc:
+        raise AgentEnrollmentError("node certificate signature is invalid") from exc
+
+
+def _validate_response(data: dict, private_key: ec.EllipticCurvePrivateKey) -> AgentIdentity:
+    try:
+        node = data["node"]
+        node_id = node["node_id"]
+        certificate_pem = data["certificate_pem"].encode("ascii")
+        ca_pem = data["ca_certificate_pem"].encode("ascii")
+        fingerprint = data["certificate_fingerprint"]
+        expires_at = data["certificate_expires_at"]
+        certificate = x509.load_pem_x509_certificate(certificate_pem)
+        ca_certificate = x509.load_pem_x509_certificate(ca_pem)
+    except (KeyError, TypeError, ValueError, UnicodeError) as exc:
+        raise AgentEnrollmentError("enrollment response is invalid") from exc
+    own_public = private_key.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    issued_public = certificate.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    if own_public != issued_public or certificate.issuer != ca_certificate.subject:
+        raise AgentEnrollmentError("enrollment certificate does not match this agent")
+    _verify_signature(certificate, ca_certificate)
+    actual_fingerprint = certificate.fingerprint(hashes.SHA256()).hex()
+    if actual_fingerprint != fingerprint:
+        raise AgentEnrollmentError("enrollment fingerprint mismatch")
+    usages = certificate.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value
+    if ExtendedKeyUsageOID.CLIENT_AUTH not in usages:
+        raise AgentEnrollmentError("enrollment certificate lacks client authentication")
+    sans = certificate.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    if f"urn:hydrahive:node:{node_id}" not in sans.get_values_for_type(x509.UniformResourceIdentifier):
+        raise AgentEnrollmentError("enrollment certificate has wrong node identity")
+    if certificate.not_valid_before_utc > datetime.now(UTC) or certificate.not_valid_after_utc <= datetime.now(UTC):
+        raise AgentEnrollmentError("enrollment certificate is not currently valid")
+    return AgentIdentity(
+        server_url="",
+        node_id=node_id,
+        certificate_fingerprint=fingerprint,
+        certificate_expires_at=expires_at,
+        protocol_version=1,
+    )
+
+
+def enroll(
+    *,
+    server_url: str,
+    token: str,
+    node_name: str,
+    paths: StatePaths,
+    ca_file: Path | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> AgentIdentity:
+    server_url = server_url.rstrip("/")
+    if not server_url.startswith("https://"):
+        raise AgentEnrollmentError("server URL must use HTTPS")
+    if not token or len(token) > 128 or not node_name.strip() or len(node_name) > 128:
+        raise AgentEnrollmentError("enrollment input is invalid")
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    csr_pem = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, node_name.strip())]))
+        .sign(private_key, hashes.SHA256())
+        .public_bytes(serialization.Encoding.PEM)
+        .decode("ascii")
+    )
+    verify: bool | str = str(ca_file) if ca_file else True
+    try:
+        with httpx.Client(verify=verify, timeout=20.0, transport=transport) as client:
+            response = client.post(
+                f"{server_url}/api/compute/agent/enroll",
+                json={
+                    "token": token,
+                    "csr_pem": csr_pem,
+                    "protocol_version": 1,
+                    "agent_version": "0.1.0",
+                    "capabilities": {},
+                    "resources": {},
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise AgentEnrollmentError("enrollment request failed") from exc
+    identity = _validate_response(data, private_key)
+    identity = AgentIdentity(
+        server_url=server_url,
+        node_id=identity.node_id,
+        certificate_fingerprint=identity.certificate_fingerprint,
+        certificate_expires_at=identity.certificate_expires_at,
+        protocol_version=identity.protocol_version,
+    )
+    private_key_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    save_identity(
+        paths,
+        identity,
+        private_key_pem=private_key_pem,
+        certificate_pem=data["certificate_pem"].encode("ascii"),
+        ca_certificate_pem=data["ca_certificate_pem"].encode("ascii"),
+    )
+    return identity

--- a/node-agent/src/hydrahive_node/enrollment.py
+++ b/node-agent/src/hydrahive_node/enrollment.py
@@ -144,5 +144,6 @@ def enroll(
         private_key_pem=private_key_pem,
         certificate_pem=data["certificate_pem"].encode("ascii"),
         ca_certificate_pem=data["ca_certificate_pem"].encode("ascii"),
+        server_ca_certificate_pem=ca_file.read_bytes() if ca_file else None,
     )
     return identity

--- a/node-agent/src/hydrahive_node/runtime.py
+++ b/node-agent/src/hydrahive_node/runtime.py
@@ -1,0 +1,9 @@
+"""Persistent agent runtime; heartbeat transport is implemented in P2.4."""
+
+from __future__ import annotations
+
+from hydrahive_node.storage import AgentIdentity, StatePaths
+
+
+def run_forever(paths: StatePaths, identity: AgentIdentity) -> None:
+    raise RuntimeError("node heartbeat channel is not configured yet")

--- a/node-agent/src/hydrahive_node/runtime.py
+++ b/node-agent/src/hydrahive_node/runtime.py
@@ -1,9 +1,116 @@
-"""Persistent agent runtime; heartbeat transport is implemented in P2.4."""
+"""Persistent mTLS WebSocket runtime for read-only node reports."""
 
 from __future__ import annotations
 
-from hydrahive_node.storage import AgentIdentity, StatePaths
+import asyncio
+import json
+import random
+import secrets
+import ssl
+from datetime import UTC, datetime
+
+import websockets
+
+from hydrahive_node import __version__
+from hydrahive_node.capabilities import collect
+from hydrahive_node.storage import AgentIdentity, StatePaths, next_sequence
+
+HEARTBEAT_SECONDS = 30.0
+MAX_MESSAGE_BYTES = 64 * 1024
+
+
+def _websocket_url(server_url: str) -> str:
+    return server_url.replace("https://", "wss://", 1).rstrip("/") + "/api/compute/agent/connect"
+
+
+def _ssl_context(paths: StatePaths) -> ssl.SSLContext:
+    if paths.server_ca_certificate.is_file():
+        context = ssl.create_default_context(cafile=str(paths.server_ca_certificate))
+    else:
+        context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_3
+    context.load_cert_chain(str(paths.certificate), str(paths.private_key))
+    return context
+
+
+def _message(
+    paths: StatePaths,
+    identity: AgentIdentity,
+    message_type: str,
+    payload: dict[str, object],
+) -> tuple[int, str]:
+    sequence = next_sequence(paths)
+    message = {
+        "type": message_type,
+        "protocol_version": identity.protocol_version,
+        "node_id": identity.node_id,
+        "sequence": sequence,
+        "nonce": secrets.token_urlsafe(24),
+        "sent_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "payload": payload,
+    }
+    encoded = json.dumps(message, separators=(",", ":"), allow_nan=False)
+    if len(encoded.encode("utf-8")) > MAX_MESSAGE_BYTES:
+        raise RuntimeError("agent message exceeds protocol limit")
+    return sequence, encoded
+
+
+async def _send(websocket, paths: StatePaths, identity: AgentIdentity, message_type: str, payload: dict) -> None:
+    sequence, encoded = _message(paths, identity, message_type, payload)
+    await websocket.send(encoded)
+    raw = await asyncio.wait_for(websocket.recv(), timeout=20.0)
+    acknowledgement = json.loads(raw)
+    if acknowledgement.get("type") != "ack" or acknowledgement.get("sequence") != sequence:
+        raise RuntimeError("invalid acknowledgement from control plane")
+
+
+async def _run_session(paths: StatePaths, identity: AgentIdentity) -> None:
+    async with websockets.connect(
+        _websocket_url(identity.server_url),
+        ssl=_ssl_context(paths),
+        additional_headers={"X-HydraHive-Node-ID": identity.node_id},
+        proxy=None,
+        compression=None,
+        max_size=MAX_MESSAGE_BYTES,
+        open_timeout=20.0,
+    ) as websocket:
+        await _send(websocket, paths, identity, "hello", {"agent_version": __version__})
+        capabilities, resources, health_errors = collect()
+        await _send(
+            websocket,
+            paths,
+            identity,
+            "capabilities",
+            {"capabilities": capabilities, "resources": resources},
+        )
+        while True:
+            capabilities, resources, health_errors = collect()
+            await _send(
+                websocket,
+                paths,
+                identity,
+                "heartbeat",
+                {
+                    "capabilities": capabilities,
+                    "resources": resources,
+                    "health_errors": health_errors,
+                },
+            )
+            await asyncio.sleep(HEARTBEAT_SECONDS)
+
+
+async def run(paths: StatePaths, identity: AgentIdentity) -> None:
+    delay = 1.0
+    while True:
+        try:
+            await _run_session(paths, identity)
+            delay = 1.0
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await asyncio.sleep(delay + random.uniform(0, min(delay, 5.0)))
+            delay = min(delay * 2, 30.0)
 
 
 def run_forever(paths: StatePaths, identity: AgentIdentity) -> None:
-    raise RuntimeError("node heartbeat channel is not configured yet")
+    asyncio.run(run(paths, identity))

--- a/node-agent/src/hydrahive_node/storage.py
+++ b/node-agent/src/hydrahive_node/storage.py
@@ -1,0 +1,91 @@
+"""Restricted on-disk identity storage for the node agent."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    server_url: str
+    node_id: str
+    certificate_fingerprint: str
+    certificate_expires_at: str
+    protocol_version: int = 1
+
+
+@dataclass(frozen=True)
+class StatePaths:
+    directory: Path
+
+    @property
+    def identity(self) -> Path:
+        return self.directory / "identity.json"
+
+    @property
+    def private_key(self) -> Path:
+        return self.directory / "node-key.pem"
+
+    @property
+    def certificate(self) -> Path:
+        return self.directory / "node-cert.pem"
+
+    @property
+    def ca_certificate(self) -> Path:
+        return self.directory / "ca-cert.pem"
+
+
+def _atomic_write(path: Path, content: bytes, mode: int) -> None:
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, mode)
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def save_identity(
+    paths: StatePaths,
+    identity: AgentIdentity,
+    *,
+    private_key_pem: bytes,
+    certificate_pem: bytes,
+    ca_certificate_pem: bytes,
+) -> None:
+    paths.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(paths.directory, 0o700)
+    _atomic_write(paths.private_key, private_key_pem, 0o600)
+    _atomic_write(paths.certificate, certificate_pem, 0o644)
+    _atomic_write(paths.ca_certificate, ca_certificate_pem, 0o644)
+    identity_json = json.dumps(asdict(identity), ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8")
+    _atomic_write(paths.identity, identity_json, 0o600)
+
+
+def load_identity(paths: StatePaths) -> AgentIdentity:
+    required = (paths.identity, paths.private_key, paths.certificate, paths.ca_certificate)
+    if not all(path.is_file() for path in required):
+        raise RuntimeError("node identity is incomplete; run hydrahive-node enroll")
+    if paths.private_key.stat().st_mode & 0o077:
+        raise RuntimeError("node private key permissions must be 0600")
+    try:
+        data = json.loads(paths.identity.read_text(encoding="utf-8"))
+        identity = AgentIdentity(**data)
+    except (OSError, ValueError, TypeError) as exc:
+        raise RuntimeError("node identity is invalid") from exc
+    if not identity.server_url.startswith("https://"):
+        raise RuntimeError("node server URL must use HTTPS")
+    return identity

--- a/node-agent/src/hydrahive_node/storage.py
+++ b/node-agent/src/hydrahive_node/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import secrets
@@ -38,6 +39,14 @@ class StatePaths:
     def ca_certificate(self) -> Path:
         return self.directory / "ca-cert.pem"
 
+    @property
+    def server_ca_certificate(self) -> Path:
+        return self.directory / "server-ca.pem"
+
+    @property
+    def protocol_state(self) -> Path:
+        return self.directory / "protocol-state.json"
+
 
 def _atomic_write(path: Path, content: bytes, mode: int) -> None:
     temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
@@ -65,12 +74,15 @@ def save_identity(
     private_key_pem: bytes,
     certificate_pem: bytes,
     ca_certificate_pem: bytes,
+    server_ca_certificate_pem: bytes | None = None,
 ) -> None:
     paths.directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     os.chmod(paths.directory, 0o700)
     _atomic_write(paths.private_key, private_key_pem, 0o600)
     _atomic_write(paths.certificate, certificate_pem, 0o644)
     _atomic_write(paths.ca_certificate, ca_certificate_pem, 0o644)
+    if server_ca_certificate_pem is not None:
+        _atomic_write(paths.server_ca_certificate, server_ca_certificate_pem, 0o644)
     identity_json = json.dumps(asdict(identity), ensure_ascii=False, sort_keys=True, indent=2).encode("utf-8")
     _atomic_write(paths.identity, identity_json, 0o600)
 
@@ -89,3 +101,27 @@ def load_identity(paths: StatePaths) -> AgentIdentity:
     if not identity.server_url.startswith("https://"):
         raise RuntimeError("node server URL must use HTTPS")
     return identity
+
+
+def next_sequence(paths: StatePaths) -> int:
+    lock_path = paths.directory / ".protocol-state.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        try:
+            data = json.loads(paths.protocol_state.read_text(encoding="utf-8"))
+            current = int(data["sequence"])
+        except FileNotFoundError:
+            current = 0
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            raise RuntimeError("node protocol state is invalid") from exc
+        sequence = current + 1
+        _atomic_write(
+            paths.protocol_state,
+            json.dumps({"sequence": sequence}, separators=(",", ":")).encode("ascii"),
+            0o600,
+        )
+        return sequence
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)

--- a/node-agent/systemd/hydrahive-node.service
+++ b/node-agent/systemd/hydrahive-node.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=HydraHive Compute Node Agent
+After=network-online.target incus.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hydrahive-node
+Group=hydrahive-node
+ExecStart=/usr/local/bin/hydrahive-node run
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+RestrictRealtime=true
+ReadWritePaths=/var/lib/hydrahive-node
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/node-agent/tests/test_cli.py
+++ b/node-agent/tests/test_cli.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+
+from hydrahive_node import cli
+from hydrahive_node.storage import AgentIdentity
+
+
+def test_enroll_cli_prints_identity_but_not_token(tmp_path, monkeypatch, capsys) -> None:
+    token = "secret-enrollment-token"
+    identity = AgentIdentity(
+        server_url="https://hydrahive.test",
+        node_id="node-1",
+        certificate_fingerprint="ab" * 32,
+        certificate_expires_at="2030-01-01T00:00:00Z",
+    )
+    monkeypatch.setattr(cli, "enroll", lambda **kwargs: identity)
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(token + "\n"))
+
+    result = cli.main(
+        [
+            "--state-dir",
+            str(tmp_path),
+            "enroll",
+            "--server",
+            identity.server_url,
+            "--token-stdin",
+            "--name",
+            "Node One",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert identity.node_id in output
+    assert identity.certificate_fingerprint in output
+    assert token not in output

--- a/node-agent/tests/test_enrollment.py
+++ b/node-agent/tests/test_enrollment.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from hydrahive_node.enrollment import AgentEnrollmentError, enroll
+from hydrahive_node.storage import StatePaths, load_identity
+
+
+def _ca():
+    key = ec.generate_private_key(ec.SECP384R1())
+    now = datetime.now(UTC)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test Compute CA")])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), True)
+        .sign(key, hashes.SHA384())
+    )
+    return key, certificate
+
+
+def _transport(*, fingerprint_override: str | None = None) -> httpx.MockTransport:
+    ca_key, ca_certificate = _ca()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        csr = x509.load_pem_x509_csr(payload["csr_pem"].encode("ascii"))
+        node_id = "019-node-test"
+        now = datetime.now(UTC)
+        certificate = (
+            x509.CertificateBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, node_id)]))
+            .issuer_name(ca_certificate.subject)
+            .public_key(csr.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=1))
+            .not_valid_after(now + timedelta(days=7))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None), True)
+            .add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.CLIENT_AUTH]), True)
+            .add_extension(
+                x509.SubjectAlternativeName([x509.UniformResourceIdentifier(f"urn:hydrahive:node:{node_id}")]),
+                False,
+            )
+            .sign(ca_key, hashes.SHA384())
+        )
+        from cryptography.hazmat.primitives import serialization
+
+        cert_pem = certificate.public_bytes(serialization.Encoding.PEM).decode("ascii")
+        ca_pem = ca_certificate.public_bytes(serialization.Encoding.PEM).decode("ascii")
+        fingerprint = fingerprint_override or certificate.fingerprint(hashes.SHA256()).hex()
+        return httpx.Response(
+            201,
+            json={
+                "node": {"node_id": node_id},
+                "certificate_pem": cert_pem,
+                "ca_certificate_pem": ca_pem,
+                "certificate_fingerprint": fingerprint,
+                "certificate_expires_at": certificate.not_valid_after_utc.isoformat(),
+            },
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def test_enroll_validates_response_and_stores_restricted_identity(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+
+    identity = enroll(
+        server_url="https://hydrahive.test",
+        token="x" * 43,
+        node_name="Node Test",
+        paths=paths,
+        transport=_transport(),
+    )
+
+    assert identity.node_id == "019-node-test"
+    assert load_identity(paths) == identity
+    assert os.stat(paths.directory).st_mode & 0o777 == 0o700
+    assert os.stat(paths.private_key).st_mode & 0o777 == 0o600
+    assert os.stat(paths.identity).st_mode & 0o777 == 0o600
+    assert "x" * 43 not in paths.identity.read_text()
+
+
+def test_enroll_rejects_plain_http(tmp_path) -> None:
+    with pytest.raises(AgentEnrollmentError, match="HTTPS"):
+        enroll(
+            server_url="http://hydrahive.test",
+            token="x" * 43,
+            node_name="Node Test",
+            paths=StatePaths(tmp_path),
+            transport=_transport(),
+        )
+
+
+def test_enroll_rejects_tampered_fingerprint_without_writing_key(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    with pytest.raises(AgentEnrollmentError, match="fingerprint"):
+        enroll(
+            server_url="https://hydrahive.test",
+            token="x" * 43,
+            node_name="Node Test",
+            paths=paths,
+            transport=_transport(fingerprint_override="00" * 32),
+        )
+    assert not paths.private_key.exists()

--- a/node-agent/tests/test_runtime.py
+++ b/node-agent/tests/test_runtime.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from hydrahive_node import capabilities, runtime
+from hydrahive_node.storage import AgentIdentity, StatePaths
+
+
+def _identity() -> AgentIdentity:
+    return AgentIdentity(
+        server_url="https://hydrahive.test",
+        node_id="node-1",
+        certificate_fingerprint="ab" * 32,
+        certificate_expires_at="2030-01-01T00:00:00Z",
+    )
+
+
+def test_protocol_messages_have_persistent_sequence_and_fresh_nonce(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+
+    first_sequence, first_raw = runtime._message(paths, _identity(), "hello", {"agent_version": "0.1.0"})
+    second_sequence, second_raw = runtime._message(paths, _identity(), "heartbeat", {"resources": {}})
+    first = json.loads(first_raw)
+    second = json.loads(second_raw)
+
+    assert (first_sequence, second_sequence) == (1, 2)
+    assert first["node_id"] == "node-1"
+    assert first["nonce"] != second["nonce"]
+    assert os.stat(paths.protocol_state).st_mode & 0o777 == 0o600
+
+
+def test_protocol_sequence_is_process_safe(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        sequences = list(executor.map(lambda _: runtime._message(paths, _identity(), "heartbeat", {})[0], range(20)))
+
+    assert sorted(sequences) == list(range(1, 21))
+
+
+def test_capability_collection_is_bounded_and_typed() -> None:
+    reported, resources, errors = capabilities.collect()
+
+    assert isinstance(reported["hostname"], str)
+    assert len(reported["hostname"]) <= 255
+    assert isinstance(reported["instance_types"], list)
+    assert isinstance(resources["cpu_cores"], int)
+    assert isinstance(resources["memory_total_bytes"], int)
+    assert all(isinstance(error, str) for error in errors)


### PR DESCRIPTION
## Summary

Implements Cluster Management V1 phase P2: secure enrollment and the read-only compute-node agent channel.

- adds one-time enrollment tokens, internal Compute CA, CSR signing, approval/revocation and append-only audit records
- adds authenticated node administration and enrollment APIs with bounded payloads and rate limiting
- adds the standalone `hydrahive-node` package, hardened systemd service, persistent identity/sequence state and enrollment CLI
- adds TLS 1.3 WebSocket heartbeats with capability/resource/health reporting, replay protection and audited dead-node detection
- binds the channel to Nginx-verified mTLS client certificates and a root-only proxy secret; the backend remains loopback-only
- rolls the new systemd/Nginx security configuration out to existing installations through updater rewrite guards

## Security properties

- mTLS client certificate checked against the approved node fingerprint
- revocation/disabled states fail closed
- strict protocol schema, 64 KiB WebSocket limit and bounded JSON fields
- persistent monotonic sequence plus expiring nonce replay protection
- root-only proxy secret files; no secret embedded in the world-readable systemd unit or main Nginx config
- no shell execution in capability collection
- security review completed; all Blocker/High findings resolved

## Verification

- `1815 passed` — complete Core pytest suite
- `7 passed` — node-agent pytest suite
- Ruff format and lint passed
- installer/update shell syntax passed
- node-agent wheel build passed
- `git diff --check` passed
