### PR TITLE
feat(node-agent): geführtes Ein-Befehl-Setup für Nicht-Techniker

### DIFF
--- a/docs/compute-node-runbook.md
+++ b/docs/compute-node-runbook.md
@@ -25,11 +25,13 @@ Der Agent läuft als eigener Benutzer `hydrahive-node` mit ausschließlich den f
 Incus notwendigen Gruppenrechten. Identität und Zustand liegen unter
 `/var/lib/hydrahive-node/` mit restriktiven Dateirechten (`0600`/`0700`).
 
-> **Woher kommt der Agent, wie wird er installiert und der Master vorbereitet?**
-> Schritt-für-Schritt in [`../node-agent/README.md`](../node-agent/README.md)
-> (Bezugsquelle, Master-Proxy-Setup, `scripts/install.sh`, Troubleshooting).
-> Dieses Runbook fasst den Betrieb zusammen; das README ist die
-> Installationsreferenz.
+> **Einfachster Weg — geführtes Skript:** Auf dem neuen Node genügt
+> `git clone …hydrahive2.0 && cd hydrahive2.0/node-agent && sudo sh scripts/setup.sh`.
+> Das Skript prüft die Voraussetzungen, installiert den Agent und führt durch
+> Kopplung + Freigabe. Vollständige Anleitung (inkl. der einmaligen Server-
+> Vorbereitung mit Proxy/mTLS) in [`../node-agent/README.md`](../node-agent/README.md).
+> Der Rest dieses Abschnitts beschreibt die manuellen Schritte, die das Skript
+> automatisiert.
 
 ## 2. Node koppeln (Enrollment)
 

--- a/node-agent/README.md
+++ b/node-agent/README.md
@@ -1,107 +1,128 @@
-# HydraHive Node Agent
+# HydraHive Compute-Node
 
-Der Node Agent ist ein eigenständiges, minimales Python-Paket, das einen
-freigegebenen Ubuntu-Host zu einem HydraHive-**Compute-Node** macht. Er verbindet
-sich **ausgehend** mit dem HydraHive-Master, sendet Heartbeats und führt
-ausschließlich signierte, allowlistete Incus-Operationen aus (Remote-Container und
-imagebasierte Remote-VMs). Der Agent nimmt **keine** eingehenden Verbindungen an
-und kennt keine LLM- oder Frontend-Abhängigkeiten.
-
-- Vollständiges Betriebs-Runbook: [`../docs/compute-node-runbook.md`](../docs/compute-node-runbook.md)
-- Architektur/Spec: [`../docs/specs/compute-cluster-v1.md`](../docs/specs/compute-cluster-v1.md)
+Mit einem Compute-Node hängst du einen weiteren Rechner (Ubuntu-Server) an
+HydraHive an, damit dort Container und virtuelle Maschinen laufen. Der Node
+verbindet sich von selbst nach außen zum HydraHive-Server — du musst am Node
+**keine Ports öffnen** und keine Firewall umbauen.
 
 ---
 
-## 1. Woher bekomme ich den Node-Client?
+## Schnellstart — einen Node dazuhängen (für alle)
 
-Der Agent-Code liegt in **diesem Repository** unter `node-agent/`. Es gibt kein
-separates Download-Paket — du bringst den Ordner auf den Zielhost und installierst
-ihn dort. Drei übliche Wege:
+> Das ist der normale Fall: Du hast einen fertigen HydraHive-Server und willst
+> einen weiteren Rechner als Compute-Node dazunehmen. Voraussetzung: Auf dem
+> Server hat der Admin die **einmalige Einrichtung** (ganz unten) schon gemacht.
 
-**A) Repo direkt auf dem Node klonen (einfachster Weg)**
+Du brauchst nur ein Terminal auf dem neuen Rechner. Kopiere diese Befehle:
+
 ```bash
+# 1. HydraHive-Projekt holen (falls noch nicht da)
 git clone https://github.com/hydrahive/hydrahive2.0.git
 cd hydrahive2.0/node-agent
+
+# 2. Geführte Einrichtung starten
+sudo sh scripts/setup.sh
 ```
 
