### PR TITLE
feat(compute): add durable signed job protocol

### DIFF
--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -27,6 +27,7 @@ from hydrahive.api.routes.container_console import router as container_console_r
 from hydrahive.api.routes.containers import router as containers_router
 from hydrahive.api.routes.compute_agent import router as compute_agent_router
 from hydrahive.api.routes.compute_channel import router as compute_channel_router
+from hydrahive.api.routes.compute_jobs import router as compute_jobs_router
 from hydrahive.api.routes.compute_nodes import router as compute_nodes_router
 from hydrahive.api.routes.credentials import router as credentials_router
 from hydrahive.api.routes.research_apis import router as research_apis_router
@@ -152,6 +153,7 @@ app.include_router(vms_router)
 app.include_router(containers_router)
 app.include_router(compute_agent_router)
 app.include_router(compute_channel_router)
+app.include_router(compute_jobs_router)
 app.include_router(compute_nodes_router)
 app.include_router(credentials_router)
 app.include_router(research_apis_router)

--- a/core/src/hydrahive/api/routes/compute_channel.py
+++ b/core/src/hydrahive/api/routes/compute_channel.py
@@ -30,7 +30,7 @@ async def connect_agent(websocket: WebSocket) -> None:
                 return
             try:
                 message = channel.parse_message(raw)
-                acknowledgement = channel.accept_message(node_id, message)
+                acknowledgement = channel.response_for_message(node_id, message)
             except channel.ProtocolError as exc:
                 await websocket.send_json({"type": "error", "code": exc.code})
                 await websocket.close(code=4400, reason=exc.code)

--- a/core/src/hydrahive/api/routes/compute_jobs.py
+++ b/core/src/hydrahive/api/routes/compute_jobs.py
@@ -1,0 +1,111 @@
+"""Authenticated, ownership-scoped compute-job status API."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+
+from hydrahive.api.middleware.auth import AuthPrincipal, require_principal
+from hydrahive.api.middleware.errors import coded
+from hydrahive.compute import jobs
+from hydrahive.compute.models import ComputeJob, ComputeJobEvent
+
+router = APIRouter(prefix="/api/compute/jobs", tags=["compute"])
+
+
+def _visible(job: ComputeJob, principal: AuthPrincipal) -> bool:
+    return principal.role == "admin" or job.created_by == principal.user_id
+
+
+def _job_or_404(job_id: str, principal: AuthPrincipal) -> ComputeJob:
+    job = jobs.get_job(job_id)
+    if job is None or not _visible(job, principal):
+        raise coded(status.HTTP_404_NOT_FOUND, "compute_job_not_found")
+    return job
+
+
+def _public_job(job: ComputeJob) -> dict:
+    return {
+        "job_id": job.job_id,
+        "node_id": job.node_id,
+        "resource_kind": job.resource_kind,
+        "resource_id": job.resource_id,
+        "operation": job.operation,
+        "generation": job.generation,
+        "status": job.status,
+        "attempts": job.attempts,
+        "progress": job.progress,
+        "error_code": job.error_code,
+        "created_by": job.created_by,
+        "created_at": job.created_at,
+        "started_at": job.started_at,
+        "finished_at": job.finished_at,
+        "lease_until": job.lease_until,
+    }
+
+
+def _public_event(event: ComputeJobEvent) -> dict:
+    data: dict = {}
+    if event.event_type == "progress":
+        data = {"progress": event.data.get("progress")}
+    elif event.event_type == "failed":
+        data = {"error_code": event.data.get("error_code")}
+    elif event.event_type in {"requeued", "expired"}:
+        data = {"reason": event.data.get("reason")}
+    return {
+        "event_id": event.event_id,
+        "sequence": event.sequence,
+        "event_type": event.event_type,
+        "data": data,
+        "created_at": event.created_at,
+    }
+
+
+@router.get("")
+def list_compute_jobs(
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
+    node_id: str | None = Query(default=None, max_length=128),
+    job_status: str | None = Query(default=None, alias="status", max_length=32),
+    limit: int = Query(default=100, ge=1, le=200),
+) -> list[dict]:
+    try:
+        found = jobs.list_jobs(
+            node_id=node_id,
+            status=job_status,
+            created_by=None if principal.role == "admin" else principal.user_id,
+            limit=limit,
+        )
+    except ValueError:
+        raise coded(status.HTTP_400_BAD_REQUEST, "compute_job_filter_invalid")
+    return [_public_job(job) for job in found]
+
+
+@router.get("/{job_id}")
+def get_compute_job(
+    job_id: str,
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
+) -> dict:
+    return _public_job(_job_or_404(job_id, principal))
+
+
+@router.get("/{job_id}/events")
+def list_compute_job_events(
+    job_id: str,
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
+) -> list[dict]:
+    _job_or_404(job_id, principal)
+    return [_public_event(event) for event in jobs.list_events(job_id)]
+
+
+@router.post("/{job_id}/cancel")
+def cancel_compute_job(
+    job_id: str,
+    principal: Annotated[AuthPrincipal, Depends(require_principal)],
+) -> dict:
+    _job_or_404(job_id, principal)
+    try:
+        cancelled = jobs.cancel_job(job_id, actor=principal.user_id)
+    except jobs.JobConflict:
+        raise coded(status.HTTP_409_CONFLICT, "compute_job_transition_invalid")
+    return _public_job(cancelled)

--- a/core/src/hydrahive/compute/_job_codec.py
+++ b/core/src/hydrahive/compute/_job_codec.py
@@ -1,0 +1,87 @@
+"""Validation and SQLite codecs for durable compute jobs."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from hydrahive.compute._node_codec import dump_json, load_json
+from hydrahive.compute.models import (
+    JOB_RESOURCE_KINDS,
+    JOB_STATUSES,
+    ComputeJob,
+    ComputeJobEvent,
+    JSONObject,
+    JobResourceKind,
+)
+
+MAX_JOB_TEXT = 255
+MAX_IDEMPOTENCY_KEY = 255
+
+
+class JobConflict(ValueError):
+    pass
+
+
+class JobNotFound(ValueError):
+    pass
+
+
+def validate_text(value: str, field: str, *, maximum: int = MAX_JOB_TEXT) -> str:
+    value = value.strip()
+    if not value or len(value) > maximum:
+        raise ValueError(f"{field} must contain 1-{maximum} characters")
+    return value
+
+
+def validate_resource_kind(value: str) -> JobResourceKind:
+    if value not in JOB_RESOURCE_KINDS:
+        raise ValueError("invalid compute job resource kind")
+    return value  # type: ignore[return-value]
+
+
+def dump_job_json(value: JSONObject, field: str) -> str:
+    return dump_json(value, field)
+
+
+def row_to_job(row: sqlite3.Row) -> ComputeJob:
+    return ComputeJob(
+        job_id=row["job_id"],
+        node_id=row["node_id"],
+        resource_kind=row["resource_kind"],
+        resource_id=row["resource_id"],
+        operation=row["operation"],
+        generation=row["generation"],
+        payload=load_json(row["payload_json"], "payload"),
+        idempotency_key=row["idempotency_key"],
+        status=row["status"],
+        lease_id=row["lease_id"],
+        lease_until=row["lease_until"],
+        attempts=row["attempts"],
+        progress=row["progress"],
+        error_code=row["error_code"],
+        error_params=(load_json(row["error_params_json"], "error_params") if row["error_params_json"] else None),
+        created_by=row["created_by"],
+        created_at=row["created_at"],
+        started_at=row["started_at"],
+        finished_at=row["finished_at"],
+    )
+
+
+def row_to_event(row: sqlite3.Row) -> ComputeJobEvent:
+    data = json.loads(row["data_json"])
+    if not isinstance(data, dict):
+        raise ValueError("stored job event data must be an object")
+    return ComputeJobEvent(
+        event_id=row["event_id"],
+        job_id=row["job_id"],
+        sequence=row["sequence"],
+        event_type=row["event_type"],
+        data=data,
+        created_at=row["created_at"],
+    )
+
+
+def validate_job_status(value: str) -> None:
+    if value not in JOB_STATUSES:
+        raise ValueError("invalid stored compute job status")

--- a/core/src/hydrahive/compute/_job_codec.py
+++ b/core/src/hydrahive/compute/_job_codec.py
@@ -29,7 +29,7 @@ class JobNotFound(ValueError):
 
 def validate_text(value: str, field: str, *, maximum: int = MAX_JOB_TEXT) -> str:
     value = value.strip()
-    if not value or len(value) > maximum:
+    if not value or len(value) > maximum or any(not character.isprintable() for character in value):
         raise ValueError(f"{field} must contain 1-{maximum} characters")
     return value
 

