### PR TITLE
feat(node-agent): Incus + br0 automatisch im Setup-Wizard einrichten

### DIFF
--- a/node-agent/README.md
+++ b/node-agent/README.md
@@ -26,7 +26,9 @@ sudo sh scripts/setup.sh
 
 Das Skript nimmt dich an die Hand und fragt der Reihe nach:
 
-1. **Prüft**, ob Incus (und optional KVM für VMs) vorhanden ist.
+1. **Richtet Incus ein** — installiert und initialisiert es automatisch (nach
+   Rückfrage), falls noch nicht vorhanden, und legt die Netzwerk-Bridge `br0` an.
+   Du musst vorher nichts vorbereiten.
 2. **Installiert** den Node-Agent.
 3. **Fragt** nach der Server-Adresse, einem Namen für den Node und dem
    **Kopplungs-Code**. Den Code holst du im Browser aus dem Cockpit:
@@ -56,12 +58,16 @@ einmalige Server-Einrichtung für Admins.
 
 ## Voraussetzungen am Node
 
-- **Ubuntu** (LTS empfohlen) mit sudo-Zugriff.
-- **Incus** installiert und initialisiert (`incus admin init`), Bridge **`br0`**.
-  Das Setup-Skript prüft das und sagt dir, falls etwas fehlt.
+- **Ubuntu** (LTS empfohlen) mit sudo-Zugriff und Internetverbindung.
+- Python ≥ 3.12 (auf aktuellem Ubuntu vorinstalliert).
 - Für **virtuelle Maschinen** zusätzlich **KVM** (`/dev/kvm`). Fehlt es, läuft der
   Node trotzdem — dann eben nur mit Containern.
-- Python ≥ 3.12 (auf aktuellem Ubuntu vorinstalliert).
+
+**Incus musst du nicht vorbereiten.** Das Setup-Skript installiert und
+initialisiert Incus bei Bedarf automatisch (nach Rückfrage) und legt die benötigte
+Netzwerk-Bridge **`br0`** an. Diese Bridge nutzt NAT und **verändert deine
+SSH-Verbindung nicht**. Wer Container/VMs mit echten IP-Adressen aus dem Heimnetz
+will, richtet stattdessen manuell LAN-Bridging ein (siehe unten).
 
 ---
 
@@ -81,17 +87,41 @@ rsync -a node-agent/ root@<node-host>:/opt/hydrahive-node-agent/
 
 ## Was macht das Setup-Skript technisch?
 
-`scripts/setup.sh` ruft intern `scripts/install.sh` auf. Das:
-- legt den gesperrten System-Benutzer `hydrahive-node` an und hängt ihn in die
-  Gruppe `incus-admin`,
-- erstellt `/var/lib/hydrahive-node/` (`0700`) für Identität und Zustand,
-- installiert das Paket (CLI `hydrahive-node`),
-- installiert die gehärtete systemd-Unit und aktiviert sie.
+`scripts/setup.sh` prüft und richtet der Reihe nach ein:
+- **Incus:** installiert es bei Bedarf (`apt-get install incus`) und initialisiert
+  es (`incus admin init --auto`, Standard-Storage, keine LAN-Änderung),
+- **Bridge `br0`:** legt sie bei Bedarf als von Incus verwaltete NAT-Bridge an
+  (`incus network create br0`),
+- ruft dann `scripts/install.sh` auf. Das legt den gesperrten System-Benutzer
+  `hydrahive-node` an, hängt ihn in die Gruppe `incus-admin`, erstellt
+  `/var/lib/hydrahive-node/` (`0700`), installiert das Paket (CLI
+  `hydrahive-node`) und die gehärtete systemd-Unit.
+
+Jeder Änderungsschritt fragt vorher nach — nichts wird ungefragt installiert.
 
 Die Kopplung selbst läuft über `hydrahive-node enroll`. Der Agent erzeugt lokal
 ein Schlüsselpaar, sendet einen Zertifikatsantrag (CSR) und zeigt einen
 Fingerprint, den du im Cockpit bestätigst. Erst nach der Freigabe nimmt der Node
 Arbeit an.
+
+---
+
+## Optional: echtes LAN-Bridging (fortgeschritten)
+
+Die vom Skript angelegte `br0` nutzt **NAT**: Container/VMs haben ein eigenes
+Subnetz und kommen nach außen, sind aber nicht direkt aus deinem Heimnetz
+erreichbar. Für die meisten Dienste reicht das.
+
+Wenn Container/VMs **echte IP-Adressen aus deinem LAN** (per DHCP vom Router)
+bekommen sollen, brauchst du eine echte Bridge über dein physisches Netzwerk-
+Interface. **Achtung:** Das kann über SSH die Verbindung kurz unterbrechen —
+mach es nur mit lokalem Zugang oder einer zweiten Zugangsmöglichkeit.
+
+Kurz gefasst: Statt der NAT-`br0` legst du mit netplan eine System-Bridge `br0`
+an, die dein Interface (z. B. `enp3s0`) einschließt, und lässt Incus diese Bridge
+nur nutzen (`incus network` wird dann nicht gebraucht — der Agent hängt Container
+per `parent=br0` an die System-Bridge). Details richten sich nach deiner
+netplan-Konfiguration; das ist ein bewusster, manueller Admin-Schritt.
 
 ---
 