-**B) Nur den node-agent-Ordner per rsync/scp auf den Node kopieren**
+Das Skript nimmt dich an die Hand und fragt der Reihe nach:
+
+1. **Prüft**, ob Incus (und optional KVM für VMs) vorhanden ist.
+2. **Installiert** den Node-Agent.
+3. **Fragt** nach der Server-Adresse, einem Namen für den Node und dem
+   **Kopplungs-Code**. Den Code holst du im Browser aus dem Cockpit:
+   **Admin → Compute-Nodes → „Node koppeln"** → Namen vergeben → Token kopieren.
+4. **Koppelt** den Node und zeigt dir einen **Sicherheits-Code**.
+5. Du klickst im Cockpit auf **„Freigeben"** und vergleichst den Sicherheits-Code.
+   Dann drückst du Enter — fertig. Der Node erscheint als **„Online"**.
+
+Danach kannst du beim Anlegen von Containern und VMs diesen Node auswählen.
+
+**Wenn etwas schiefgeht**, sagt dir das Skript im Klartext, was zu tun ist. Log
+ansehen:
 ```bash
-# vom Master/Arbeitsrechner aus:
+journalctl -u hydrahive-node -f
+```
+
+Node später wieder entfernen: im Cockpit **„Widerrufen"**, dann auf dem Node:
+```bash
+sudo systemctl disable --now hydrahive-node
+sudo rm -rf /var/lib/hydrahive-node
+```
+
+Das war's für den Normalfall. Alles darunter ist Hintergrundwissen und die
+einmalige Server-Einrichtung für Admins.
+
+---
+
+## Voraussetzungen am Node
+
+- **Ubuntu** (LTS empfohlen) mit sudo-Zugriff.
+- **Incus** installiert und initialisiert (`incus admin init`), Bridge **`br0`**.
+  Das Setup-Skript prüft das und sagt dir, falls etwas fehlt.
+- Für **virtuelle Maschinen** zusätzlich **KVM** (`/dev/kvm`). Fehlt es, läuft der
+  Node trotzdem — dann eben nur mit Containern.
+- Python ≥ 3.12 (auf aktuellem Ubuntu vorinstalliert).
+
+---
+
+## Woher kommt der Node-Client?
+
+Der Agent ist Teil dieses Repositories im Ordner `node-agent/`. Es gibt kein
+separates Download-Paket — der Schnellstart oben klont einfach das Repo. Wer den
+Ordner lieber ohne Git überträgt:
+
+```bash
+# vom Server/Arbeitsrechner aus auf den neuen Node kopieren:
 rsync -a node-agent/ root@<node-host>:/opt/hydrahive-node-agent/
-# --exclude '.venv' --exclude '.pytest_cache' schadet nicht
+# dann auf dem Node:  cd /opt/hydrahive-node-agent && sudo sh scripts/setup.sh
 ```
-
-**C) Als Wheel bauen und übertragen**
-```bash
-cd node-agent
-python3 -m pip install build && python3 -m build   # erzeugt dist/hydrahive_node_agent-*.whl
-scp dist/*.whl root@<node-host>:/tmp/
-# auf dem Node:  pip install /tmp/hydrahive_node_agent-*.whl
-```
-
-Der Agent hat nur drei Laufzeit-Abhängigkeiten (`cryptography`, `httpx`,
-`websockets`) und braucht Python ≥ 3.12.
 
 ---
 
-## 2. Voraussetzungen auf dem Node
+## Was macht das Setup-Skript technisch?
 
-- **Ubuntu** (LTS empfohlen) mit Root-/sudo-Zugriff.
-- **Incus** installiert und initialisiert, Bridge **`br0`** vorhanden
-  (`incus network list`). Die Gruppe `incus-admin` muss existieren.
-- Für **VMs** zusätzlich **KVM**: `/dev/kvm` vorhanden und für den Agent-Benutzer
-  les-/schreibbar (`ls -l /dev/kvm`).
-- **Ausgehende HTTPS/WSS-Verbindung** zum Master erlaubt (kein eingehender Port
-  nötig).
-- Python ≥ 3.12.
+`scripts/setup.sh` ruft intern `scripts/install.sh` auf. Das:
+- legt den gesperrten System-Benutzer `hydrahive-node` an und hängt ihn in die
+  Gruppe `incus-admin`,
+- erstellt `/var/lib/hydrahive-node/` (`0700`) für Identität und Zustand,
+- installiert das Paket (CLI `hydrahive-node`),
+- installiert die gehärtete systemd-Unit und aktiviert sie.
 