--- a/core/src/hydrahive/compute/_job_events.py
+++ b/core/src/hydrahive/compute/_job_events.py
@@ -1,0 +1,38 @@
+"""Append-only event and audit writes for compute-job transitions."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from hydrahive.compute import audit
+from hydrahive.compute._job_codec import dump_job_json
+from hydrahive.compute.models import JSONObject
+from hydrahive.db._utils import now_iso
+
+
+def append_event(
+    conn: sqlite3.Connection,
+    *,
+    job_id: str,
+    node_id: str,
+    event_type: str,
+    data: JSONObject,
+    actor: str,
+) -> None:
+    sequence = conn.execute(
+        "SELECT COALESCE(MAX(sequence), -1) + 1 FROM compute_job_events WHERE job_id = ?",
+        (job_id,),
+    ).fetchone()[0]
+    conn.execute(
+        """INSERT INTO compute_job_events
+               (job_id, sequence, event_type, data_json, created_at)
+           VALUES (?, ?, ?, ?, ?)""",
+        (job_id, sequence, event_type, dump_job_json(data, "job event"), now_iso()),
+    )
+    audit.record_in_connection(
+        conn,
+        actor=actor,
+        action=f"job.{event_type}",
+        node_id=node_id,
+        details={"job_id": job_id, "sequence": sequence},
+    )

--- a/core/src/hydrahive/compute/_job_leases.py
+++ b/core/src/hydrahive/compute/_job_leases.py
@@ -1,0 +1,78 @@
+"""Atomic leasing and expiry for durable compute jobs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from hydrahive.compute._job_codec import row_to_job
+from hydrahive.compute._job_events import append_event
+from hydrahive.compute.models import ComputeJob
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+
+
+def claim_next_job(node_id: str, *, lease_seconds: int = 60) -> ComputeJob | None:
+    if not 10 <= lease_seconds <= 300:
+        raise ValueError("lease_seconds must be between 10 and 300")
+    lease_until = (datetime.now(UTC) + timedelta(seconds=lease_seconds)).isoformat().replace("+00:00", "Z")
+    with db(immediate=True) as conn:
+        node = conn.execute("SELECT status FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if node is None or node["status"] not in {"online", "draining"}:
+            return None
+        row = conn.execute(
+            """SELECT * FROM compute_jobs
+               WHERE node_id = ? AND status = 'queued'
+                 AND (? != 'draining' OR operation NOT IN ('container.create', 'vm.create_from_image'))
+               ORDER BY created_at, job_id LIMIT 1""",
+            (node_id, node["status"]),
+        ).fetchone()
+        if row is None:
+            return None
+        lease_id = uuid7()
+        conn.execute(
+            """UPDATE compute_jobs
+               SET status = 'leased', lease_id = ?, lease_until = ?, attempts = attempts + 1
+               WHERE job_id = ? AND status = 'queued'""",
+            (lease_id, lease_until, row["job_id"]),
+        )
+        append_event(
+            conn,
+            job_id=row["job_id"],
+            node_id=node_id,
+            event_type="leased",
+            data={"lease_until": lease_until},
+            actor=f"node:{node_id}",
+        )
+        claimed = conn.execute("SELECT * FROM compute_jobs WHERE job_id = ?", (row["job_id"],)).fetchone()
+    return row_to_job(claimed)
+
+
+def expire_leases() -> tuple[int, int]:
+    timestamp = now_iso()
+    with db(immediate=True) as conn:
+        rows = conn.execute(
+            """SELECT * FROM compute_jobs
+               WHERE status IN ('leased', 'running') AND lease_until IS NOT NULL AND lease_until < ?""",
+            (timestamp,),
+        ).fetchall()
+        requeued = expired = 0
+        for row in rows:
+            target = "queued" if row["status"] == "leased" else "expired"
+            finished_at = None if target == "queued" else timestamp
+            conn.execute(
+                """UPDATE compute_jobs
+                   SET status = ?, lease_id = NULL, lease_until = NULL, finished_at = ?
+                   WHERE job_id = ?""",
+                (target, finished_at, row["job_id"]),
+            )
+            append_event(
+                conn,
+                job_id=row["job_id"],
+                node_id=row["node_id"],
+                event_type=target,
+                data={"reason": "lease_expired"},
+                actor="system:compute-jobs",
+            )
+            requeued += target == "queued"
+            expired += target == "expired"
+    return requeued, expired

--- a/core/src/hydrahive/compute/_job_lifecycle.py
+++ b/core/src/hydrahive/compute/_job_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import UTC, datetime, timedelta
 
 from hydrahive.compute._job_codec import (
     JobConflict,
@@ -59,6 +60,19 @@ def start_job(job_id: str, lease_id: str) -> ComputeJob:
             data={},
             actor=f"node:{row['node_id']}",
         )
+        return _updated(conn, job_id)
+
+
+def renew_job_lease(job_id: str, lease_id: str, *, lease_seconds: int = 300) -> ComputeJob:
+    if not 10 <= lease_seconds <= 300:
+        raise ValueError("lease_seconds must be between 10 and 300")
+    lease_until = (datetime.now(UTC) + timedelta(seconds=lease_seconds)).isoformat().replace("+00:00", "Z")
+    with db(immediate=True) as conn:
+        row = _load(conn, job_id)
+        if row["status"] != "running":
+            raise JobConflict("compute job is not running")
+        _lease(row, lease_id)
+        conn.execute("UPDATE compute_jobs SET lease_until = ? WHERE job_id = ?", (lease_until, job_id))
         return _updated(conn, job_id)
 
 

--- a/core/src/hydrahive/compute/_job_lifecycle.py
+++ b/core/src/hydrahive/compute/_job_lifecycle.py
@@ -162,6 +162,8 @@ def cancel_job(job_id: str, *, actor: str) -> ComputeJob:
         row = _load(conn, job_id)
         if row["status"] in TERMINAL_STATUSES:
             raise JobConflict("compute job is already terminal")
+        if row["status"] == "running":
+            raise JobConflict("running compute job cannot be cancelled safely")
         timestamp = now_iso()
         conn.execute(
             """UPDATE compute_jobs

--- a/core/src/hydrahive/compute/_job_lifecycle.py
+++ b/core/src/hydrahive/compute/_job_lifecycle.py
@@ -1,0 +1,180 @@
+"""Lease-checked state transitions for durable compute jobs."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from hydrahive.compute._job_codec import (
+    JobConflict,
+    JobNotFound,
+    dump_job_json,
+    row_to_job,
+    validate_text,
+)
+from hydrahive.compute._job_events import append_event
+from hydrahive.compute.models import ComputeJob, JSONObject
+from hydrahive.db._utils import now_iso
+from hydrahive.db.connection import db
+
+TERMINAL_STATUSES = {"succeeded", "failed", "cancelled", "expired"}
+
+
+def _load(conn: sqlite3.Connection, job_id: str) -> sqlite3.Row:
+    row = conn.execute("SELECT * FROM compute_jobs WHERE job_id = ?", (job_id,)).fetchone()
+    if row is None:
+        raise JobNotFound("compute job not found")
+    return row
+
+
+def _lease(row: sqlite3.Row, lease_id: str) -> None:
+    if not lease_id or row["lease_id"] != lease_id:
+        raise JobConflict("compute job lease does not match")
+    if row["lease_until"] is None or row["lease_until"] < now_iso():
+        raise JobConflict("compute job lease has expired")
+
+
+def _updated(conn: sqlite3.Connection, job_id: str) -> ComputeJob:
+    return row_to_job(_load(conn, job_id))
+
+
+def start_job(job_id: str, lease_id: str) -> ComputeJob:
+    with db(immediate=True) as conn:
+        row = _load(conn, job_id)
+        if row["status"] == "running":
+            _lease(row, lease_id)
+            return row_to_job(row)
+        if row["status"] != "leased":
+            raise JobConflict("compute job is not leased")
+        _lease(row, lease_id)
+        timestamp = now_iso()
+        conn.execute(
+            "UPDATE compute_jobs SET status = 'running', started_at = COALESCE(started_at, ?) WHERE job_id = ?",
+            (timestamp, job_id),
+        )
+        append_event(
+            conn,
+            job_id=job_id,
+            node_id=row["node_id"],
+            event_type="running",
+            data={},
+            actor=f"node:{row['node_id']}",
+        )
+        return _updated(conn, job_id)
+
+
+def report_progress(job_id: str, lease_id: str, progress: int, data: JSONObject | None = None) -> ComputeJob:
+    if not 0 <= progress <= 99:
+        raise ValueError("progress must be between 0 and 99")
+    details = data or {}
+    dump_job_json(details, "progress data")
+    with db(immediate=True) as conn:
+        row = _load(conn, job_id)
+        if row["status"] != "running":
+            raise JobConflict("compute job is not running")
+        _lease(row, lease_id)
+        if progress < row["progress"]:
+            raise JobConflict("compute job progress cannot decrease")
+        if progress == row["progress"]:
+            return row_to_job(row)
+        conn.execute("UPDATE compute_jobs SET progress = ? WHERE job_id = ?", (progress, job_id))
+        append_event(
+            conn,
+            job_id=job_id,
+            node_id=row["node_id"],
+            event_type="progress",
+            data={"progress": progress, "details": details},
+            actor=f"node:{row['node_id']}",
+        )
+        return _updated(conn, job_id)
+
+
+def _finish(
+    job_id: str,
+    lease_id: str,
+    *,
+    target: str,
+    event_data: JSONObject,
+    error_code: str | None = None,
+    error_params: JSONObject | None = None,
+) -> ComputeJob:
+    with db(immediate=True) as conn:
+        row = _load(conn, job_id)
+        if row["status"] == target:
+            event = conn.execute(
+                "SELECT data_json FROM compute_job_events WHERE job_id = ? ORDER BY sequence DESC LIMIT 1",
+                (job_id,),
+            ).fetchone()
+            if event is not None and event["data_json"] == dump_job_json(event_data, "result"):
+                return row_to_job(row)
+            raise JobConflict("terminal compute job result differs")
+        if row["status"] in TERMINAL_STATUSES:
+            raise JobConflict("compute job is already terminal")
+        if row["status"] not in {"leased", "running"}:
+            raise JobConflict("compute job cannot be completed")
+        _lease(row, lease_id)
+        timestamp = now_iso()
+        conn.execute(
+            """UPDATE compute_jobs
+               SET status = ?, progress = CASE WHEN ? = 'succeeded' THEN 100 ELSE progress END,
+                   error_code = ?, error_params_json = ?, finished_at = ?
+               WHERE job_id = ?""",
+            (
+                target,
+                target,
+                error_code,
+                dump_job_json(error_params, "error_params") if error_params is not None else None,
+                timestamp,
+                job_id,
+            ),
+        )
+        append_event(
+            conn,
+            job_id=job_id,
+            node_id=row["node_id"],
+            event_type=target,
+            data=event_data,
+            actor=f"node:{row['node_id']}",
+        )
+        return _updated(conn, job_id)
+
+
+def succeed_job(job_id: str, lease_id: str, result: JSONObject) -> ComputeJob:
+    dump_job_json(result, "result")
+    return _finish(job_id, lease_id, target="succeeded", event_data={"result": result})
+
+
+def fail_job(job_id: str, lease_id: str, error_code: str, error_params: JSONObject) -> ComputeJob:
+    error_code = validate_text(error_code, "error_code", maximum=128)
+    dump_job_json(error_params, "error_params")
+    return _finish(
+        job_id,
+        lease_id,
+        target="failed",
+        event_data={"error_code": error_code, "error_params": error_params},
+        error_code=error_code,
+        error_params=error_params,
+    )
+
+
+def cancel_job(job_id: str, *, actor: str) -> ComputeJob:
+    actor = validate_text(actor, "actor", maximum=128)
+    with db(immediate=True) as conn:
+        row = _load(conn, job_id)
+        if row["status"] in TERMINAL_STATUSES:
+            raise JobConflict("compute job is already terminal")
+        timestamp = now_iso()
+        conn.execute(
+            """UPDATE compute_jobs
+               SET status = 'cancelled', lease_id = NULL, lease_until = NULL, finished_at = ?
+               WHERE job_id = ?""",
+            (timestamp, job_id),
+        )
+        append_event(
+            conn,
+            job_id=job_id,
+            node_id=row["node_id"],
+            event_type="cancelled",
+            data={},
+            actor=actor,
+        )
+        return _updated(conn, job_id)

--- a/core/src/hydrahive/compute/channel.py
+++ b/core/src/hydrahive/compute/channel.py
@@ -6,51 +6,17 @@ import hmac
 import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
-from typing import Literal
 from urllib.parse import unquote
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
-
-from hydrahive.compute import audit, identity
+from hydrahive.compute import audit, identity, job_protocol
 from hydrahive.compute._node_codec import dump_json, normalize_certificate_fingerprint
+from hydrahive.compute.channel_message import AgentMessage, ProtocolError, parse_message
 from hydrahive.db._utils import now_iso
 from hydrahive.db.connection import db
 from hydrahive.settings import settings
 
-MAX_CLOCK_SKEW_SECONDS = 120
 NONCE_TTL_MINUTES = 10
 CONNECTED_STATUSES = {"online", "degraded", "offline", "draining"}
-
-
-class ProtocolError(ValueError):
-    def __init__(self, code: str) -> None:
-        self.code = code
-        super().__init__(code)
-
-
-class AgentMessage(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    type: Literal["hello", "heartbeat", "capabilities"]
-    protocol_version: Literal[1]
-    node_id: str = Field(min_length=1, max_length=128)
-    sequence: int = Field(ge=1, le=9_223_372_036_854_775_807)
-    nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
-    sent_at: datetime
-    payload: dict[str, object] = Field(default_factory=dict)
-
-
-def parse_message(raw: str) -> AgentMessage:
-    try:
-        message = AgentMessage.model_validate_json(raw)
-    except ValidationError as exc:
-        raise ProtocolError("agent_message_invalid") from exc
-    sent_at = message.sent_at
-    if sent_at.tzinfo is None:
-        raise ProtocolError("agent_timestamp_invalid")
-    if abs((datetime.now(UTC) - sent_at.astimezone(UTC)).total_seconds()) > MAX_CLOCK_SKEW_SECONDS:
-        raise ProtocolError("agent_timestamp_invalid")
-    return message
 
 
 def proxy_certificate_fingerprint(escaped_certificate: str) -> str:
@@ -145,7 +111,7 @@ def accept_message(authenticated_node_id: str, message: AgentMessage) -> dict:
                 raise ProtocolError("agent_payload_invalid")
             updates.extend(("capabilities_json = ?", "resources_json = ?"))
             values.extend((_json_object(capabilities, "capabilities"), _json_object(resources, "resources")))
-        else:
+        elif message.type == "heartbeat":
             capabilities = message.payload.get("capabilities")
             resources = message.payload.get("resources")
             if not isinstance(capabilities, dict) or not isinstance(resources, dict):
@@ -182,3 +148,19 @@ def accept_message(authenticated_node_id: str, message: AgentMessage) -> dict:
             values,
         )
     return {"type": "ack", "sequence": message.sequence, "accepted_at": now}
+
+
+def response_for_message(authenticated_node_id: str, message: AgentMessage) -> dict:
+    acknowledgement = accept_message(authenticated_node_id, message)
+    if message.type in job_protocol.JOB_MESSAGE_TYPES:
+        try:
+            response = job_protocol.handle_message(authenticated_node_id, message.type, message.payload)
+        except job_protocol.JobProtocolError as exc:
+            raise ProtocolError("agent_job_invalid") from exc
+        response["sequence"] = message.sequence
+        return response
+    if message.type == "hello":
+        from hydrahive.compute import job_signing
+
+        acknowledgement["job_signing_public_key"] = job_signing.public_key_text()
+    return acknowledgement

--- a/core/src/hydrahive/compute/channel_message.py
+++ b/core/src/hydrahive/compute/channel_message.py
@@ -1,0 +1,49 @@
+"""Strict versioned inbound message schema for the compute-agent channel."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+MAX_CLOCK_SKEW_SECONDS = 120
+
+
+class ProtocolError(ValueError):
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class AgentMessage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal[
+        "hello",
+        "heartbeat",
+        "capabilities",
+        "job_poll",
+        "job_started",
+        "job_progress",
+        "job_succeeded",
+        "job_failed",
+    ]
+    protocol_version: Literal[1]
+    node_id: str = Field(min_length=1, max_length=128)
+    sequence: int = Field(ge=1, le=9_223_372_036_854_775_807)
+    nonce: str = Field(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$")
+    sent_at: datetime
+    payload: dict[str, object] = Field(default_factory=dict)
+
+
+def parse_message(raw: str) -> AgentMessage:
+    try:
+        message = AgentMessage.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ProtocolError("agent_message_invalid") from exc
+    if message.sent_at.tzinfo is None:
+        raise ProtocolError("agent_timestamp_invalid")
+    if abs((datetime.now(UTC) - message.sent_at.astimezone(UTC)).total_seconds()) > MAX_CLOCK_SKEW_SECONDS:
+        raise ProtocolError("agent_timestamp_invalid")
+    return message

--- a/core/src/hydrahive/compute/channel_message.py
+++ b/core/src/hydrahive/compute/channel_message.py
@@ -25,6 +25,7 @@ class AgentMessage(BaseModel):
         "capabilities",
         "job_poll",
         "job_started",
+        "job_renew",
         "job_progress",
         "job_succeeded",
         "job_failed",

--- a/core/src/hydrahive/compute/channel_monitor.py
+++ b/core/src/hydrahive/compute/channel_monitor.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
 
-from hydrahive.compute import audit
+from hydrahive.compute import audit, jobs
 from hydrahive.db._utils import now_iso
 from hydrahive.db.connection import db
 
@@ -64,6 +64,7 @@ async def run_loop(stop: asyncio.Event, interval: float = 15.0) -> None:
     while not stop.is_set():
         try:
             await asyncio.to_thread(mark_stale_nodes)
+            await asyncio.to_thread(jobs.expire_leases)
         except Exception:
             logger.exception("compute node dead-detection failed")
         try:

--- a/core/src/hydrahive/compute/job_protocol.py
+++ b/core/src/hydrahive/compute/job_protocol.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from hydrahive.compute import job_signing, jobs
 from hydrahive.compute.models import ComputeJob, JSONObject
 
-JOB_MESSAGE_TYPES = frozenset({"job_poll", "job_started", "job_progress", "job_succeeded", "job_failed"})
+JOB_MESSAGE_TYPES = frozenset({"job_poll", "job_started", "job_renew", "job_progress", "job_succeeded", "job_failed"})
 
 
 class JobProtocolError(ValueError):
@@ -61,6 +61,10 @@ def handle_message(node_id: str, message_type: str, payload: dict[str, object]) 
             if set(payload) != {"job_id", "lease_id"}:
                 raise JobProtocolError("job started payload is invalid")
             jobs.start_job(job.job_id, lease_id)
+        elif message_type == "job_renew":
+            if set(payload) != {"job_id", "lease_id"}:
+                raise JobProtocolError("job renewal payload is invalid")
+            jobs.renew_job_lease(job.job_id, lease_id)
         elif message_type == "job_progress":
             if set(payload) != {"job_id", "lease_id", "progress", "data"}:
                 raise JobProtocolError("job progress payload is invalid")
@@ -79,8 +83,10 @@ def handle_message(node_id: str, message_type: str, payload: dict[str, object]) 
             if not isinstance(error_code, str):
                 raise JobProtocolError("job error code is invalid")
             jobs.fail_job(job.job_id, lease_id, error_code, _object(payload, "error_params"))
-    except (jobs.JobConflict, jobs.JobNotFound, ValueError) as exc:
-        if isinstance(exc, JobProtocolError):
-            raise
-        raise JobProtocolError(str(exc)) from exc
+    except JobProtocolError:
+        raise
+    except jobs.JobConflict:
+        return {"type": "job_rejected", "reason": "state_conflict"}
+    except (jobs.JobNotFound, ValueError) as exc:
+        raise JobProtocolError("job state update is invalid") from exc
     return {"type": "ack"}

--- a/core/src/hydrahive/compute/job_protocol.py
+++ b/core/src/hydrahive/compute/job_protocol.py
@@ -1,0 +1,86 @@
+"""Typed mapping between authenticated agent messages and durable jobs."""
+
+from __future__ import annotations
+
+from hydrahive.compute import job_signing, jobs
+from hydrahive.compute.models import ComputeJob, JSONObject
+
+JOB_MESSAGE_TYPES = frozenset({"job_poll", "job_started", "job_progress", "job_succeeded", "job_failed"})
+
+
+class JobProtocolError(ValueError):
+    pass
+
+
+def _job_for_node(node_id: str, payload: dict[str, object]) -> tuple[ComputeJob, str]:
+    job_id = payload.get("job_id")
+    lease_id = payload.get("lease_id")
+    if not isinstance(job_id, str) or not isinstance(lease_id, str):
+        raise JobProtocolError("job payload is invalid")
+    job = jobs.get_job(job_id)
+    if job is None or job.node_id != node_id:
+        raise JobProtocolError("job does not belong to authenticated node")
+    return job, lease_id
+
+
+def _object(payload: dict[str, object], key: str) -> JSONObject:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise JobProtocolError(f"job {key} is invalid")
+    return value  # type: ignore[return-value]
+
+
+def _offer(job: ComputeJob) -> dict:
+    body = {
+        "job_id": job.job_id,
+        "node_id": job.node_id,
+        "resource_kind": job.resource_kind,
+        "resource_id": job.resource_id,
+        "operation": job.operation,
+        "generation": job.generation,
+        "payload": job.payload,
+        "idempotency_key": job.idempotency_key,
+        "lease_id": job.lease_id,
+        "lease_until": job.lease_until,
+    }
+    return {"type": "job_offer", "job": body, "signature": job_signing.sign_offer(body)}
+
+
+def handle_message(node_id: str, message_type: str, payload: dict[str, object]) -> dict:
+    if message_type not in JOB_MESSAGE_TYPES:
+        raise JobProtocolError("unknown job message type")
+    if message_type == "job_poll":
+        if payload:
+            raise JobProtocolError("job poll payload must be empty")
+        claimed = jobs.claim_next_job(node_id, lease_seconds=300)
+        return _offer(claimed) if claimed is not None else {"type": "no_job"}
+
+    job, lease_id = _job_for_node(node_id, payload)
+    try:
+        if message_type == "job_started":
+            if set(payload) != {"job_id", "lease_id"}:
+                raise JobProtocolError("job started payload is invalid")
+            jobs.start_job(job.job_id, lease_id)
+        elif message_type == "job_progress":
+            if set(payload) != {"job_id", "lease_id", "progress", "data"}:
+                raise JobProtocolError("job progress payload is invalid")
+            progress = payload["progress"]
+            if not isinstance(progress, int):
+                raise JobProtocolError("job progress is invalid")
+            jobs.report_progress(job.job_id, lease_id, progress, _object(payload, "data"))
+        elif message_type == "job_succeeded":
+            if set(payload) != {"job_id", "lease_id", "result"}:
+                raise JobProtocolError("job result payload is invalid")
+            jobs.succeed_job(job.job_id, lease_id, _object(payload, "result"))
+        else:
+            if set(payload) != {"job_id", "lease_id", "error_code", "error_params"}:
+                raise JobProtocolError("job failure payload is invalid")
+            error_code = payload["error_code"]
+            if not isinstance(error_code, str):
+                raise JobProtocolError("job error code is invalid")
+            jobs.fail_job(job.job_id, lease_id, error_code, _object(payload, "error_params"))
+    except (jobs.JobConflict, jobs.JobNotFound, ValueError) as exc:
+        if isinstance(exc, JobProtocolError):
+            raise
+        raise JobProtocolError(str(exc)) from exc
+    return {"type": "ack"}

--- a/core/src/hydrahive/compute/job_signing.py
+++ b/core/src/hydrahive/compute/job_signing.py
@@ -1,0 +1,79 @@
+"""Dedicated Ed25519 signing key and canonical signatures for compute jobs."""
+
+from __future__ import annotations
+
+import base64
+import fcntl
+import json
+import os
+import secrets
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
+from hydrahive.settings import settings
+
+
+def canonical_offer(offer: dict) -> bytes:
+    return json.dumps(offer, ensure_ascii=False, separators=(",", ":"), sort_keys=True, allow_nan=False).encode("utf-8")
+
+
+def _private_key() -> Ed25519PrivateKey:
+    directory = settings.compute_pki_dir
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    key_path = directory / "job-signing-key.bin"
+    lock_path = directory / ".job-signing.lock"
+    descriptor = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        if key_path.exists():
+            raw = key_path.read_bytes()
+            if len(raw) != 32:
+                raise RuntimeError("compute job signing key is invalid")
+            os.chmod(key_path, 0o600)
+            return Ed25519PrivateKey.from_private_bytes(raw)
+        key = Ed25519PrivateKey.generate()
+        raw = key.private_bytes(
+            serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption()
+        )
+        temporary = key_path.with_name(f".{key_path.name}.{secrets.token_hex(8)}.tmp")
+        temporary_descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(temporary_descriptor, "wb") as handle:
+                handle.write(raw)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, key_path)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return key
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _decode(value: str) -> bytes:
+    return base64.b64decode(value + "=" * (-len(value) % 4), altchars=b"-_", validate=True)
+
+
+def public_key_text() -> str:
+    raw = _private_key().public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+    return _encode(raw)
+
+
+def sign_offer(offer: dict) -> str:
+    return _encode(_private_key().sign(canonical_offer(offer)))
+
+
+def verify_offer(offer: dict, signature: str, public_key: str) -> bool:
+    try:
+        key = Ed25519PublicKey.from_public_bytes(_decode(public_key))
+        key.verify(_decode(signature), canonical_offer(offer))
+    except (ValueError, TypeError, InvalidSignature):
+        return False
+    return True

--- a/core/src/hydrahive/compute/jobs.py
+++ b/core/src/hydrahive/compute/jobs.py
@@ -1,0 +1,156 @@
+"""Durable compute-job creation, claiming, leasing, and lookup."""
+
+from __future__ import annotations
+
+from hydrahive.compute._job_codec import (
+    MAX_IDEMPOTENCY_KEY,
+    JobConflict,
+    JobNotFound,
+    dump_job_json,
+    row_to_event,
+    row_to_job,
+    validate_resource_kind,
+    validate_text,
+)
+from hydrahive.compute._job_events import append_event
+from hydrahive.compute.models import ComputeJob, ComputeJobEvent, JSONObject, JobResourceKind
+from hydrahive.db._utils import now_iso, uuid7
+from hydrahive.db.connection import db
+
+ALLOWED_OPERATIONS = frozenset(
+    {
+        "container.create",
+        "container.start",
+        "container.stop",
+        "container.restart",
+        "container.delete",
+        "container.inspect",
+        "vm.create_from_image",
+        "vm.start",
+        "vm.stop",
+        "vm.restart",
+        "vm.delete",
+        "vm.inspect",
+    }
+)
+
+
+def get_job(job_id: str) -> ComputeJob | None:
+    with db() as conn:
+        row = conn.execute("SELECT * FROM compute_jobs WHERE job_id = ?", (job_id,)).fetchone()
+    return row_to_job(row) if row else None
+
+
+def list_events(job_id: str) -> list[ComputeJobEvent]:
+    with db() as conn:
+        rows = conn.execute(
+            "SELECT * FROM compute_job_events WHERE job_id = ? ORDER BY sequence",
+            (job_id,),
+        ).fetchall()
+    return [row_to_event(row) for row in rows]
+
+
+def _request_matches(existing: ComputeJob, values: tuple[object, ...]) -> bool:
+    return (
+        existing.node_id,
+        existing.resource_kind,
+        existing.resource_id,
+        existing.operation,
+        existing.generation,
+        existing.payload,
+        existing.created_by,
+    ) == values
+
+
+def create_job(
+    *,
+    node_id: str,
+    resource_kind: JobResourceKind,
+    resource_id: str | None,
+    operation: str,
+    generation: int,
+    payload: JSONObject,
+    idempotency_key: str,
+    created_by: str,
+) -> ComputeJob:
+    node_id = validate_text(node_id, "node_id", maximum=128)
+    resource_kind = validate_resource_kind(resource_kind)
+    if operation not in ALLOWED_OPERATIONS or not operation.startswith(f"{resource_kind}."):
+        raise ValueError("compute job operation is not allowed")
+    if generation < 0:
+        raise ValueError("generation must be non-negative")
+    resource_id = validate_text(resource_id, "resource_id") if resource_id is not None else None
+    idempotency_key = validate_text(idempotency_key, "idempotency_key", maximum=MAX_IDEMPOTENCY_KEY)
+    created_by = validate_text(created_by, "created_by", maximum=128)
+    payload_json = dump_job_json(payload, "payload")
+    comparison = (node_id, resource_kind, resource_id, operation, generation, payload, created_by)
+    timestamp = now_iso()
+    with db(immediate=True) as conn:
+        existing_row = conn.execute(
+            "SELECT * FROM compute_jobs WHERE idempotency_key = ?",
+            (idempotency_key,),
+        ).fetchone()
+        if existing_row is not None:
+            existing = row_to_job(existing_row)
+            if not _request_matches(existing, comparison):
+                raise JobConflict("idempotency key belongs to a different request")
+            return existing
+        node = conn.execute("SELECT kind, status FROM compute_nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if node is None or node["kind"] != "agent" or node["status"] not in {"online", "draining"}:
+            raise JobConflict("target compute node cannot accept jobs")
+        if node["status"] == "draining" and operation.endswith(".create"):
+            raise JobConflict("draining compute node cannot accept create jobs")
+        job_id = uuid7()
+        conn.execute(
+            """INSERT INTO compute_jobs
+                   (job_id, node_id, resource_kind, resource_id, operation, generation,
+                    payload_json, idempotency_key, status, created_by, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'queued', ?, ?)""",
+            (
+                job_id,
+                node_id,
+                resource_kind,
+                resource_id,
+                operation,
+                generation,
+                payload_json,
+                idempotency_key,
+                created_by,
+                timestamp,
+            ),
+        )
+        append_event(
+            conn,
+            job_id=job_id,
+            node_id=node_id,
+            event_type="queued",
+            data={},
+            actor=created_by,
+        )
+        row = conn.execute("SELECT * FROM compute_jobs WHERE job_id = ?", (job_id,)).fetchone()
+    return row_to_job(row)
+
+
+from hydrahive.compute._job_leases import claim_next_job, expire_leases  # noqa: E402
+from hydrahive.compute._job_lifecycle import (  # noqa: E402
+    cancel_job,
+    fail_job,
+    report_progress,
+    start_job,
+    succeed_job,
+)
+
+__all__ = [
+    "JobConflict",
+    "JobNotFound",
+    "cancel_job",
+    "claim_next_job",
+    "create_job",
+    "expire_leases",
+    "fail_job",
+    "get_job",
+    "list_events",
+    "report_progress",
+    "start_job",
+    "succeed_job",
+]

--- a/core/src/hydrahive/compute/jobs.py
+++ b/core/src/hydrahive/compute/jobs.py
@@ -13,7 +13,7 @@ from hydrahive.compute._job_codec import (
     validate_text,
 )
 from hydrahive.compute._job_events import append_event
-from hydrahive.compute.models import ComputeJob, ComputeJobEvent, JSONObject, JobResourceKind
+from hydrahive.compute.models import JOB_STATUSES, ComputeJob, ComputeJobEvent, JSONObject, JobResourceKind
 from hydrahive.db._utils import now_iso, uuid7
 from hydrahive.db.connection import db
 
@@ -39,6 +39,32 @@ def get_job(job_id: str) -> ComputeJob | None:
     with db() as conn:
         row = conn.execute("SELECT * FROM compute_jobs WHERE job_id = ?", (job_id,)).fetchone()
     return row_to_job(row) if row else None
+
+
+def list_jobs(
+    *,
+    node_id: str | None = None,
+    status: str | None = None,
+    created_by: str | None = None,
+    limit: int = 100,
+) -> list[ComputeJob]:
+    if status is not None and status not in JOB_STATUSES:
+        raise ValueError("invalid compute job status")
+    limit = max(1, min(limit, 200))
+    conditions: list[str] = []
+    values: list[object] = []
+    for column, value in (("node_id", node_id), ("status", status), ("created_by", created_by)):
+        if value is not None:
+            conditions.append(f"{column} = ?")
+            values.append(value)
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    values.append(limit)
+    with db() as conn:
+        rows = conn.execute(
+            f"SELECT * FROM compute_jobs {where} ORDER BY created_at DESC, job_id DESC LIMIT ?",
+            values,
+        ).fetchall()
+    return [row_to_job(row) for row in rows]
 
 
 def list_events(job_id: str) -> list[ComputeJobEvent]:
@@ -150,6 +176,7 @@ __all__ = [
     "fail_job",
     "get_job",
     "list_events",
+    "list_jobs",
     "report_progress",
     "start_job",
     "succeed_job",

--- a/core/src/hydrahive/compute/jobs.py
+++ b/core/src/hydrahive/compute/jobs.py
@@ -161,6 +161,7 @@ from hydrahive.compute._job_leases import claim_next_job, expire_leases  # noqa:
 from hydrahive.compute._job_lifecycle import (  # noqa: E402
     cancel_job,
     fail_job,
+    renew_job_lease,
     report_progress,
     start_job,
     succeed_job,
@@ -177,6 +178,7 @@ __all__ = [
     "get_job",
     "list_events",
     "list_jobs",
+    "renew_job_lease",
     "report_progress",
     "start_job",
     "succeed_job",

--- a/core/src/hydrahive/compute/models.py
+++ b/core/src/hydrahive/compute/models.py
@@ -14,6 +14,8 @@ JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
 JSONObject: TypeAlias = dict[str, JSONValue]
 
 NODE_KINDS: frozenset[str] = frozenset({"local", "agent"})
+JOB_RESOURCE_KINDS: frozenset[str] = frozenset({"container", "vm", "node"})
+JOB_STATUSES: frozenset[str] = frozenset({"queued", "leased", "running", "succeeded", "failed", "cancelled", "expired"})
 NODE_STATUSES: frozenset[str] = frozenset(
     {"pending", "online", "degraded", "offline", "draining", "disabled", "revoked"}
 )

--- a/core/tests/test_compute_channel.py
+++ b/core/tests/test_compute_channel.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from hydrahive.compute import channel, channel_monitor
+from hydrahive.compute import channel, channel_monitor, jobs
 from hydrahive.compute import db as node_db
 from hydrahive.db.connection import db, init_db
 from hydrahive.settings import settings
@@ -145,8 +145,9 @@ def test_capabilities_and_heartbeats_update_node_health(connected_node: str) -> 
     assert "node.degraded" in actions
 
 
-def test_websocket_channel_requires_bound_identity_and_acknowledges(client, monkeypatch) -> None:
+def test_websocket_channel_requires_bound_identity_and_offers_jobs(client, monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(settings, "compute_proxy_secret", "proxy-secret", raising=False)
+    monkeypatch.setattr(settings, "compute_pki_dir", tmp_path / "compute-pki", raising=False)
     monkeypatch.setattr(channel, "proxy_certificate_fingerprint", lambda certificate: "cd" * 32)
     node = node_db.create_node(
         node_id="node-websocket",
@@ -154,14 +155,40 @@ def test_websocket_channel_requires_bound_identity_and_acknowledges(client, monk
         certificate_fingerprint="cd" * 32,
     )
     node_db.approve_node(node.node_id, "admin-id")
+    node_db.transition_node_status(node.node_id, "online")
+    created = jobs.create_job(
+        node_id=node.node_id,
+        resource_kind="container",
+        resource_id="demo",
+        operation="container.start",
+        generation=1,
+        payload={"name": "demo"},
+        idempotency_key="websocket-demo-start",
+        created_by="admin-id",
+    )
     headers = {
         "x-hydrahive-node-id": node.node_id,
         "x-hydrahive-client-cert": "valid-cert",
         "x-hydrahive-proxy-secret": "proxy-secret",
     }
     with client.websocket_connect("/api/compute/agent/connect", headers=headers) as websocket:
-        websocket.send_text(_raw(node.node_id, sequence=1, nonce="nonce-websocket01"))
-        assert websocket.receive_json()["sequence"] == 1
+        websocket.send_text(
+            _raw(
+                node.node_id,
+                sequence=1,
+                nonce="nonce-websocket01",
+                kind="hello",
+                payload={"agent_version": "0.1.0"},
+            )
+        )
+        hello = websocket.receive_json()
+        assert hello["sequence"] == 1
+        assert hello["job_signing_public_key"]
+
+        websocket.send_text(_raw(node.node_id, sequence=2, nonce="nonce-websocket02", kind="job_poll", payload={}))
+        offer = websocket.receive_json()
+        assert offer["type"] == "job_offer"
+        assert offer["job"]["job_id"] == created.job_id
 
 
 def test_dead_detection_marks_degraded_then_offline(connected_node: str) -> None:

--- a/core/tests/test_compute_job_protocol.py
+++ b/core/tests/test_compute_job_protocol.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hydrahive.compute import db as node_db
+from hydrahive.compute import job_protocol, job_signing, jobs
+from hydrahive.db.connection import init_db
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def protocol_node(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(settings, "sessions_db", tmp_path / "protocol-jobs.db", raising=False)
+    monkeypatch.setattr(settings, "compute_pki_dir", tmp_path / "pki", raising=False)
+    init_db()
+    node = node_db.create_node(
+        node_id="node-protocol",
+        name="Protocol Node",
+        certificate_fingerprint="ab" * 32,
+    )
+    node_db.approve_node(node.node_id, "admin")
+    node_db.transition_node_status(node.node_id, "online")
+    return node.node_id
+
+
+def _job(node_id: str):
+    return jobs.create_job(
+        node_id=node_id,
+        resource_kind="container",
+        resource_id="demo",
+        operation="container.start",
+        generation=2,
+        payload={"name": "demo"},
+        idempotency_key="container:demo:start:2",
+        created_by="admin",
+    )
+
+
+def test_job_poll_returns_signed_node_bound_offer(protocol_node: str) -> None:
+    created = _job(protocol_node)
+    response = job_protocol.handle_message(protocol_node, "job_poll", {})
+
+    assert response["type"] == "job_offer"
+    assert response["job"]["job_id"] == created.job_id
+    assert response["job"]["node_id"] == protocol_node
+    assert job_signing.verify_offer(response["job"], response["signature"], job_signing.public_key_text())
+
+    tampered = dict(response["job"], operation="container.delete")
+    assert not job_signing.verify_offer(tampered, response["signature"], job_signing.public_key_text())
+
+
+def test_job_events_require_matching_node_job_and_lease(protocol_node: str) -> None:
+    created = _job(protocol_node)
+    offer = job_protocol.handle_message(protocol_node, "job_poll", {})
+    lease_id = offer["job"]["lease_id"]
+
+    started = job_protocol.handle_message(
+        protocol_node,
+        "job_started",
+        {"job_id": created.job_id, "lease_id": lease_id},
+    )
+    assert started["type"] == "ack"
+    assert jobs.get_job(created.job_id).status == "running"
+
+    with pytest.raises(job_protocol.JobProtocolError, match="node"):
+        job_protocol.handle_message(
+            "different-node",
+            "job_succeeded",
+            {"job_id": created.job_id, "lease_id": lease_id, "result": {}},
+        )
+
+    job_protocol.handle_message(
+        protocol_node,
+        "job_succeeded",
+        {"job_id": created.job_id, "lease_id": lease_id, "result": {"state": "running"}},
+    )
+    assert jobs.get_job(created.job_id).status == "succeeded"
+
+
+def test_job_poll_without_work_is_explicit(protocol_node: str) -> None:
+    assert job_protocol.handle_message(protocol_node, "job_poll", {}) == {"type": "no_job"}

--- a/core/tests/test_compute_job_protocol.py
+++ b/core/tests/test_compute_job_protocol.py
@@ -77,6 +77,17 @@ def test_job_events_require_matching_node_job_and_lease(protocol_node: str) -> N
         {"job_id": created.job_id, "lease_id": lease_id, "result": {"state": "running"}},
     )
     assert jobs.get_job(created.job_id).status == "succeeded"
+    rejected = job_protocol.handle_message(
+        protocol_node,
+        "job_failed",
+        {
+            "job_id": created.job_id,
+            "lease_id": "stale-lease",
+            "error_code": "late",
+            "error_params": {},
+        },
+    )
+    assert rejected == {"type": "job_rejected", "reason": "state_conflict"}
 
 
 def test_job_poll_without_work_is_explicit(protocol_node: str) -> None:

--- a/core/tests/test_compute_jobs.py
+++ b/core/tests/test_compute_jobs.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from hydrahive.compute import db as node_db
+from hydrahive.compute import jobs
+from hydrahive.db.connection import db, init_db
+from hydrahive.settings import settings
+
+
+@pytest.fixture
+def jobs_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(settings, "sessions_db", tmp_path / "jobs.db", raising=False)
+    init_db()
+    node = node_db.create_node(
+        node_id="node-jobs",
+        name="Jobs Node",
+        certificate_fingerprint="ab" * 32,
+    )
+    node_db.approve_node(node.node_id, "admin")
+    node_db.transition_node_status(node.node_id, "online")
+    return node.node_id
+
+
+def _create(node_id: str, *, key: str = "container:create:one"):
+    return jobs.create_job(
+        node_id=node_id,
+        resource_kind="container",
+        resource_id="container-one",
+        operation="container.create",
+        generation=1,
+        payload={"name": "container-one", "image": "images:debian/12"},
+        idempotency_key=key,
+        created_by="admin",
+    )
+
+
+def test_create_job_is_idempotent_and_appends_initial_event(jobs_db: str) -> None:
+    created = _create(jobs_db)
+    repeated = _create(jobs_db)
+
+    assert repeated == created
+    assert created.status == "queued"
+    assert created.attempts == 0
+    assert [event.event_type for event in jobs.list_events(created.job_id)] == ["queued"]
+
+    with pytest.raises(jobs.JobConflict, match="idempotency"):
+        jobs.create_job(
+            node_id=jobs_db,
+            resource_kind="container",
+            resource_id="other",
+            operation="container.start",
+            generation=1,
+            payload={},
+            idempotency_key="container:create:one",
+            created_by="admin",
+        )
+
+
+def test_claim_is_atomic_node_bound_and_lease_checked(jobs_db: str) -> None:
+    queued = _create(jobs_db)
+    claimed = jobs.claim_next_job(jobs_db, lease_seconds=30)
+
+    assert claimed is not None
+    assert claimed.job_id == queued.job_id
+    assert claimed.status == "leased"
+    assert claimed.lease_id
+    assert claimed.lease_until
+    assert claimed.attempts == 1
+    assert jobs.claim_next_job(jobs_db, lease_seconds=30) is None
+    assert jobs.claim_next_job("other-node", lease_seconds=30) is None
+
+    with pytest.raises(jobs.JobConflict, match="lease"):
+        jobs.start_job(claimed.job_id, "wrong-lease")
+
+
+def test_running_job_reports_progress_and_terminal_result_idempotently(jobs_db: str) -> None:
+    created = _create(jobs_db)
+    claimed = jobs.claim_next_job(jobs_db)
+    assert claimed is not None and claimed.lease_id is not None
+
+    running = jobs.start_job(created.job_id, claimed.lease_id)
+    assert running.status == "running"
+    assert running.started_at is not None
+    progressed = jobs.report_progress(created.job_id, claimed.lease_id, 40, {"phase": "launch"})
+    assert progressed.progress == 40
+
+    succeeded = jobs.succeed_job(created.job_id, claimed.lease_id, {"runtime_ref": "container-one"})
+    repeated = jobs.succeed_job(created.job_id, claimed.lease_id, {"runtime_ref": "container-one"})
+    assert repeated == succeeded
+    assert succeeded.status == "succeeded"
+    assert succeeded.progress == 100
+    assert succeeded.finished_at is not None
+    assert [event.event_type for event in jobs.list_events(created.job_id)] == [
+        "queued",
+        "leased",
+        "running",
+        "progress",
+        "succeeded",
+    ]
+
+    with pytest.raises(jobs.JobConflict, match="terminal"):
+        jobs.fail_job(created.job_id, claimed.lease_id, "late_failure", {})
+
+
+def test_expired_lease_requeues_unstarted_but_expires_running_job(jobs_db: str) -> None:
+    first = _create(jobs_db, key="first")
+    first_claim = jobs.claim_next_job(jobs_db, lease_seconds=30)
+    assert first_claim is not None and first_claim.lease_id
+    second = _create(jobs_db, key="second")
+    second_claim = jobs.claim_next_job(jobs_db, lease_seconds=30)
+    assert second_claim is not None and second_claim.lease_id
+    jobs.start_job(second.job_id, second_claim.lease_id)
+
+    expired = (datetime.now(UTC) - timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    with db() as conn:
+        conn.execute(
+            "UPDATE compute_jobs SET lease_until = ? WHERE job_id IN (?, ?)",
+            (expired, first.job_id, second.job_id),
+        )
+
+    assert jobs.expire_leases() == (1, 1)
+    assert jobs.get_job(first.job_id).status == "queued"
+    assert jobs.get_job(second.job_id).status == "expired"
+
+
+def test_cancel_rejects_terminal_job_and_every_transition_is_audited(jobs_db: str) -> None:
+    created = _create(jobs_db)
+    cancelled = jobs.cancel_job(created.job_id, actor="admin")
+    assert cancelled.status == "cancelled"
+
+    with pytest.raises(jobs.JobConflict, match="terminal"):
+        jobs.cancel_job(created.job_id, actor="admin")
+
+    with db() as conn:
+        actions = [
+            row["action"]
+            for row in conn.execute(
+                "SELECT action FROM compute_audit_log WHERE node_id = ? AND action LIKE 'job.%' ORDER BY created_at",
+                (jobs_db,),
+            )
+        ]
+    assert actions == ["job.queued", "job.cancelled"]

--- a/core/tests/test_compute_jobs.py
+++ b/core/tests/test_compute_jobs.py
@@ -85,6 +85,8 @@ def test_running_job_reports_progress_and_terminal_result_idempotently(jobs_db: 
     running = jobs.start_job(created.job_id, claimed.lease_id)
     assert running.status == "running"
     assert running.started_at is not None
+    renewed = jobs.renew_job_lease(created.job_id, claimed.lease_id)
+    assert renewed.lease_until > running.lease_until
     progressed = jobs.report_progress(created.job_id, claimed.lease_id, 40, {"phase": "launch"})
     assert progressed.progress == 40
     with pytest.raises(jobs.JobConflict, match="running"):

--- a/core/tests/test_compute_jobs.py
+++ b/core/tests/test_compute_jobs.py
@@ -87,6 +87,8 @@ def test_running_job_reports_progress_and_terminal_result_idempotently(jobs_db: 
     assert running.started_at is not None
     progressed = jobs.report_progress(created.job_id, claimed.lease_id, 40, {"phase": "launch"})
     assert progressed.progress == 40
+    with pytest.raises(jobs.JobConflict, match="running"):
+        jobs.cancel_job(created.job_id, actor="admin")
 
     succeeded = jobs.succeed_job(created.job_id, claimed.lease_id, {"runtime_ref": "container-one"})
     repeated = jobs.succeed_job(created.job_id, claimed.lease_id, {"runtime_ref": "container-one"})

--- a/core/tests/test_compute_jobs_api.py
+++ b/core/tests/test_compute_jobs_api.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from hydrahive.api.middleware import users
+from hydrahive.compute import db as node_db
+from hydrahive.compute import jobs
+from tests.conftest import error_code
+
+
+@pytest.fixture
+def api_jobs() -> dict[str, object]:
+    node_id = "node-jobs-api"
+    if node_db.get_node(node_id) is None:
+        node_db.create_node(
+            node_id=node_id,
+            name="Jobs API Node",
+            certificate_fingerprint="ef" * 32,
+        )
+        node_db.approve_node(node_id, "admin")
+        node_db.transition_node_status(node_id, "online")
+    user_id = users.get_by_username("testuser")["user_id"]
+    admin_id = users.get_by_username("admin")["user_id"]
+    user_job = jobs.create_job(
+        node_id=node_id,
+        resource_kind="container",
+        resource_id="user-demo",
+        operation="container.start",
+        generation=1,
+        payload={"secret": "must-not-be-returned"},
+        idempotency_key="api-user-job",
+        created_by=user_id,
+    )
+    admin_job = jobs.create_job(
+        node_id=node_id,
+        resource_kind="container",
+        resource_id="admin-demo",
+        operation="container.stop",
+        generation=1,
+        payload={},
+        idempotency_key="api-admin-job",
+        created_by=admin_id,
+    )
+    return {"user": user_job, "admin": admin_job}
+
+
+def test_job_list_requires_auth_scopes_owner_and_never_returns_payload(
+    client, auth_headers, admin_headers, api_jobs
+) -> None:
+    assert client.get("/api/compute/jobs").status_code == 401
+
+    owned = client.get("/api/compute/jobs", headers=auth_headers)
+    assert owned.status_code == 200
+    assert [item["job_id"] for item in owned.json()] == [api_jobs["user"].job_id]
+    assert "payload" not in owned.json()[0]
+    assert "idempotency_key" not in owned.json()[0]
+
+    admin = client.get("/api/compute/jobs", headers=admin_headers)
+    assert admin.status_code == 200
+    ids = {item["job_id"] for item in admin.json()}
+    assert {api_jobs["user"].job_id, api_jobs["admin"].job_id} <= ids
+
+
+def test_job_detail_events_and_cancel_enforce_ownership(client, auth_headers, admin_headers, api_jobs) -> None:
+    admin_job_id = api_jobs["admin"].job_id
+    hidden = client.get(f"/api/compute/jobs/{admin_job_id}", headers=auth_headers)
+    assert hidden.status_code == 404
+    assert error_code(hidden) == "compute_job_not_found"
+
+    user_job_id = api_jobs["user"].job_id
+    detail = client.get(f"/api/compute/jobs/{user_job_id}", headers=auth_headers)
+    assert detail.status_code == 200
+    events = client.get(f"/api/compute/jobs/{user_job_id}/events", headers=auth_headers)
+    assert events.status_code == 200
+    assert events.json()[0]["event_type"] == "queued"
+
+    cancelled = client.post(f"/api/compute/jobs/{user_job_id}/cancel", headers=auth_headers)
+    assert cancelled.status_code == 200
+    assert cancelled.json()["status"] == "cancelled"
+    repeated = client.post(f"/api/compute/jobs/{user_job_id}/cancel", headers=auth_headers)
+    assert repeated.status_code == 409
+    assert error_code(repeated) == "compute_job_transition_invalid"
+
+    assert client.get(f"/api/compute/jobs/{admin_job_id}", headers=admin_headers).status_code == 200

--- a/node-agent/src/hydrahive_node/job_runtime.py
+++ b/node-agent/src/hydrahive_node/job_runtime.py
@@ -1,0 +1,58 @@
+"""Polling and delivery loop for signed compute jobs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+from hydrahive_node import jobs
+from hydrahive_node.job_state import load_delivered_jobs, load_job_results, mark_job_result_delivered
+from hydrahive_node.storage import AgentIdentity, StatePaths
+
+Exchange = Callable[[str, dict[str, object]], Awaitable[dict]]
+Handler = Callable[[jobs.VerifiedJob], Awaitable[dict[str, object]]]
+
+
+async def _unsupported_handler(job: jobs.VerifiedJob) -> dict[str, object]:
+    raise RuntimeError(f"operation is not installed: {job.operation}")
+
+
+async def _deliver(exchange: Exchange, outcome: dict[str, object]) -> None:
+    message_type = outcome.get("type")
+    if message_type not in {"job_succeeded", "job_failed"}:
+        raise RuntimeError("persisted job outcome is invalid")
+    payload = {key: value for key, value in outcome.items() if key != "type"}
+    response = await exchange(str(message_type), payload)
+    if response.get("type") != "ack":
+        raise RuntimeError("job result was not acknowledged")
+
+
+async def _flush_results(paths: StatePaths, exchange: Exchange) -> None:
+    delivered = load_delivered_jobs(paths)
+    for idempotency_key, outcome in load_job_results(paths).items():
+        if idempotency_key in delivered:
+            continue
+        await _deliver(exchange, outcome)
+        mark_job_result_delivered(paths, idempotency_key)
+
+
+async def run_loop(
+    paths: StatePaths,
+    identity: AgentIdentity,
+    exchange: Exchange,
+    handler: Handler = _unsupported_handler,
+) -> None:
+    public_key = paths.job_signing_public_key.read_text(encoding="ascii").strip()
+    while True:
+        await _flush_results(paths, exchange)
+        response = await exchange("job_poll", {})
+        if response.get("type") == "no_job":
+            await asyncio.sleep(2.0)
+            continue
+        verified = jobs.verify_offer(response, public_key, identity.node_id)
+        started = await exchange("job_started", {"job_id": verified.job_id, "lease_id": verified.lease_id})
+        if started.get("type") != "ack":
+            raise RuntimeError("job start was not acknowledged")
+        outcome = await jobs.execute_offer(paths, verified, handler)
+        await _deliver(exchange, outcome)
+        mark_job_result_delivered(paths, verified.idempotency_key)

--- a/node-agent/src/hydrahive_node/job_runtime.py
+++ b/node-agent/src/hydrahive_node/job_runtime.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import asdict
 
 from hydrahive_node import jobs
-from hydrahive_node.job_state import load_delivered_jobs, load_job_results, mark_job_result_delivered
+from hydrahive_node.job_state import (
+    load_delivered_jobs,
+    load_job_executions,
+    load_job_results,
+    mark_job_result_delivered,
+    prepare_job_execution,
+    save_job_result,
+)
 from hydrahive_node.storage import AgentIdentity, StatePaths
 
 Exchange = Callable[[str, dict[str, object]], Awaitable[dict]]
@@ -23,7 +31,7 @@ async def _deliver(exchange: Exchange, outcome: dict[str, object]) -> None:
         raise RuntimeError("persisted job outcome is invalid")
     payload = {key: value for key, value in outcome.items() if key != "type"}
     response = await exchange(str(message_type), payload)
-    if response.get("type") != "ack":
+    if response.get("type") not in {"ack", "job_rejected"}:
         raise RuntimeError("job result was not acknowledged")
 
 
@@ -36,6 +44,66 @@ async def _flush_results(paths: StatePaths, exchange: Exchange) -> None:
         mark_job_result_delivered(paths, idempotency_key)
 
 
+async def _execute_with_renewal(
+    paths: StatePaths,
+    job: jobs.VerifiedJob,
+    exchange: Exchange,
+    handler: Handler,
+) -> dict[str, object]:
+    execution = asyncio.create_task(jobs.execute_offer(paths, job, handler))
+    while True:
+        done, _ = await asyncio.wait({execution}, timeout=60.0)
+        if done:
+            return await execution
+        try:
+            response = await exchange("job_renew", {"job_id": job.job_id, "lease_id": job.lease_id})
+        except BaseException:
+            execution.cancel()
+            try:
+                await execution
+            except asyncio.CancelledError:
+                pass
+            raise
+        if response.get("type") == "ack":
+            continue
+        execution.cancel()
+        try:
+            await execution
+        except asyncio.CancelledError:
+            pass
+        outcome: dict[str, object] = {
+            "type": "job_failed",
+            "job_id": job.job_id,
+            "lease_id": job.lease_id,
+            "error_code": "lease_lost",
+            "error_params": {},
+        }
+        save_job_result(paths, job.idempotency_key, outcome)
+        return outcome
+
+
+async def _resume_executions(paths: StatePaths, exchange: Exchange, handler: Handler) -> None:
+    delivered = load_delivered_jobs(paths)
+    for idempotency_key, execution in load_job_executions(paths).items():
+        if idempotency_key in delivered:
+            mark_job_result_delivered(paths, idempotency_key)
+            continue
+        job_data = execution.get("job")
+        if not isinstance(job_data, dict):
+            raise RuntimeError("persisted job execution is invalid")
+        job = jobs.VerifiedJob(**job_data)  # type: ignore[arg-type]
+        if execution.get("state") == "accepted":
+            started = await exchange("job_started", {"job_id": job.job_id, "lease_id": job.lease_id})
+            if started.get("type") == "job_rejected":
+                mark_job_result_delivered(paths, idempotency_key)
+                continue
+            if started.get("type") != "ack":
+                raise RuntimeError("resumed job start was not acknowledged")
+        outcome = await _execute_with_renewal(paths, job, exchange, handler)
+        await _deliver(exchange, outcome)
+        mark_job_result_delivered(paths, idempotency_key)
+
+
 async def run_loop(
     paths: StatePaths,
     identity: AgentIdentity,
@@ -43,16 +111,21 @@ async def run_loop(
     handler: Handler = _unsupported_handler,
 ) -> None:
     public_key = paths.job_signing_public_key.read_text(encoding="ascii").strip()
+    await _flush_results(paths, exchange)
+    await _resume_executions(paths, exchange, handler)
     while True:
-        await _flush_results(paths, exchange)
         response = await exchange("job_poll", {})
         if response.get("type") == "no_job":
             await asyncio.sleep(2.0)
             continue
         verified = jobs.verify_offer(response, public_key, identity.node_id)
+        prepare_job_execution(paths, asdict(verified))
         started = await exchange("job_started", {"job_id": verified.job_id, "lease_id": verified.lease_id})
+        if started.get("type") == "job_rejected":
+            mark_job_result_delivered(paths, verified.idempotency_key)
+            continue
         if started.get("type") != "ack":
             raise RuntimeError("job start was not acknowledged")
-        outcome = await jobs.execute_offer(paths, verified, handler)
+        outcome = await _execute_with_renewal(paths, verified, exchange, handler)
         await _deliver(exchange, outcome)
         mark_job_result_delivered(paths, verified.idempotency_key)

--- a/node-agent/src/hydrahive_node/job_state.py
+++ b/node-agent/src/hydrahive_node/job_state.py
@@ -1,0 +1,73 @@
+"""Crash-safe pinning, outcomes, and delivery state for compute jobs."""
+
+from __future__ import annotations
+
+import json
+
+from hydrahive_node.storage import StatePaths, _atomic_write
+
+MAX_STORED_JOBS = 10_000
+
+
+def save_job_signing_public_key(paths: StatePaths, public_key: str) -> None:
+    if not public_key or len(public_key) > 128 or not public_key.isascii():
+        raise RuntimeError("job signing public key is invalid")
+    if paths.job_signing_public_key.exists():
+        pinned = paths.job_signing_public_key.read_text(encoding="ascii").strip()
+        if pinned != public_key:
+            raise RuntimeError("job signing public key changed unexpectedly")
+        return
+    _atomic_write(paths.job_signing_public_key, (public_key + "\n").encode("ascii"), 0o644)
+
+
+def load_job_results(paths: StatePaths) -> dict[str, dict[str, object]]:
+    try:
+        decoded = json.loads(paths.job_results.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("persisted job results are invalid") from exc
+    if not isinstance(decoded, dict) or not all(
+        isinstance(key, str) and isinstance(value, dict) for key, value in decoded.items()
+    ):
+        raise RuntimeError("persisted job results are invalid")
+    return decoded
+
+
+def save_job_result(paths: StatePaths, idempotency_key: str, result: dict[str, object]) -> None:
+    results = load_job_results(paths)
+    existing = results.get(idempotency_key)
+    if existing is not None and existing != result:
+        raise RuntimeError("persisted job result conflicts with completed operation")
+    results[idempotency_key] = result
+    if len(results) > MAX_STORED_JOBS:
+        raise RuntimeError("persisted job result limit reached")
+    _atomic_write(
+        paths.job_results,
+        json.dumps(results, ensure_ascii=False, separators=(",", ":"), sort_keys=True, allow_nan=False).encode("utf-8"),
+        0o600,
+    )
+
+
+def load_delivered_jobs(paths: StatePaths) -> set[str]:
+    try:
+        decoded = json.loads(paths.delivered_jobs.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return set()
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("delivered job state is invalid") from exc
+    if not isinstance(decoded, list) or not all(isinstance(item, str) for item in decoded):
+        raise RuntimeError("delivered job state is invalid")
+    return set(decoded)
+
+
+def mark_job_result_delivered(paths: StatePaths, idempotency_key: str) -> None:
+    delivered = load_delivered_jobs(paths)
+    delivered.add(idempotency_key)
+    if len(delivered) > MAX_STORED_JOBS:
+        raise RuntimeError("delivered job state limit reached")
+    _atomic_write(
+        paths.delivered_jobs,
+        json.dumps(sorted(delivered), separators=(",", ":")).encode("utf-8"),
+        0o600,
+    )

--- a/node-agent/src/hydrahive_node/job_state.py
+++ b/node-agent/src/hydrahive_node/job_state.py
@@ -1,12 +1,35 @@
-"""Crash-safe pinning, outcomes, and delivery state for compute jobs."""
+"""Crash-safe pinning, execution journal, outcomes, and delivery state."""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from hydrahive_node.storage import StatePaths, _atomic_write
 
 MAX_STORED_JOBS = 10_000
+MAX_PENDING_RESULTS = 1_000
+
+
+def _load(path: Path, label: str) -> dict[str, dict[str, object]]:
+    try:
+        decoded = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"persisted {label} state is invalid") from exc
+    if not isinstance(decoded, dict) or not all(
+        isinstance(key, str) and isinstance(value, dict) for key, value in decoded.items()
+    ):
+        raise RuntimeError(f"persisted {label} state is invalid")
+    return decoded
+
+
+def _save(path: Path, value: object) -> None:
+    encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True, allow_nan=False).encode(
+        "utf-8"
+    )
+    _atomic_write(path, encoded, 0o600)
 
 
 def save_job_signing_public_key(paths: StatePaths, public_key: str) -> None:
@@ -21,17 +44,7 @@ def save_job_signing_public_key(paths: StatePaths, public_key: str) -> None:
 
 
 def load_job_results(paths: StatePaths) -> dict[str, dict[str, object]]:
-    try:
-        decoded = json.loads(paths.job_results.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return {}
-    except (OSError, ValueError) as exc:
-        raise RuntimeError("persisted job results are invalid") from exc
-    if not isinstance(decoded, dict) or not all(
-        isinstance(key, str) and isinstance(value, dict) for key, value in decoded.items()
-    ):
-        raise RuntimeError("persisted job results are invalid")
-    return decoded
+    return _load(paths.job_results, "job result")
 
 
 def save_job_result(paths: StatePaths, idempotency_key: str, result: dict[str, object]) -> None:
@@ -40,34 +53,64 @@ def save_job_result(paths: StatePaths, idempotency_key: str, result: dict[str, o
     if existing is not None and existing != result:
         raise RuntimeError("persisted job result conflicts with completed operation")
     results[idempotency_key] = result
-    if len(results) > MAX_STORED_JOBS:
-        raise RuntimeError("persisted job result limit reached")
-    _atomic_write(
-        paths.job_results,
-        json.dumps(results, ensure_ascii=False, separators=(",", ":"), sort_keys=True, allow_nan=False).encode("utf-8"),
-        0o600,
-    )
+    if len(results) > MAX_PENDING_RESULTS:
+        raise RuntimeError("too many undelivered job results")
+    _save(paths.job_results, results)
 
 
-def load_delivered_jobs(paths: StatePaths) -> set[str]:
+def load_job_executions(paths: StatePaths) -> dict[str, dict[str, object]]:
+    return _load(paths.job_executions, "job execution")
+
+
+def prepare_job_execution(paths: StatePaths, job: dict[str, object]) -> None:
+    key = job.get("idempotency_key")
+    if not isinstance(key, str):
+        raise RuntimeError("job execution identity is invalid")
+    executions = load_job_executions(paths)
+    existing = executions.get(key)
+    if existing is not None:
+        if existing.get("job") != job:
+            raise RuntimeError("idempotency key is bound to a different job")
+        return
+    executions[key] = {"state": "accepted", "job": job}
+    _save(paths.job_executions, executions)
+
+
+def mark_job_in_progress(paths: StatePaths, idempotency_key: str) -> None:
+    executions = load_job_executions(paths)
+    execution = executions.get(idempotency_key)
+    if execution is None:
+        raise RuntimeError("job execution was not prepared")
+    execution["state"] = "in_progress"
+    _save(paths.job_executions, executions)
+
+
+def _load_delivered_list(paths: StatePaths) -> list[str]:
     try:
         decoded = json.loads(paths.delivered_jobs.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        return set()
+        return []
     except (OSError, ValueError) as exc:
         raise RuntimeError("delivered job state is invalid") from exc
     if not isinstance(decoded, list) or not all(isinstance(item, str) for item in decoded):
         raise RuntimeError("delivered job state is invalid")
-    return set(decoded)
+    return decoded
+
+
+def load_delivered_jobs(paths: StatePaths) -> set[str]:
+    return set(_load_delivered_list(paths))
 
 
 def mark_job_result_delivered(paths: StatePaths, idempotency_key: str) -> None:
-    delivered = load_delivered_jobs(paths)
-    delivered.add(idempotency_key)
-    if len(delivered) > MAX_STORED_JOBS:
-        raise RuntimeError("delivered job state limit reached")
-    _atomic_write(
-        paths.delivered_jobs,
-        json.dumps(sorted(delivered), separators=(",", ":")).encode("utf-8"),
-        0o600,
-    )
+    delivered = _load_delivered_list(paths)
+    if idempotency_key not in delivered:
+        delivered.append(idempotency_key)
+    delivered = delivered[-MAX_STORED_JOBS:]
+    _save(paths.delivered_jobs, delivered)
+
+    results = load_job_results(paths)
+    results.pop(idempotency_key, None)
+    _save(paths.job_results, results)
+    executions = load_job_executions(paths)
+    executions.pop(idempotency_key, None)
+    _save(paths.job_executions, executions)

--- a/node-agent/src/hydrahive_node/jobs.py
+++ b/node-agent/src/hydrahive_node/jobs.py
@@ -1,0 +1,160 @@
+"""Signed job validation and crash-safe idempotent dispatch."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from hydrahive_node.job_state import load_job_results, save_job_result
+from hydrahive_node.storage import StatePaths
+
+MAX_JOB_BYTES = 64 * 1024
+ALLOWED_OPERATIONS = frozenset(
+    {
+        "container.create",
+        "container.start",
+        "container.stop",
+        "container.restart",
+        "container.delete",
+        "container.inspect",
+        "vm.create_from_image",
+        "vm.start",
+        "vm.stop",
+        "vm.restart",
+        "vm.delete",
+        "vm.inspect",
+    }
+)
+OFFER_FIELDS = {
+    "job_id",
+    "node_id",
+    "resource_kind",
+    "resource_id",
+    "operation",
+    "generation",
+    "payload",
+    "idempotency_key",
+    "lease_id",
+    "lease_until",
+}
+
+
+class JobValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedJob:
+    job_id: str
+    node_id: str
+    resource_kind: str
+    resource_id: str | None
+    operation: str
+    generation: int
+    payload: dict[str, object]
+    idempotency_key: str
+    lease_id: str
+    lease_until: str
+
+
+def canonical_offer(offer: dict) -> bytes:
+    try:
+        encoded = json.dumps(
+            offer,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise JobValidationError("job offer contains invalid JSON") from exc
+    if len(encoded) > MAX_JOB_BYTES:
+        raise JobValidationError("job offer is too large")
+    return encoded
+
+
+def _decode(value: str) -> bytes:
+    try:
+        return base64.b64decode(value + "=" * (-len(value) % 4), altchars=b"-_", validate=True)
+    except (ValueError, TypeError) as exc:
+        raise JobValidationError("job signature encoding is invalid") from exc
+
+
+def verify_offer(message: dict, public_key: str, expected_node_id: str) -> VerifiedJob:
+    if set(message) != {"type", "job", "signature"} or message.get("type") != "job_offer":
+        raise JobValidationError("job offer envelope is invalid")
+    offer = message.get("job")
+    signature = message.get("signature")
+    if not isinstance(offer, dict) or set(offer) != OFFER_FIELDS or not isinstance(signature, str):
+        raise JobValidationError("job offer schema is invalid")
+    try:
+        key = Ed25519PublicKey.from_public_bytes(_decode(public_key))
+        key.verify(_decode(signature), canonical_offer(offer))
+    except (ValueError, InvalidSignature) as exc:
+        raise JobValidationError("job signature is invalid") from exc
+    if offer["node_id"] != expected_node_id:
+        raise JobValidationError("job belongs to a different node")
+    if offer["operation"] not in ALLOWED_OPERATIONS:
+        raise JobValidationError("job operation is not allowed")
+    if offer["resource_kind"] not in {"container", "vm"} or not str(offer["operation"]).startswith(
+        f"{offer['resource_kind']}."
+    ):
+        raise JobValidationError("job resource kind is invalid")
+    if not isinstance(offer["generation"], int) or offer["generation"] < 0 or not isinstance(offer["payload"], dict):
+        raise JobValidationError("job payload is invalid")
+    for field in ("job_id", "node_id", "idempotency_key", "lease_id", "lease_until"):
+        if not isinstance(offer[field], str) or not 0 < len(offer[field]) <= 255:
+            raise JobValidationError(f"job {field} is invalid")
+    if offer["resource_id"] is not None and not isinstance(offer["resource_id"], str):
+        raise JobValidationError("job resource_id is invalid")
+    try:
+        lease_until = datetime.fromisoformat(str(offer["lease_until"]).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise JobValidationError("job lease expiry is invalid") from exc
+    if lease_until.tzinfo is None or lease_until.astimezone(UTC) <= datetime.now(UTC):
+        raise JobValidationError("job lease has expired")
+    return VerifiedJob(**offer)  # type: ignore[arg-type]
+
+
+async def execute_offer(
+    paths: StatePaths,
+    job: VerifiedJob,
+    handler: Callable[[VerifiedJob], Awaitable[dict[str, object]]],
+) -> dict[str, object]:
+    existing = load_job_results(paths).get(job.idempotency_key)
+    if existing is not None:
+        return existing
+    try:
+        result = await handler(job)
+        if not isinstance(result, dict):
+            raise TypeError("handler result must be an object")
+        outcome: dict[str, object] = {
+            "type": "job_succeeded",
+            "job_id": job.job_id,
+            "lease_id": job.lease_id,
+            "result": result,
+        }
+    except Exception:
+        outcome = {
+            "type": "job_failed",
+            "job_id": job.job_id,
+            "lease_id": job.lease_id,
+            "error_code": "operation_failed",
+            "error_params": {},
+        }
+    if len(json.dumps(outcome, allow_nan=False).encode("utf-8")) > MAX_JOB_BYTES:
+        outcome = {
+            "type": "job_failed",
+            "job_id": job.job_id,
+            "lease_id": job.lease_id,
+            "error_code": "result_too_large",
+            "error_params": {},
+        }
+    save_job_result(paths, job.idempotency_key, outcome)
+    return outcome

--- a/node-agent/src/hydrahive_node/jobs.py
+++ b/node-agent/src/hydrahive_node/jobs.py
@@ -11,7 +11,12 @@ from datetime import UTC, datetime
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-from hydrahive_node.job_state import load_job_results, save_job_result
+from hydrahive_node.job_state import (
+    load_job_executions,
+    load_job_results,
+    mark_job_in_progress,
+    save_job_result,
+)
 from hydrahive_node.storage import StatePaths
 
 MAX_JOB_BYTES = 64 * 1024
@@ -130,11 +135,25 @@ async def execute_offer(
     existing = load_job_results(paths).get(job.idempotency_key)
     if existing is not None:
         return existing
+    execution = load_job_executions(paths).get(job.idempotency_key)
+    if execution is None:
+        raise RuntimeError("job execution was not durably prepared")
+    if execution.get("state") == "in_progress":
+        outcome: dict[str, object] = {
+            "type": "job_failed",
+            "job_id": job.job_id,
+            "lease_id": job.lease_id,
+            "error_code": "operation_outcome_unknown",
+            "error_params": {},
+        }
+        save_job_result(paths, job.idempotency_key, outcome)
+        return outcome
+    mark_job_in_progress(paths, job.idempotency_key)
     try:
         result = await handler(job)
         if not isinstance(result, dict):
             raise TypeError("handler result must be an object")
-        outcome: dict[str, object] = {
+        outcome = {
             "type": "job_succeeded",
             "job_id": job.job_id,
             "lease_id": job.lease_id,

--- a/node-agent/src/hydrahive_node/runtime.py
+++ b/node-agent/src/hydrahive_node/runtime.py
@@ -12,7 +12,6 @@ from datetime import UTC, datetime
 import websockets
 
 from hydrahive_node import __version__
-from hydrahive_node import job_runtime
 from hydrahive_node.capabilities import collect
 from hydrahive_node.job_state import save_job_signing_public_key
 from hydrahive_node.storage import AgentIdentity, StatePaths, next_sequence
@@ -118,9 +117,9 @@ async def _run_session(paths: StatePaths, identity: AgentIdentity) -> None:
         )
         if response.get("type") != "ack":
             raise RuntimeError("capabilities were not acknowledged")
-        async with asyncio.TaskGroup() as tasks:
-            tasks.create_task(_heartbeat_loop(exchange))
-            tasks.create_task(job_runtime.run_loop(paths, identity, exchange))
+        # Job polling is enabled by the P4 runtime only after concrete, allowlisted
+        # operation handlers have been installed.
+        await _heartbeat_loop(exchange)
 
 
 async def run(paths: StatePaths, identity: AgentIdentity) -> None:

--- a/node-agent/src/hydrahive_node/runtime.py
+++ b/node-agent/src/hydrahive_node/runtime.py
@@ -12,7 +12,9 @@ from datetime import UTC, datetime
 import websockets
 
 from hydrahive_node import __version__
+from hydrahive_node import job_runtime
 from hydrahive_node.capabilities import collect
+from hydrahive_node.job_state import save_job_signing_public_key
 from hydrahive_node.storage import AgentIdentity, StatePaths, next_sequence
 
 HEARTBEAT_SECONDS = 30.0
@@ -55,13 +57,38 @@ def _message(
     return sequence, encoded
 
 
-async def _send(websocket, paths: StatePaths, identity: AgentIdentity, message_type: str, payload: dict) -> None:
+async def _exchange(
+    websocket,
+    lock: asyncio.Lock,
+    paths: StatePaths,
+    identity: AgentIdentity,
+    message_type: str,
+    payload: dict[str, object],
+) -> dict:
     sequence, encoded = _message(paths, identity, message_type, payload)
-    await websocket.send(encoded)
-    raw = await asyncio.wait_for(websocket.recv(), timeout=20.0)
-    acknowledgement = json.loads(raw)
-    if acknowledgement.get("type") != "ack" or acknowledgement.get("sequence") != sequence:
-        raise RuntimeError("invalid acknowledgement from control plane")
+    async with lock:
+        await websocket.send(encoded)
+        raw = await asyncio.wait_for(websocket.recv(), timeout=20.0)
+    response = json.loads(raw)
+    if not isinstance(response, dict) or response.get("sequence") != sequence or response.get("type") == "error":
+        raise RuntimeError("invalid response from control plane")
+    return response
+
+
+async def _heartbeat_loop(exchange) -> None:
+    while True:
+        capabilities, resources, health_errors = collect()
+        response = await exchange(
+            "heartbeat",
+            {
+                "capabilities": capabilities,
+                "resources": resources,
+                "health_errors": health_errors,
+            },
+        )
+        if response.get("type") != "ack":
+            raise RuntimeError("heartbeat was not acknowledged")
+        await asyncio.sleep(HEARTBEAT_SECONDS)
 
 
 async def _run_session(paths: StatePaths, identity: AgentIdentity) -> None:
@@ -74,29 +101,26 @@ async def _run_session(paths: StatePaths, identity: AgentIdentity) -> None:
         max_size=MAX_MESSAGE_BYTES,
         open_timeout=20.0,
     ) as websocket:
-        await _send(websocket, paths, identity, "hello", {"agent_version": __version__})
-        capabilities, resources, health_errors = collect()
-        await _send(
-            websocket,
-            paths,
-            identity,
+        lock = asyncio.Lock()
+
+        async def exchange(message_type: str, payload: dict[str, object]) -> dict:
+            return await _exchange(websocket, lock, paths, identity, message_type, payload)
+
+        hello = await exchange("hello", {"agent_version": __version__})
+        public_key = hello.get("job_signing_public_key")
+        if not isinstance(public_key, str):
+            raise RuntimeError("control plane did not provide a job signing key")
+        save_job_signing_public_key(paths, public_key)
+        capabilities, resources, _ = collect()
+        response = await exchange(
             "capabilities",
             {"capabilities": capabilities, "resources": resources},
         )
-        while True:
-            capabilities, resources, health_errors = collect()
-            await _send(
-                websocket,
-                paths,
-                identity,
-                "heartbeat",
-                {
-                    "capabilities": capabilities,
-                    "resources": resources,
-                    "health_errors": health_errors,
-                },
-            )
-            await asyncio.sleep(HEARTBEAT_SECONDS)
+        if response.get("type") != "ack":
+            raise RuntimeError("capabilities were not acknowledged")
+        async with asyncio.TaskGroup() as tasks:
+            tasks.create_task(_heartbeat_loop(exchange))
+            tasks.create_task(job_runtime.run_loop(paths, identity, exchange))
 
 
 async def run(paths: StatePaths, identity: AgentIdentity) -> None:

--- a/node-agent/src/hydrahive_node/storage.py
+++ b/node-agent/src/hydrahive_node/storage.py
@@ -47,6 +47,18 @@ class StatePaths:
     def protocol_state(self) -> Path:
         return self.directory / "protocol-state.json"
 
+    @property
+    def job_signing_public_key(self) -> Path:
+        return self.directory / "job-signing-public-key.txt"
+
+    @property
+    def job_results(self) -> Path:
+        return self.directory / "job-results.json"
+
+    @property
+    def delivered_jobs(self) -> Path:
+        return self.directory / "delivered-jobs.json"
+
 
 def _atomic_write(path: Path, content: bytes, mode: int) -> None:
     temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")

--- a/node-agent/src/hydrahive_node/storage.py
+++ b/node-agent/src/hydrahive_node/storage.py
@@ -59,6 +59,10 @@ class StatePaths:
     def delivered_jobs(self) -> Path:
         return self.directory / "delivered-jobs.json"
 
+    @property
+    def job_executions(self) -> Path:
+        return self.directory / "job-executions.json"
+
 
 def _atomic_write(path: Path, content: bytes, mode: int) -> None:
     temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")

--- a/node-agent/tests/test_jobs.py
+++ b/node-agent/tests/test_jobs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from hydrahive_node import jobs
+from hydrahive_node.storage import StatePaths
+
+
+def _signed_offer(*, node_id: str = "node-one", operation: str = "container.start") -> tuple[dict, str]:
+    key = Ed25519PrivateKey.generate()
+    public = (
+        base64.urlsafe_b64encode(
+            key.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    payload = {
+        "job_id": "job-one",
+        "node_id": node_id,
+        "resource_kind": "container",
+        "resource_id": "demo",
+        "operation": operation,
+        "generation": 1,
+        "payload": {"name": "demo"},
+        "idempotency_key": "container:demo:start:1",
+        "lease_id": "lease-one",
+        "lease_until": (datetime.now(UTC) + timedelta(minutes=1)).isoformat().replace("+00:00", "Z"),
+    }
+    signature = base64.urlsafe_b64encode(key.sign(jobs.canonical_offer(payload))).decode("ascii").rstrip("=")
+    return {"type": "job_offer", "job": payload, "signature": signature}, public
+
+
+def test_verify_offer_rejects_tampering_wrong_node_and_expiry() -> None:
+    offer, public = _signed_offer()
+    verified = jobs.verify_offer(offer, public, "node-one")
+    assert verified.operation == "container.start"
+
+    offer["job"]["operation"] = "container.delete"
+    with pytest.raises(jobs.JobValidationError, match="signature"):
+        jobs.verify_offer(offer, public, "node-one")
+
+    fresh, public = _signed_offer(node_id="other")
+    with pytest.raises(jobs.JobValidationError, match="node"):
+        jobs.verify_offer(fresh, public, "node-one")
+
+
+def test_dispatcher_persists_result_before_delivery_and_never_executes_twice(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    offer, public = _signed_offer()
+    calls = 0
+
+    async def handler(job: jobs.VerifiedJob) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {"state": "running"}
+
+    first = asyncio.run(jobs.execute_offer(paths, jobs.verify_offer(offer, public, "node-one"), handler))
+    second = asyncio.run(jobs.execute_offer(paths, jobs.verify_offer(offer, public, "node-one"), handler))
+
+    assert first == second
+    assert first["type"] == "job_succeeded"
+    assert calls == 1
+    assert paths.job_results.stat().st_mode & 0o777 == 0o600

--- a/node-agent/tests/test_jobs.py
+++ b/node-agent/tests/test_jobs.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
+from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from hydrahive_node import jobs
+from hydrahive_node import job_runtime, job_state, jobs
 from hydrahive_node.storage import StatePaths
 
 
@@ -62,10 +64,93 @@ def test_dispatcher_persists_result_before_delivery_and_never_executes_twice(tmp
         calls += 1
         return {"state": "running"}
 
-    first = asyncio.run(jobs.execute_offer(paths, jobs.verify_offer(offer, public, "node-one"), handler))
-    second = asyncio.run(jobs.execute_offer(paths, jobs.verify_offer(offer, public, "node-one"), handler))
+    verified = jobs.verify_offer(offer, public, "node-one")
+    job_state.prepare_job_execution(paths, asdict(verified))
+    first = asyncio.run(jobs.execute_offer(paths, verified, handler))
+    second = asyncio.run(jobs.execute_offer(paths, verified, handler))
 
     assert first == second
     assert first["type"] == "job_succeeded"
     assert calls == 1
     assert paths.job_results.stat().st_mode & 0o777 == 0o600
+
+
+def test_interrupted_in_progress_job_is_not_executed_again(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    offer, public = _signed_offer()
+    verified = jobs.verify_offer(offer, public, "node-one")
+    job_state.prepare_job_execution(paths, asdict(verified))
+    job_state.mark_job_in_progress(paths, verified.idempotency_key)
+    calls = 0
+
+    async def handler(job: jobs.VerifiedJob) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {}
+
+    outcome = asyncio.run(jobs.execute_offer(paths, verified, handler))
+
+    assert calls == 0
+    assert outcome["error_code"] == "operation_outcome_unknown"
+
+
+def test_delivered_job_state_is_bounded_and_pending_payload_is_removed(tmp_path, monkeypatch) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    monkeypatch.setattr(job_state, "MAX_STORED_JOBS", 2)
+    job_state.save_job_result(paths, "one", {"type": "job_failed"})
+    job_state.mark_job_result_delivered(paths, "one")
+    job_state.mark_job_result_delivered(paths, "two")
+    job_state.mark_job_result_delivered(paths, "three")
+
+    assert job_state.load_job_results(paths) == {}
+    assert job_state.load_delivered_jobs(paths) == {"two", "three"}
+
+
+def test_resume_cleans_journal_if_delivery_marker_was_already_committed(tmp_path) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    offer, public = _signed_offer()
+    verified = jobs.verify_offer(offer, public, "node-one")
+    job_state.prepare_job_execution(paths, asdict(verified))
+    job_state.mark_job_in_progress(paths, verified.idempotency_key)
+    paths.delivered_jobs.write_text(json.dumps([verified.idempotency_key]), encoding="utf-8")
+
+    async def unused_exchange(message_type: str, payload: dict[str, object]) -> dict:
+        raise AssertionError("delivered job must not contact the control plane")
+
+    async def unused_handler(job: jobs.VerifiedJob) -> dict[str, object]:
+        raise AssertionError("delivered job must not execute")
+
+    asyncio.run(job_runtime._resume_executions(paths, unused_exchange, unused_handler))
+    assert job_state.load_job_executions(paths) == {}
+
+
+def test_renewal_transport_failure_cancels_running_handler(tmp_path, monkeypatch) -> None:
+    paths = StatePaths(tmp_path / "state")
+    paths.directory.mkdir(mode=0o700)
+    offer, public = _signed_offer()
+    verified = jobs.verify_offer(offer, public, "node-one")
+    job_state.prepare_job_execution(paths, asdict(verified))
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def handler(job: jobs.VerifiedJob) -> dict[str, object]:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    async def immediate_timeout(awaitables, timeout):
+        await started.wait()
+        return set(), set(awaitables)
+
+    async def failed_exchange(message_type: str, payload: dict[str, object]) -> dict:
+        raise ConnectionError("connection lost")
+
+    monkeypatch.setattr(job_runtime.asyncio, "wait", immediate_timeout)
+    with pytest.raises(ConnectionError, match="connection lost"):
+        asyncio.run(job_runtime._execute_with_renewal(paths, verified, failed_exchange, handler))
+    assert cancelled.is_set()


### PR DESCRIPTION
## Summary

Implements Cluster MVP phase P3: persistent, node-bound compute jobs and a signed agent protocol.

- durable job state machine with atomic node-scoped claims, leases, renewal, timeout and append-only events/audit
- idempotent terminal results and explicit handling of stale leases without reconnect loops
- dedicated Ed25519 job-signing key; strict canonical offers bound to node, resource, generation, idempotency key and lease
- crash-safe agent execution journal with accepted/in-progress states, reconnect resume and no blind re-execution after an unknown outcome
- bounded rolling delivery history and cleanup of delivered payloads
- ownership-scoped job status/events/cancel API that never returns job payloads, lease IDs or result payloads
- agent runtime intentionally does not poll jobs until P4 installs concrete allowlisted Incus handlers

## Security

- no arbitrary command or operation input; protocol allowlist only
- invalid node/lease/signature/expiry fails closed
- renewal transport loss cancels and awaits the running handler
- stale results are explicitly rejected and retired instead of blocking heartbeats
- security review completed; all Blocker/High findings resolved

## Verification

- `1825 passed` — complete Core suite
- `13 passed` — complete node-agent suite
- node-agent wheel build passed
- Ruff format/lint and diff check passed