--- a/node-agent/scripts/setup.sh
+++ b/node-agent/scripts/setup.sh
@@ -37,27 +37,75 @@ say ""
 # --- 0. als root? -----------------------------------------------------------
 [ "$(id -u)" -eq 0 ] || die "Bitte mit sudo starten:  sudo sh scripts/setup.sh"
 
-# --- 1. Voraussetzungen prüfen ---------------------------------------------
+confirm() { # confirm "Frage" -> 0 wenn ja
+    printf '%s%s [J/n]%s ' "$C" "$1" "$N"
+    IFS= read -r _yn || return 1
+    case "${_yn:-j}" in j*|J*|y*|Y*|"") return 0 ;; *) return 1 ;; esac
+}
+
+# --- 1. Voraussetzungen prüfen und ggf. einrichten -------------------------
 step "Schritt 1/5: Voraussetzungen prüfen"
 
 command -v python3 >/dev/null 2>&1 || die "Python 3 fehlt. Installiere es mit:  apt install python3 python3-pip"
 ok "Python 3 vorhanden"
 
+# Incus installieren, falls es fehlt
 if command -v incus >/dev/null 2>&1; then
     ok "Incus ist installiert"
 else
-    die "Incus fehlt. Installiere und richte es zuerst ein:
-       apt install incus
-       incus admin init      (Fragen mit Enter bestätigen, Bridge br0 erstellen lassen)
-     Danach dieses Skript erneut starten."
+    warn "Incus ist nicht installiert."
+    if command -v apt-get >/dev/null 2>&1; then
+        if confirm "Soll ich Incus jetzt automatisch installieren?"; then
+            say "  Installiere Incus (das kann ein bis zwei Minuten dauern)…"
+            apt-get update -qq || die "apt-get update fehlgeschlagen. Internetverbindung prüfen."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus \
+                || die "Incus-Installation fehlgeschlagen. Prüfe: apt-get install incus"
+            command -v incus >/dev/null 2>&1 || die "Incus ist nach der Installation nicht auffindbar."
+            ok "Incus installiert"
+        else
+            die "Ohne Incus geht es nicht. Installiere es mit:  apt install incus"
+        fi
+    else
+        die "Kein apt-get gefunden. Bitte Incus manuell installieren, dann erneut starten."
+    fi
 fi
 
-if getent group incus-admin >/dev/null 2>&1; then
-    ok "Incus ist einsatzbereit (Gruppe incus-admin vorhanden)"
+# Incus initialisieren, falls noch nie geschehen (Gruppe incus-admin fehlt sonst)
+if ! getent group incus-admin >/dev/null 2>&1; then
+    warn "Incus wurde noch nie initialisiert."
+    if confirm "Soll ich Incus jetzt mit Standardeinstellungen initialisieren?"; then
+        say "  Initialisiere Incus (Standard-Storage, keine LAN-Änderung)…"
+        incus admin init --auto \
+            || die "incus admin init fehlgeschlagen. Manuell versuchen:  incus admin init"
+        getent group incus-admin >/dev/null 2>&1 \
+            || die "Gruppe incus-admin fehlt weiterhin. Bitte 'incus admin init' manuell ausführen."
+        ok "Incus initialisiert"
+    else
+        die "Incus muss initialisiert werden. Führe aus:  incus admin init"
+    fi
 else
-    die "Incus ist noch nicht fertig eingerichtet. Führe aus:  incus admin init"
+    ok "Incus ist einsatzbereit"
 fi
 
+# Bridge br0 sicherstellen (der Agent hängt Container/VMs an 'br0')
+if incus network show br0 >/dev/null 2>&1; then
+    ok "Netzwerk-Bridge 'br0' vorhanden"
+else
+    warn "Die vom Agent benötigte Bridge 'br0' fehlt."
+    say "  Ich lege eine von Incus verwaltete Bridge 'br0' mit eigenem Subnetz an."
+    say "  ${Y}Das verändert deine SSH-Verbindung NICHT${N} — die Bridge nutzt NAT."
+    say "  (Für echtes LAN-Bridging, damit Container IPs aus deinem Heimnetz bekommen,"
+    say "   siehe README — das ist ein bewusster manueller Schritt.)"
+    if confirm "Soll ich die Bridge 'br0' (NAT) jetzt anlegen?"; then
+        incus network create br0 \
+            || die "Konnte Bridge 'br0' nicht anlegen. Prüfe:  incus network create br0"
+        ok "Bridge 'br0' angelegt (NAT-Modus)"
+    else
+        die "Ohne Bridge 'br0' können keine Workloads starten. Lege sie an mit:  incus network create br0"
+    fi
+fi
+
+# KVM (optional, nur für VMs)
 if [ -e /dev/kvm ]; then
     ok "KVM vorhanden — dieser Node kann auch virtuelle Maschinen betreiben"
 else


### PR DESCRIPTION
Macht das Node-Setup wirklich voraussetzungsfrei. Das geführte `scripts/setup.sh` installiert und initialisiert jetzt Incus selbst (per apt, nach Rückfrage), führt `incus admin init --auto` aus und legt die benötigte Bridge `br0` als verwaltete NAT-Bridge an.

Sicher by design: die NAT-Bridge fasst das physische Netzwerk-Interface **nicht** an, kappt also keine SSH-Verbindung. Jeder verändernde Schritt fragt vorher nach. Für echtes LAN-Bridging (Container-IPs aus dem Heimnetz) gibt es einen neuen README-Abschnitt als bewussten manuellen Admin-Schritt.

Nur Skript/Doku, kein Produktionscode.