-> Incus zuerst einrichten. Ohne die Gruppe `incus-admin` bricht der Installer
-> bewusst ab.
+Die Kopplung selbst läuft über `hydrahive-node enroll`. Der Agent erzeugt lokal
+ein Schlüsselpaar, sendet einen Zertifikatsantrag (CSR) und zeigt einen
+Fingerprint, den du im Cockpit bestätigst. Erst nach der Freigabe nimmt der Node
+Arbeit an.
 
 ---
 
-## 3. Master-seitige Vorbereitung (einmalig)
+## Einmalige Server-Einrichtung (nur Server-Admin)
 
-Der Agentkanal ist mTLS-gesichert: Der Agent authentisiert sich mit einem
-Client-Zertifikat, das die HydraHive-**Compute-CA** ausgestellt hat. Ein
-Reverse-Proxy vor dem Master terminiert TLS, prüft das Client-Zertifikat und
-reicht Identität + ein gemeinsames Proxy-Secret als Header an das Backend weiter.
+> Das macht **einmal** die Person, die den HydraHive-Server betreibt. Danach
+> können beliebig viele Nodes über den Schnellstart oben dazukommen, ohne dass
+> hier nochmal etwas angefasst werden muss.
 
-### 3.1 Proxy-Secret setzen
+Der Agentkanal ist mit gegenseitigem TLS (mTLS) abgesichert: Der Node meldet sich
+mit einem Client-Zertifikat, das die HydraHive-**Compute-CA** ausgestellt hat. Ein
+Reverse-Proxy vor dem Server prüft dieses Zertifikat und reicht die Identität plus
+ein gemeinsames Geheimnis ans Backend weiter.
 
-Das Backend akzeptiert Agent-Verbindungen nur, wenn der Proxy ein passendes
-Secret mitschickt (`HH_COMPUTE_PROXY_SECRET`). In der Master-Umgebung setzen
-(z. B. `/etc/hydrahive2/env`):
-
+**1. Proxy-Secret setzen** (in der Server-Umgebung, z. B. `/etc/hydrahive2/env`):
 ```
 HH_COMPUTE_PROXY_SECRET=<langes-zufälliges-secret>
 ```
+Danach den HydraHive-Dienst neu starten. Die Compute-CA wird automatisch beim
+ersten Enrollment erzeugt (`<config>/compute-pki/ca-cert.pem`).
 
-Danach den HydraHive-Dienst neu starten.
-
-### 3.2 Compute-CA
-
-Die Compute-CA wird **automatisch** beim ersten Enrollment erzeugt und unter
-`HH_COMPUTE_PKI_DIR` (Default `<config>/compute-pki/`) abgelegt:
-`ca-cert.pem` (öffentlich) und `ca-key.pem` (geheim, `0600`). Das
-`ca-cert.pem` brauchst du im Reverse-Proxy für `ssl_verify_client` sowie
-optional auf dem Node als `--ca-file`.
-
-### 3.3 Reverse-Proxy (Beispiel nginx)
-
+**2. Reverse-Proxy** (Beispiel nginx) für den WSS-Endpunkt:
 ```nginx
-# WSS-Endpunkt ausschließlich für Compute-Agents
 location /api/compute/agent/connect {
-    # Client-Zertifikat gegen die Compute-CA verifizieren
     ssl_verify_client       on;
     ssl_client_certificate  /etc/hydrahive2/compute-pki/ca-cert.pem;
 
-    # Verifizierte Identität + Proxy-Secret ans Backend weiterreichen
     proxy_set_header X-HydraHive-Client-Cert   $ssl_client_escaped_cert;
-    proxy_set_header X-HydraHive-Proxy-Secret  "<dasselbe-secret-wie-HH_COMPUTE_PROXY_SECRET>";
+    proxy_set_header X-HydraHive-Proxy-Secret  "<dasselbe-secret-wie-oben>";
     proxy_set_header X-HydraHive-Node-ID       $http_x_hydrahive_node_id;
 
-    # WebSocket-Upgrade
     proxy_http_version 1.1;
     proxy_set_header Upgrade    $http_upgrade;
     proxy_set_header Connection "upgrade";
@@ -109,129 +130,48 @@ location /api/compute/agent/connect {
 }
 ```
 
-> Das Backend prüft fail-closed: ohne gültiges, von der Compute-CA signiertes
-> Client-Zertifikat **und** korrektes Proxy-Secret wird die Verbindung mit
-> `4403 agent_identity_invalid` abgewiesen. Ein widerrufener Node kann sich nicht
-> mehr verbinden.
+Das Backend prüft fail-closed: ohne gültiges, von der Compute-CA signiertes
+Client-Zertifikat **und** korrektes Proxy-Secret wird die Verbindung mit
+`4403 agent_identity_invalid` abgewiesen. Ein im Cockpit widerrufener Node kann
+sich nicht mehr verbinden.
+
+Ausführliches Betriebs-Runbook (Recovery, Widerruf, Sicherheitsgrenzen):
+[`../docs/compute-node-runbook.md`](../docs/compute-node-runbook.md).
 
 ---
 
-## 4. Agent installieren
+## Manuelle Kopplung (ohne Setup-Skript)
 
-Auf dem Node als root im `node-agent`-Ordner:
-
+Falls du die Schritte einzeln steuern willst:
 ```bash
 sudo ./scripts/install.sh
-```
-
-Der Installer:
-- legt System-Benutzer/-Gruppe `hydrahive-node` an (Login gesperrt),
-- fügt ihn der Gruppe `incus-admin` hinzu,
-- erstellt `/var/lib/hydrahive-node/` (`0700`),
-- installiert das Paket (`pip install .`) → CLI `hydrahive-node`,
-- installiert die gehärtete systemd-Unit und aktiviert sie (startet aber noch
-  nicht).
-
----
-
-## 5. Node koppeln (Enrollment)
-
-**Schritt 1 — Master (Admin):** Cockpit → **Admin → Compute-Nodes → „Node
-koppeln"**. Eindeutigen Namen vergeben, **Enrollment-Token** erzeugen. Der Token
-ist einmalig und wird nur einmal angezeigt → sofort kopieren.
-
-**Schritt 2 — Node:** Enrollment ausführen. Den Token sicher übergeben (Datei mit
-`0600` oder via stdin, nicht als Klartext-Argument):
-
-```bash
-# Token in eine 0600-Datei legen und referenzieren:
 umask 077; printf '%s' '<TOKEN>' > /run/hh-node-token
 sudo -u hydrahive-node hydrahive-node enroll \
-    --server https://<master-host> \
-    --name  <exakt-der-name-aus-schritt-1> \
+    --server https://<server> --name <node-name> \
     --token-file /run/hh-node-token \
-    --ca-file /etc/hydrahive2/compute-pki/ca-cert.pem   # optional, empfohlen
+    --ca-file /etc/hydrahive2/compute-pki/ca-cert.pem
 rm -f /run/hh-node-token
-```
-
-Alternativen zur Token-Übergabe: `--token-stdin` (Token über die Standardeingabe)
-oder ganz ohne Flag → interaktive Passwort-Abfrage.
-
-Der Agent generiert lokal ein Schlüsselpaar, sendet einen CSR und gibt aus:
-```
-Node ID: <node-id>
-Certificate fingerprint: <sha256-fingerprint>
-```
-
-**Schritt 3 — Master (Admin):** In der Node-Liste erscheint der Node als
-**„Wartet"**. **„Freigeben"** öffnen, den vom Agent gezeigten **Fingerprint exakt
-vergleichen** und bestätigen. Nur bei Übereinstimmung wird der Node freigegeben.
-
-**Schritt 4 — Node:** Dienst starten:
-```bash
+# Fingerprint im Cockpit freigeben, dann:
 sudo systemctl enable --now hydrahive-node
-sudo systemctl status hydrahive-node
 ```
-Nach dem ersten Heartbeat wird der Node im Cockpit **Online**.
+Token-Alternativen: `--token-stdin` oder ganz ohne Flag (interaktive Abfrage).
 
 ---
 
-## 6. Workloads platzieren
+## Troubleshooting
 
-- **Remote-Container:** Container-Create-Dialog → Ziel-Node wählen (nur online +
-  incus-fähig; Admin-only). Die Container-Karte zeigt ein Remote-Node-Badge.
-- **Remote-VMs:** VM-Create-Dialog → Ziel-Node wählen (nur online + incus + kvm).
-  Auf Remote-Nodes werden kuratierte Cloud-Images angeboten; ISO-Boot, Import und
-  Passthrough sind dort nicht verfügbar.
-
-Alle Mutationen laufen als persistente, node- und generation-gebundene Jobs und
-sind im Cockpit unter **Compute-Jobs** mit Event-Timeline nachvollziehbar.
-
----
-
-## 7. Troubleshooting
-
-| Symptom | Ursache / Prüfung |
+| Symptom | Ursache / Lösung |
 |---|---|
-| `incus-admin group is missing` beim Install | Incus nicht installiert/initialisiert. Erst `incus admin init`. |
-| Enrollment `enrollment request failed` | Server-URL falsch/nicht per HTTPS erreichbar, oder Token abgelaufen (TTL) / schon verbraucht. Neuen Token erzeugen. |
-| Enrollment `fingerprint mismatch` / `certificate does not match` | Manipulierte oder falsche Antwort. Enrollment abbrechen, `--ca-file` prüfen. |
-| Node bleibt **Wartet** | Fingerprint im Cockpit noch nicht freigegeben (Schritt 3). |
-| WS schließt mit `4403 agent_identity_invalid` | Reverse-Proxy reicht Client-Cert/Proxy-Secret nicht korrekt weiter, `HH_COMPUTE_PROXY_SECRET` stimmt nicht, oder Node wurde widerrufen. |
-| Node wird **degraded** | Health-Warnung im Heartbeat (z. B. Incus-Socket nicht erreichbar). `journalctl -u hydrahive-node` prüfen. |
-| VMs nicht wählbar | `/dev/kvm` fehlt oder ohne Rechte → Node meldet keine `kvm`-Capability. |
-
-Logs des Agents:
-```bash
-sudo journalctl -u hydrahive-node -f
-```
+| `incus admin init` verlangt | Incus zuerst einrichten, Bridge `br0` erstellen lassen. |
+| Kopplung „fehlgeschlagen" | Server-Adresse falsch/nicht erreichbar, oder Token abgelaufen/verbraucht → im Cockpit neuen Token erzeugen. |
+| Node bleibt **„Wartet"** | Im Cockpit noch nicht **„Freigeben"** geklickt (Fingerprint bestätigen). |
+| Verbindung bricht mit `4403` ab | Server-Einrichtung unvollständig: Proxy-Secret oder Reverse-Proxy fehlt/falsch, oder Node wurde widerrufen. |
+| Node **„degraded"** | Health-Warnung (z. B. Incus-Socket nicht erreichbar). `journalctl -u hydrahive-node`. |
+| VMs nicht auswählbar | `/dev/kvm` fehlt → Node kann nur Container. |
 
 ---
 
-## 8. Widerruf & Deinstallation
-
-**Master zuerst:** Admin → Compute-Nodes → Node → **„Widerrufen"** (Bestätigung).
-Das macht die Node-Identität dauerhaft ungültig und invalidiert alle offenen
-Console-Tickets. Danach auf dem **Node**:
-
-```bash
-sudo systemctl disable --now hydrahive-node
-sudo rm -rf /var/lib/hydrahive-node
-sudo rm -f  /etc/systemd/system/hydrahive-node.service
-sudo systemctl daemon-reload
-sudo userdel hydrahive-node        # optional
-```
-
-Von HydraHive erstellte Incus-Instanzen tragen den Marker `user.hydrahive.id` und
-können regulär über Incus entfernt werden:
-```bash
-incus list -c n,user.hydrahive.id
-incus delete <name> --force
-```
-
----
-
-## 9. Entwicklung / Tests
+## Entwicklung / Tests
 
 ```bash
 cd node-agent

--- a/node-agent/scripts/setup.sh
+++ b/node-agent/scripts/setup.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# HydraHive Compute-Node — geführte Einrichtung.
+#
+# Dieses Skript führt dich Schritt für Schritt durch die komplette Einrichtung
+# eines neuen Compute-Nodes. Du musst nur ein paar Fragen beantworten und am Ende
+# im HydraHive-Cockpit auf "Freigeben" klicken.
+#
+# Aufruf (als root):   sudo sh scripts/setup.sh
+set -eu
+
+# --- kleine Helfer für lesbare Ausgabe --------------------------------------
+if [ -t 1 ]; then
+    B="$(printf '\033[1m')"; G="$(printf '\033[32m')"; Y="$(printf '\033[33m')"
+    R="$(printf '\033[31m')"; C="$(printf '\033[36m')"; N="$(printf '\033[0m')"
+else
+    B=""; G=""; Y=""; R=""; C=""; N=""
+fi
+say()  { printf '%s\n' "$*"; }
+step() { printf '\n%s==> %s%s\n' "$B" "$*" "$N"; }
+ok()   { printf '%s  ✓ %s%s\n' "$G" "$*" "$N"; }
+warn() { printf '%s  ! %s%s\n' "$Y" "$*" "$N"; }
+die()  { printf '%s  ✗ %s%s\n' "$R" "$*" "$N" >&2; exit 1; }
+ask()  { # ask "Frage" VARNAME
+    printf '%s%s%s ' "$C" "$1" "$N"
+    IFS= read -r _ans || die "Abbruch."
+    eval "$2=\$_ans"
+}
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+say ""
+say "${B}HydraHive Compute-Node — Einrichtung${N}"
+say "Dauer: ca. 5 Minuten. Du brauchst: die Adresse deines HydraHive-Servers und"
+say "einen Kopplungs-Code (Token) aus dem Cockpit. Beides holst du im nächsten Schritt."
+say ""
+
+# --- 0. als root? -----------------------------------------------------------
+[ "$(id -u)" -eq 0 ] || die "Bitte mit sudo starten:  sudo sh scripts/setup.sh"
+
+# --- 1. Voraussetzungen prüfen ---------------------------------------------
+step "Schritt 1/5: Voraussetzungen prüfen"
+
+command -v python3 >/dev/null 2>&1 || die "Python 3 fehlt. Installiere es mit:  apt install python3 python3-pip"
+ok "Python 3 vorhanden"
+
+if command -v incus >/dev/null 2>&1; then
+    ok "Incus ist installiert"
+else
+    die "Incus fehlt. Installiere und richte es zuerst ein:
+       apt install incus
+       incus admin init      (Fragen mit Enter bestätigen, Bridge br0 erstellen lassen)
+     Danach dieses Skript erneut starten."
+fi
+
+if getent group incus-admin >/dev/null 2>&1; then
+    ok "Incus ist einsatzbereit (Gruppe incus-admin vorhanden)"
+else
+    die "Incus ist noch nicht fertig eingerichtet. Führe aus:  incus admin init"
+fi
+
+if [ -e /dev/kvm ]; then
+    ok "KVM vorhanden — dieser Node kann auch virtuelle Maschinen betreiben"
+else
+    warn "Kein /dev/kvm — dieser Node kann nur Container betreiben, keine VMs. (Das ist ok.)"
+fi
+
+# --- 2. Agent installieren --------------------------------------------------
+step "Schritt 2/5: Node-Agent installieren"
+sh "$SCRIPT_DIR/scripts/install.sh" >/dev/null 2>&1 || sh "$SCRIPT_DIR/scripts/install.sh"
+command -v hydrahive-node >/dev/null 2>&1 || die "Installation fehlgeschlagen — 'hydrahive-node' nicht gefunden."
+ok "Agent installiert"
+
+# --- 3. Angaben abfragen ----------------------------------------------------
+step "Schritt 3/5: Deine Angaben"
+say "Öffne jetzt im Browser dein HydraHive-Cockpit und gehe zu:"
+say "   ${B}Admin  →  Compute-Nodes  →  \"Node koppeln\"${N}"
+say "Vergib dort einen Namen, klicke auf Token erzeugen und kopiere den Code."
+say ""
+
+DEFAULT_NAME="$(hostname 2>/dev/null || echo compute-01)"
+ask "Adresse deines HydraHive-Servers (z.B. https://hydrahive.example.com):" SERVER
+[ -n "${SERVER:-}" ] || die "Keine Server-Adresse eingegeben."
+case "$SERVER" in
+    https://*) : ;;
+    http://*)  die "Bitte eine https://-Adresse verwenden (verschlüsselt), nicht http://." ;;
+    *)         SERVER="https://$SERVER"; warn "https:// ergänzt → $SERVER" ;;
+esac
+
+ask "Name für diesen Node [${DEFAULT_NAME}] (muss exakt dem Namen im Cockpit entsprechen):" NODE_NAME
+[ -n "${NODE_NAME:-}" ] || NODE_NAME="$DEFAULT_NAME"
+
+say ""
+say "Füge jetzt den ${B}Kopplungs-Code (Token)${N} aus dem Cockpit ein."
+ask "Token:" TOKEN
+[ -n "${TOKEN:-}" ] || die "Kein Token eingegeben."
+
+# --- 4. Kopplung durchführen ------------------------------------------------
+step "Schritt 4/5: Node koppeln"
+TOKEN_FILE="$(mktemp)"
+chmod 600 "$TOKEN_FILE"
+printf '%s' "$TOKEN" > "$TOKEN_FILE"
+chown hydrahive-node "$TOKEN_FILE" 2>/dev/null || true
+
+set +e
+OUT="$(sudo -u hydrahive-node hydrahive-node enroll \
+        --server "$SERVER" --name "$NODE_NAME" --token-file "$TOKEN_FILE" 2>&1)"
+RC=$?
+set -e
+rm -f "$TOKEN_FILE"
+
+if [ "$RC" -ne 0 ]; then
+    say "$OUT"
+    die "Kopplung fehlgeschlagen. Häufige Ursachen:
+       • Server-Adresse falsch oder nicht erreichbar
+       • Token abgelaufen oder schon benutzt → im Cockpit einen neuen erzeugen
+       • Name stimmt nicht mit dem Cockpit überein"
+fi
+
+FINGERPRINT="$(printf '%s\n' "$OUT" | sed -n 's/^Certificate fingerprint: //p')"
+ok "Node erfolgreich angemeldet"
+
+# --- 5. Freigabe + Start ----------------------------------------------------
+step "Schritt 5/5: Im Cockpit freigeben und starten"
+say ""
+say "${B}Wichtig — jetzt im Cockpit bestätigen:${N}"
+say "Der Node steht dort auf ${Y}\"Wartet\"${N}. Klicke auf ${B}\"Freigeben\"${N} und"
+say "vergleiche diesen Sicherheits-Code Zeichen für Zeichen:"
+say ""
+say "   ${G}${B}${FINGERPRINT:-<siehe Ausgabe oben>}${N}"
+say ""
+ask "Hast du im Cockpit freigegeben? Dann Enter drücken zum Starten…" _
+
+systemctl enable --now hydrahive-node.service
+sleep 2
+if systemctl is-active --quiet hydrahive-node.service; then
+    ok "Node-Agent läuft"
+else
+    warn "Agent läuft noch nicht sauber. Log ansehen mit:  journalctl -u hydrahive-node -e"
+fi
+
+say ""
+say "${G}${B}Fertig!${N} Dein Node erscheint im Cockpit gleich als ${G}\"Online\"${N}."
+say "Ab jetzt kannst du beim Anlegen von Containern und VMs diesen Node auswählen."
+say ""
+say "Status jederzeit prüfen:  ${C}systemctl status hydrahive-node${N}"
+say "Live-Log ansehen:         ${C}journalctl -u hydrahive-node -f${N}"
+say ""


### PR DESCRIPTION
Macht das Dazuhängen eines Compute-Nodes anfängertauglich.

**scripts/setup.sh** — ein geführtes Skript (Deutsch), das durch die komplette Einrichtung führt: prüft Voraussetzungen (Incus/KVM), installiert den Agent, fragt nach Server-Adresse + Name + Kopplungs-Token, koppelt, zeigt den Fingerprint zur Freigabe im Cockpit und startet den Dienst. Klartext-Fehlermeldungen bei jedem Problem.

**README** neu strukturiert: Der Normalfall (Node dazuhängen) steht als Quickstart mit *einem* clone + *einem* Befehl ganz oben. Die einmalige, technische Server-Einrichtung (Proxy-Secret + Reverse-Proxy/mTLS) ist ans Ende verschoben und klar als *nur für Server-Admins* markiert.

Doku-/Skript-only, kein Produktionscode geändert.