### PR TITLE
feat(chat): sichtbare Upload-Limits und sicheres Chunk-Streaming

### DIFF
--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from hydrahive.api.lifespan import lifespan
+from hydrahive.api.middleware.upload_limit import ChatUploadLimitMiddleware
 from hydrahive.api.routes.agentlink import router as agentlink_router
 from hydrahive.api.routes.agents import router as agents_router
 from hydrahive.api.routes.agent_activity import router as agent_activity_router
@@ -110,6 +111,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(ChatUploadLimitMiddleware)
 
 app.include_router(agentlink_router)
 app.include_router(auth_router)

--- a/core/src/hydrahive/api/middleware/upload_limit.py
+++ b/core/src/hydrahive/api/middleware/upload_limit.py
@@ -1,0 +1,91 @@
+"""ASGI request-body limit for chat attachment endpoints."""
+from __future__ import annotations
+
+import re
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+MIB = 1024 * 1024
+MAX_CHAT_REQUEST_BYTES = 205 * MIB
+_CHAT_MESSAGE_PATH = re.compile(
+    r"^/api/sessions/[^/]+/messages(?:/[^/]+/resend)?/?$"
+)
+
+
+class _RequestBodyTooLarge(Exception):
+    pass
+
+
+class ChatUploadLimitMiddleware:
+    """Reject oversized chat message bodies before multipart parsing."""
+
+    def __init__(self, app: ASGIApp, max_bytes: int = MAX_CHAT_REQUEST_BYTES) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self._applies(scope):
+            await self.app(scope, receive, send)
+            return
+
+        content_length = self._content_length(scope)
+        if content_length is not None and content_length > self.max_bytes:
+            await self._reject(scope, receive, send)
+            return
+
+        received = 0
+        response_started = False
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    raise _RequestBodyTooLarge
+            return message
+
+        async def tracked_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, limited_receive, tracked_send)
+        except _RequestBodyTooLarge:
+            if response_started:
+                raise
+            await self._reject(scope, receive, send)
+
+    @staticmethod
+    def _applies(scope: Scope) -> bool:
+        return (
+            scope["type"] == "http"
+            and scope.get("method") == "POST"
+            and bool(_CHAT_MESSAGE_PATH.fullmatch(scope.get("path", "")))
+        )
+
+    @staticmethod
+    def _content_length(scope: Scope) -> int | None:
+        for name, value in scope.get("headers", []):
+            if name.lower() != b"content-length":
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    async def _reject(self, scope: Scope, receive: Receive, send: Send) -> None:
+        response = JSONResponse(
+            status_code=413,
+            content={
+                "detail": {
+                    "code": "upload_request_too_large",
+                    "params": {"max_mib": self.max_bytes // MIB},
+                }
+            },
+        )
+        await response(scope, receive, send)

--- a/core/src/hydrahive/api/routes/_files.py
+++ b/core/src/hydrahive/api/routes/_files.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import base64
 import mimetypes
+import os
 from pathlib import Path
+from uuid import uuid4
 
+import anyio
 from fastapi import UploadFile
 
 from hydrahive.tools._path import PathOutsideWorkspace, safe_path
@@ -15,61 +18,153 @@ TEXT_EXTENSIONS = {
     ".csv", ".sh", ".html", ".css", ".xml", ".toml", ".ini", ".cfg",
     ".rs", ".go", ".java", ".c", ".cpp", ".h", ".rb", ".php", ".sql",
 }
-MAX_IMAGE_BYTES = 5 * 1024 * 1024   # 5 MB
-MAX_TEXT_BYTES = 100 * 1024          # 100 KB
+MAX_FILES = 5
+MAX_IMAGE_BYTES = 5 * 1024 * 1024       # 5 MiB inline zum LLM
+MAX_TEXT_BYTES = 100 * 1024             # 100 KiB inline zum LLM
+MAX_FILE_BYTES = 100 * 1024 * 1024      # 100 MiB pro Anhang
+MAX_MESSAGE_UPLOAD_BYTES = 200 * 1024 * 1024
+STREAM_CHUNK_BYTES = 1024 * 1024         # 1 MiB, kein Voll-Read für Binaries
+
+
+class UploadTooLarge(ValueError):
+    def __init__(
+        self,
+        scope: str,
+        max_bytes: int,
+        actual_bytes: int,
+        filename: str | None = None,
+    ) -> None:
+        self.scope = scope
+        self.max_bytes = max_bytes
+        self.actual_bytes = actual_bytes
+        self.filename = filename
+        super().__init__(f"upload {scope} exceeds {max_bytes} bytes")
+
+
+class UploadSizeUnknown(ValueError):
+    pass
+
+
+class UploadTooManyFiles(ValueError):
+    pass
+
+
+def validate_upload_sizes(files: list[UploadFile]) -> None:
+    """Verteidigung gegen umgangene Client-Limits vor jedem Disk-Write."""
+    if len(files) > MAX_FILES:
+        raise UploadTooManyFiles
+    total = 0
+    for file in files:
+        if file.size is None:
+            raise UploadSizeUnknown(file.filename or "upload")
+        if file.size > MAX_FILE_BYTES:
+            raise UploadTooLarge(
+                "file", MAX_FILE_BYTES, file.size, file.filename or "upload",
+            )
+        total += file.size
+    if total > MAX_MESSAGE_UPLOAD_BYTES:
+        raise UploadTooLarge("message", MAX_MESSAGE_UPLOAD_BYTES, total)
 
 
 async def process_upload(file: UploadFile, workspace: Path | None) -> list[dict]:
-    """Convert an uploaded file to one or more Anthropic content blocks."""
-    data = await file.read()
+    """Konvertiert kleine Inhalte; streamt größere/binäre Dateien in den Workspace."""
     name = file.filename or "upload"
     mime = file.content_type or ""
     if not mime or mime == "application/octet-stream":
         mime = mimetypes.guess_type(name)[0] or "application/octet-stream"
     ext = Path(name).suffix.lower()
 
-    if mime in IMAGE_TYPES and len(data) <= MAX_IMAGE_BYTES:
-        blocks: list[dict] = [{
-            "type": "image",
-            "source": {
-                "type": "base64",
-                "media_type": mime,
-                "data": base64.standard_b64encode(data).decode(),
-            },
-        }]
-        # Bild auch auf Disk speichern damit shell_exec + mmx drankann
-        if workspace is not None:
-            dest = _safe_dest(workspace, name)
-            if dest is None:
-                blocks.append({"type": "text", "text": "[Bild-Name abgelehnt: ungültiger Pfad]"})
-            else:
-                dest.write_bytes(data)
-                blocks.append({"type": "text", "text": f"[Bild gespeichert: {dest}]"})
-        return blocks
+    if file.size is not None and file.size > MAX_FILE_BYTES:
+        raise UploadTooLarge("file", MAX_FILE_BYTES, file.size, name)
 
-    if ext in TEXT_EXTENSIONS and len(data) <= MAX_TEXT_BYTES:
-        try:
-            return [{"type": "text", "text": f"[{name}]\n{data.decode('utf-8')}"}]
-        except UnicodeDecodeError:
-            pass
+    if mime in IMAGE_TYPES:
+        data = await _read_limited(file, MAX_IMAGE_BYTES)
+        if data is not None:
+            blocks: list[dict] = [{
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": mime,
+                    "data": base64.standard_b64encode(data).decode(),
+                },
+            }]
+            if workspace is not None:
+                dest = _safe_dest(workspace, name)
+                if dest is None:
+                    blocks.append({"type": "text", "text": "[Bild-Name abgelehnt: ungültiger Pfad]"})
+                else:
+                    await _write_small_atomic(dest, data)
+                    blocks.append({"type": "text", "text": f"[Bild gespeichert: {dest}]"})
+            return blocks
 
-    # Binary or oversized: save to workspace
+    if ext in TEXT_EXTENSIONS:
+        data = await _read_limited(file, MAX_TEXT_BYTES)
+        if data is not None:
+            try:
+                return [{"type": "text", "text": f"[{name}]\n{data.decode('utf-8')}"}]
+            except UnicodeDecodeError:
+                pass
+
     if workspace is not None:
         dest = _safe_dest(workspace, name)
         if dest is None:
             return [{"type": "text", "text": "[Anhang abgelehnt: ungültiger Dateiname]"}]
-        dest.write_bytes(data)
+        await _stream_atomic(file, dest)
         return [{"type": "text", "text": f"[Datei hochgeladen: {dest}]"}]
 
     return [{"type": "text", "text": f"[Anhang: {name} — kein Workspace verfügbar]"}]
 
 
+async def _read_limited(file: UploadFile, limit: int) -> bytes | None:
+    """Liest höchstens limit+1 Bytes und setzt den Stream danach zurück."""
+    await file.seek(0)
+    data = await file.read(limit + 1)
+    await file.seek(0)
+    return data if len(data) <= limit else None
+
+
+async def _stream_atomic(file: UploadFile, dest: Path) -> None:
+    """Schreibt einen Upload begrenzt und atomar, ohne den Event-Loop zu blockieren."""
+    temp = dest.with_name(f".{dest.name}.upload-{uuid4().hex}")
+    written = 0
+    try:
+        await file.seek(0)
+        async with await anyio.open_file(temp, "xb") as target:
+            while chunk := await file.read(STREAM_CHUNK_BYTES):
+                written += len(chunk)
+                if written > MAX_FILE_BYTES:
+                    raise UploadTooLarge("file", MAX_FILE_BYTES, written, dest.name)
+                await target.write(chunk)
+        await anyio.to_thread.run_sync(os.replace, temp, dest)
+    finally:
+        await anyio.to_thread.run_sync(temp.unlink, True)
+
+
+async def _write_small_atomic(dest: Path, data: bytes) -> None:
+    temp = dest.with_name(f".{dest.name}.upload-{uuid4().hex}")
+    try:
+        async with await anyio.open_file(temp, "xb") as target:
+            await target.write(data)
+        await anyio.to_thread.run_sync(os.replace, temp, dest)
+    finally:
+        await anyio.to_thread.run_sync(temp.unlink, True)
+
+
 def _safe_dest(workspace: Path, name: str) -> Path | None:
-    """Validiert User-Filename gegen Path-Traversal. Wirft None bei Verstoß."""
+    """Akzeptiert nur Basis-Dateinamen und erzeugt kollisionsfreie Ziele."""
+    if not name or name in {".", ".."} or "/" in name or "\\" in name or "\x00" in name:
+        return None
     workspace.mkdir(parents=True, exist_ok=True)
     try:
         dest = safe_path(workspace, name)
-    except PathOutsideWorkspace:
+    except (OSError, PathOutsideWorkspace):
         return None
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    return dest
+    if dest == workspace.resolve():
+        return None
+    if not dest.exists():
+        return dest
+    for number in range(2, 10_000):
+        candidate = dest.with_name(f"{dest.stem}-{number}{dest.suffix}")
+        if not candidate.exists():
+            return candidate
+    return None

--- a/core/src/hydrahive/api/routes/_session_msg_helpers.py
+++ b/core/src/hydrahive/api/routes/_session_msg_helpers.py
@@ -1,33 +1,84 @@
 from __future__ import annotations
 
+import shutil
 import time
+from uuid import uuid4
 
 from fastapi import UploadFile, status
 from fastapi.responses import StreamingResponse
 
 from hydrahive.agents import config as agent_config
-from hydrahive.agents._paths import ensure_workspace
 from hydrahive.api._session_broadcast import broadcaster
 from hydrahive.api.middleware.errors import coded
-from hydrahive.api.routes._files import process_upload
+from hydrahive.api.routes._files import (
+    MAX_FILE_BYTES,
+    MAX_FILES,
+    MAX_MESSAGE_UPLOAD_BYTES,
+    UploadSizeUnknown,
+    UploadTooLarge,
+    UploadTooManyFiles,
+    process_upload,
+    validate_upload_sizes,
+)
 from hydrahive.api.routes._sse import to_sse
 from hydrahive.runner import run as runner_run
+from hydrahive.runner._run_workspace import resolve_run_context
 from hydrahive.runner.concurrency import SessionAlreadyRunning, is_running, session_run_guard
 
 # Live-Sync v1: max ein Aktivitäts-Ping pro Intervall während eines Laufs.
 _PING_INTERVAL_S = 0.5
 
 
-async def build_user_content(agent_id: str, text: str, files: list[UploadFile]) -> str | list:
+async def build_user_content(session, text: str, files: list[UploadFile]) -> str | list:
     if not files:
         return text
-    agent = agent_config.get(agent_id)
-    workspace = ensure_workspace(agent) if agent else None
-    blocks: list[dict] = []
-    for f in files:
-        blocks.extend(await process_upload(f, workspace))
+    agent = agent_config.get(session.agent_id)
+    workspace = resolve_run_context(session, agent)[0] if agent else None
+    upload_dir = (
+        workspace / ".hydrahive" / "uploads" / uuid4().hex
+        if workspace is not None else None
+    )
+    try:
+        validate_upload_sizes(files)
+        blocks: list[dict] = []
+        for file in files:
+            blocks.extend(await process_upload(file, upload_dir))
+    except (UploadSizeUnknown, UploadTooLarge, UploadTooManyFiles) as exc:
+        _cleanup_upload_batch(upload_dir)
+        raise _upload_http_error(exc)
+    except Exception:
+        _cleanup_upload_batch(upload_dir)
+        raise
     blocks.append({"type": "text", "text": text})
     return blocks
+
+
+def _cleanup_upload_batch(upload_dir) -> None:
+    if upload_dir is not None:
+        shutil.rmtree(upload_dir, ignore_errors=True)
+
+
+def _upload_http_error(exc):
+    if isinstance(exc, UploadTooLarge):
+        if exc.scope == "message":
+            return coded(
+                status.HTTP_413_CONTENT_TOO_LARGE,
+                "upload_total_too_large",
+                max_mib=MAX_MESSAGE_UPLOAD_BYTES // (1024 * 1024),
+            )
+        return coded(
+            status.HTTP_413_CONTENT_TOO_LARGE,
+            "upload_file_too_large",
+            filename=exc.filename or "upload",
+            max_mib=MAX_FILE_BYTES // (1024 * 1024),
+        )
+    if isinstance(exc, UploadTooManyFiles):
+        return coded(
+            status.HTTP_413_CONTENT_TOO_LARGE,
+            "upload_too_many_files",
+            max_files=MAX_FILES,
+        )
+    return coded(status.HTTP_400_BAD_REQUEST, "upload_size_unknown")
 
 
 def sse_run_response(events) -> StreamingResponse:

--- a/core/src/hydrahive/api/routes/sessions_messages.py
+++ b/core/src/hydrahive/api/routes/sessions_messages.py
@@ -188,8 +188,8 @@ async def resend_message(
     if target.role != "user":
         raise coded(status.HTTP_400_BAD_REQUEST, "message_not_editable")
 
+    user_content = await build_user_content(s, text, files or [])
     messages_db.delete_from(session_id, message_id)
-    user_content = await build_user_content(s.agent_id, text, files or [])
     return await sse_run_with_guard(session_id, user_content)
 
 
@@ -205,7 +205,7 @@ async def post_message(
         raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
     check_owner(s, *auth)
 
-    user_content = await build_user_content(s.agent_id, text, files or [])
+    user_content = await build_user_content(s, text, files or [])
     return await sse_run_with_guard(session_id, user_content)
 
 
@@ -256,7 +256,7 @@ async def inject_message(
         raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
     if is_running(session_id):
         raise coded(status.HTTP_409_CONFLICT, "session_already_running")
-    user_content = await build_user_content(s.agent_id, text, [])
+    user_content = await build_user_content(s, text, [])
 
     async def _run() -> None:
         logger.info("inject %s: background task starting", session_id)

--- a/core/tests/test_chat_uploads.py
+++ b/core/tests/test_chat_uploads.py
@@ -1,0 +1,352 @@
+"""Chat-Anhänge: Limits, Streaming und session-korrekter Workspace."""
+from __future__ import annotations
+
+import asyncio
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from starlette.datastructures import Headers
+
+from hydrahive.api.routes import _files
+from hydrahive.api.routes import _session_msg_helpers as helpers
+from hydrahive.api.routes import sessions_messages
+from hydrahive.api.middleware.upload_limit import ChatUploadLimitMiddleware
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _upload(
+    data: bytes,
+    name: str = "sample.apk",
+    content_type: str = "application/octet-stream",
+    *,
+    declared_size: int | None = None,
+) -> UploadFile:
+    return UploadFile(
+        BytesIO(data),
+        size=len(data) if declared_size is None else declared_size,
+        filename=name,
+        headers=Headers({"content-type": content_type}),
+    )
+
+
+class _TrackingBytesIO(BytesIO):
+    def __init__(self, data: bytes):
+        super().__init__(data)
+        self.read_sizes: list[int] = []
+
+    def read(self, size: int = -1) -> bytes:
+        self.read_sizes.append(size)
+        return super().read(size)
+
+
+def test_binary_upload_is_streamed_to_workspace(tmp_path, monkeypatch):
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8, raising=False)
+    monkeypatch.setattr(_files, "STREAM_CHUNK_BYTES", 3, raising=False)
+    source = _TrackingBytesIO(b"12345678")
+    upload = UploadFile(
+        source,
+        size=8,
+        filename="sample.apk",
+        headers=Headers({"content-type": "application/vnd.android.package-archive"}),
+    )
+
+    blocks = _run(_files.process_upload(upload, tmp_path))
+
+    assert (tmp_path / "sample.apk").read_bytes() == b"12345678"
+    assert blocks == [{"type": "text", "text": f"[Datei hochgeladen: {tmp_path / 'sample.apk'}]"}]
+    assert -1 not in source.read_sizes
+    assert max(source.read_sizes) <= 3
+
+
+def test_binary_upload_over_limit_is_rejected_and_partial_file_removed(tmp_path, monkeypatch):
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8, raising=False)
+    monkeypatch.setattr(_files, "STREAM_CHUNK_BYTES", 3, raising=False)
+    upload = _upload(b"123456789", declared_size=8)
+
+    with pytest.raises(_files.UploadTooLarge):
+        _run(_files.process_upload(upload, tmp_path))
+
+    assert not (tmp_path / "sample.apk").exists()
+    assert not list(tmp_path.glob("*.upload-*"))
+
+
+def test_validate_upload_sizes_rejects_single_file_over_limit(monkeypatch):
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8, raising=False)
+    monkeypatch.setattr(_files, "MAX_MESSAGE_UPLOAD_BYTES", 12, raising=False)
+
+    with pytest.raises(_files.UploadTooLarge) as exc:
+        _files.validate_upload_sizes([_upload(b"123456789")])
+
+    assert exc.value.scope == "file"
+
+
+def test_validate_upload_sizes_rejects_total_over_limit(monkeypatch):
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8, raising=False)
+    monkeypatch.setattr(_files, "MAX_MESSAGE_UPLOAD_BYTES", 12, raising=False)
+
+    with pytest.raises(_files.UploadTooLarge) as exc:
+        _files.validate_upload_sizes([_upload(b"1234567", "a.apk"), _upload(b"1234567", "b.exe")])
+
+    assert exc.value.scope == "message"
+
+
+def test_validate_upload_sizes_rejects_unknown_size():
+    upload = UploadFile(BytesIO(b"abc"), size=None, filename="unknown.bin")
+
+    with pytest.raises(_files.UploadSizeUnknown):
+        _files.validate_upload_sizes([upload])
+
+
+def test_validate_upload_sizes_rejects_more_than_five_files():
+    uploads = [_upload(b"x", f"{index}.bin") for index in range(6)]
+
+    with pytest.raises(_files.UploadTooManyFiles):
+        _files.validate_upload_sizes(uploads)
+
+
+def test_small_text_upload_stays_inline():
+    upload = _upload(b"hello", "notes.txt", "text/plain")
+
+    blocks = _run(_files.process_upload(upload, None))
+
+    assert blocks == [{"type": "text", "text": "[notes.txt]\nhello"}]
+
+
+def test_small_image_upload_stays_inline_and_is_saved(tmp_path):
+    upload = _upload(b"fake-png", "image.png", "image/png")
+
+    blocks = _run(_files.process_upload(upload, tmp_path))
+
+    assert blocks[0]["type"] == "image"
+    assert blocks[0]["source"]["media_type"] == "image/png"
+    assert blocks[1] == {"type": "text", "text": f"[Bild gespeichert: {tmp_path / 'image.png'}]"}
+    assert (tmp_path / "image.png").read_bytes() == b"fake-png"
+
+
+def test_path_traversal_filename_is_rejected(tmp_path):
+    upload = _upload(b"payload", "../escape.exe")
+
+    blocks = _run(_files.process_upload(upload, tmp_path))
+
+    assert blocks == [{"type": "text", "text": "[Anhang abgelehnt: ungültiger Dateiname]"}]
+    assert not (tmp_path.parent / "escape.exe").exists()
+
+
+def test_build_user_content_uses_resolved_project_workspace(tmp_path, monkeypatch):
+    session = SimpleNamespace(agent_id="agent-1", project_id="project-1")
+    agent = {"id": "agent-1", "name": "Agent"}
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: agent)
+    monkeypatch.setattr(
+        helpers,
+        "resolve_run_context",
+        lambda actual_session, actual_agent: (tmp_path, "project-1"),
+        raising=False,
+    )
+    upload = _upload(b"apk-data", "security-check.apk")
+
+    blocks = _run(helpers.build_user_content(session, "Bitte prüfen", [upload]))
+
+    saved = list((tmp_path / ".hydrahive" / "uploads").glob("*/security-check.apk"))
+    assert len(saved) == 1
+    assert saved[0].read_bytes() == b"apk-data"
+    assert blocks[-1] == {"type": "text", "text": "Bitte prüfen"}
+
+
+def test_build_user_content_does_not_overwrite_existing_project_file(tmp_path, monkeypatch):
+    existing = tmp_path / "security-check.apk"
+    existing.write_bytes(b"project-data")
+    session = SimpleNamespace(agent_id="agent-1", project_id="project-1")
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: {"id": "agent-1"})
+    monkeypatch.setattr(helpers, "resolve_run_context", lambda _s, _a: (tmp_path, "project-1"))
+
+    _run(helpers.build_user_content(session, "check", [_upload(b"upload-data", existing.name)]))
+
+    assert existing.read_bytes() == b"project-data"
+    saved = list((tmp_path / ".hydrahive" / "uploads").glob("*/security-check.apk"))
+    assert len(saved) == 1
+    assert saved[0].read_bytes() == b"upload-data"
+
+
+def test_build_user_content_keeps_duplicate_names_separate(tmp_path, monkeypatch):
+    session = SimpleNamespace(agent_id="agent-1", project_id="project-1")
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: {"id": "agent-1"})
+    monkeypatch.setattr(helpers, "resolve_run_context", lambda _s, _a: (tmp_path, "project-1"))
+
+    _run(helpers.build_user_content(
+        session, "check", [_upload(b"first", "same.apk"), _upload(b"second", "same.apk")],
+    ))
+
+    batch_dirs = list((tmp_path / ".hydrahive" / "uploads").iterdir())
+    assert len(batch_dirs) == 1
+    assert sorted(path.read_bytes() for path in batch_dirs[0].iterdir()) == [b"first", b"second"]
+
+
+def test_build_user_content_cleans_batch_when_later_file_fails(tmp_path, monkeypatch):
+    session = SimpleNamespace(agent_id="agent-1", project_id="project-1")
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: {"id": "agent-1"})
+    monkeypatch.setattr(helpers, "resolve_run_context", lambda _s, _a: (tmp_path, "project-1"))
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8)
+    monkeypatch.setattr(_files, "MAX_MESSAGE_UPLOAD_BYTES", 12)
+    first = _upload(b"ok", "first.apk")
+    second = _upload(b"123456789", "second.apk", declared_size=8)
+
+    with pytest.raises(HTTPException):
+        _run(helpers.build_user_content(session, "check", [first, second]))
+
+    uploads = tmp_path / ".hydrahive" / "uploads"
+    assert not uploads.exists() or not list(uploads.iterdir())
+    assert not list(tmp_path.rglob("first.apk"))
+
+
+def test_build_user_content_uses_agent_workspace_without_project(tmp_path, monkeypatch):
+    session = SimpleNamespace(agent_id="agent-1", project_id=None)
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: {"id": "agent-1"})
+    monkeypatch.setattr(helpers, "resolve_run_context", lambda _s, _a: (tmp_path, None))
+
+    _run(helpers.build_user_content(session, "check", [_upload(b"data", "sample.exe")]))
+
+    saved = list((tmp_path / ".hydrahive" / "uploads").glob("*/sample.exe"))
+    assert len(saved) == 1
+
+
+def test_dot_filename_is_rejected(tmp_path):
+    blocks = _run(_files.process_upload(_upload(b"payload", "."), tmp_path))
+
+    assert blocks == [{"type": "text", "text": "[Anhang abgelehnt: ungültiger Dateiname]"}]
+
+
+def test_build_user_content_maps_file_limit_to_http_413(tmp_path, monkeypatch):
+    session = SimpleNamespace(agent_id="agent-1", project_id="project-1")
+    monkeypatch.setattr(helpers.agent_config, "get", lambda _agent_id: {"id": "agent-1"})
+    monkeypatch.setattr(
+        helpers,
+        "resolve_run_context",
+        lambda _session, _agent: (tmp_path, "project-1"),
+        raising=False,
+    )
+    monkeypatch.setattr(_files, "MAX_FILE_BYTES", 8, raising=False)
+    monkeypatch.setattr(_files, "MAX_MESSAGE_UPLOAD_BYTES", 12, raising=False)
+
+    with pytest.raises(Exception) as exc:
+        _run(helpers.build_user_content(session, "Bitte prüfen", [_upload(b"123456789")]))
+
+    assert getattr(exc.value, "status_code", None) == 413
+    assert exc.value.detail["code"] == "upload_file_too_large"
+
+
+def test_resend_validates_upload_before_deleting_history(monkeypatch):
+    session = SimpleNamespace(id="session-1", agent_id="agent-1")
+    target = SimpleNamespace(id="message-1", session_id="session-1", role="user")
+    deleted: list[tuple[str, str]] = []
+    monkeypatch.setattr(sessions_messages.sessions_db, "get", lambda _sid: session)
+    monkeypatch.setattr(sessions_messages, "check_owner", lambda *_args: None)
+    monkeypatch.setattr(sessions_messages.messages_db, "get", lambda _mid: target)
+    monkeypatch.setattr(
+        sessions_messages.messages_db,
+        "delete_from",
+        lambda sid, mid: deleted.append((sid, mid)),
+    )
+
+    async def reject_upload(*_args, **_kwargs):
+        raise HTTPException(status_code=413, detail={"code": "upload_file_too_large"})
+
+    monkeypatch.setattr(sessions_messages, "build_user_content", reject_upload)
+
+    with pytest.raises(HTTPException):
+        _run(sessions_messages.resend_message(
+            session_id="session-1",
+            message_id="message-1",
+            auth=("user", "user"),
+            text="replacement",
+            files=[_upload(b"payload")],
+        ))
+
+    assert deleted == []
+
+
+def test_nginx_limits_chat_message_bodies_before_fastapi():
+    root = __import__("pathlib").Path(__file__).resolve().parents[2]
+    linux = (root / "installer/modules/60-nginx.sh").read_text()
+    mac = (root / "installer/modules-mac/60-nginx.sh").read_text()
+    updater = (root / "installer/update.sh").read_text()
+
+    for config in (linux, mac):
+        assert "chat-upload-limit" in config
+        assert "client_max_body_size 205M" in config
+        assert "upload_request_too_large" in config
+    assert 'grep -q "chat-upload-limit"' in updater
+
+
+def test_chat_upload_middleware_rejects_large_content_length_before_app():
+    called = False
+    sent: list[dict] = []
+
+    async def app(_scope, _receive, _send):
+        nonlocal called
+        called = True
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    async def run():
+        middleware = ChatUploadLimitMiddleware(app, max_bytes=8)
+        await middleware(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/api/sessions/session-1/messages",
+                "headers": [(b"content-length", b"9")],
+            },
+            receive,
+            send,
+        )
+
+    _run(run())
+
+    assert called is False
+    assert sent[0]["status"] == 413
+    assert b"upload_request_too_large" in sent[1]["body"]
+
+
+def test_chat_upload_middleware_counts_chunked_body():
+    sent: list[dict] = []
+    chunks = iter([
+        {"type": "http.request", "body": b"12345", "more_body": True},
+        {"type": "http.request", "body": b"6789", "more_body": False},
+    ])
+
+    async def app(_scope, receive, _send):
+        while (await receive()).get("more_body"):
+            pass
+
+    async def receive():
+        return next(chunks)
+
+    async def send(message):
+        sent.append(message)
+
+    async def run():
+        middleware = ChatUploadLimitMiddleware(app, max_bytes=8)
+        await middleware(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/api/sessions/session-1/messages/message-1/resend",
+                "headers": [],
+            },
+            receive,
+            send,
+        )
+
+    _run(run())
+
+    assert sent[0]["status"] == 413
+    assert b"upload_request_too_large" in sent[1]["body"]

--- a/docs/specs/chat-upload-safety-plan.md
+++ b/docs/specs/chat-upload-safety-plan.md
@@ -1,0 +1,90 @@
+# Plan: Sicherer Chat-Dateiupload bis 100 MiB
+
+## Ziel
+
+Chat-Anhänge bis 100 MiB pro Datei und 200 MiB pro Nachricht werden sichtbar validiert, serverseitig begrenzt, speicherschonend gestreamt und im richtigen Session-Workspace abgelegt.
+
+## Dateien
+
+- `core/src/hydrahive/api/routes/_files.py` — gemeinsame Uploadgrenzen, Größenvalidierung und Chunk-Streaming
+- `core/src/hydrahive/api/routes/_session_msg_helpers.py` — Session-Workspace, Batch-Cleanup und HTTP-Fehlerabbildung
+- `core/src/hydrahive/api/middleware/upload_limit.py` — 205-MiB-Hard-Limit vor Multipart-Parsing
+- `core/src/hydrahive/api/main.py` — Request-Limit-Middleware registrieren
+- `core/src/hydrahive/api/routes/sessions_messages.py` — vollständige Session übergeben und Resend-Reihenfolge absichern
+- `core/tests/test_chat_uploads.py` — Bild/Text-Kompatibilität, Binär-Streaming, Limits, Cleanup, Path Traversal und Projekt-Workspace
+- `frontend/src/features/chat/MessageInput.tsx` — 100-/200-MiB-Validierung und sichtbarer Fehlerzustand
+- `frontend/src/features/chat/api.ts` — strukturierte Backendfehler lokalisiert anzeigen
+- `frontend/src/shared/api-client.ts` — gemeinsamen API-Error-Formatter wiederverwenden
+- `frontend/src/i18n/locales/{de,en}/chat.json` — lokale Auswahlfehler
+- `frontend/src/i18n/locales/{de,en}/errors.json` — serverseitige Uploadfehler
+- `installer/modules/60-nginx.sh` — 205-MiB-Grenze vor dem Multipart-Parser
+- `installer/modules-mac/60-nginx.sh` — dieselbe Grenze für macOS
+- `installer/update.sh` — bestehende Installationen zum Nginx-Rewrite markieren
+- `docs/specs/chat-upload-safety.md` — verbindliches Verhalten
+
+## Implementierungsreihenfolge
+
+### Task 1: Backend-Limits und Streaming
+
+- [ ] Tests in `core/tests/test_chat_uploads.py` schreiben:
+  - Binärdatei innerhalb des Limits wird vollständig gespeichert
+  - Datei über 100 MiB wird abgelehnt
+  - Nachricht über 200 MiB wird abgelehnt
+  - Teil-Datei wird nach Größenfehler entfernt
+  - Path-Traversal-Dateiname wird abgelehnt
+- [ ] Tests ausführen und RED bestätigen
+- [ ] Konstanten für 100 MiB pro Datei und 200 MiB gesamt ergänzen
+- [ ] Größenprüfung vor Verarbeitung implementieren
+- [ ] Binärdateien über temporäre Datei in 1-MiB-Chunks schreiben und atomar umbenennen
+- [ ] Pro Request einen eindeutigen `.hydrahive/uploads/`-Batch anlegen
+- [ ] Basis-Dateinamen erzwingen, Kollisionen eindeutig umbenennen und Projektdateien nie überschreiben
+- [ ] Bei jedem Fehler den vollständigen Batch entfernen
+- [ ] Chat-Message-Requests in Nginx vor dem Multipart-Parser auf 205 MiB begrenzen
+- [ ] Tests ausführen und GREEN bestätigen
+
+### Task 2: Session-Workspace korrekt auflösen
+
+- [ ] Tests ergänzen:
+  - Projekt-Session verwendet Projekt-Workspace
+  - projektlose Session verwendet Agent-Workspace
+- [ ] Tests RED ausführen
+- [ ] `build_user_content` auf Session-Kontext umstellen und bestehende Aufrufer anpassen
+- [ ] Vorhandene `resolve_run_context`-Logik wiederverwenden, damit Runner und Upload dieselbe Workspace-Entscheidung treffen
+- [ ] Tests GREEN ausführen
+
+### Task 3: Frontend-Validierung und Rückmeldung
+
+- [ ] Explizite Konstanten für 5 Dateien, 100 MiB pro Datei und 200 MiB insgesamt verwenden
+- [ ] Einzeldatei-, Gesamt- und Anzahlfehler unterscheiden
+- [ ] Fehlertext im `MessageInput` sichtbar rendern
+- [ ] deutsche und englische Übersetzungen ergänzen
+- [ ] Sicherstellen, dass APK/EXE nicht per `accept` gefiltert werden
+- [ ] TypeScript-Build und ESLint ausführen
+
+### Task 4: Gesamtverifikation
+
+- [ ] Relevante Backend-Tests ausführen
+- [ ] vollständigen Frontend-Produktionsbuild ausführen
+- [ ] `git diff --check` und HH-Review durchführen
+- [ ] Security-Review: serverseitige Limits, Path Traversal, temporäres Cleanup, keine Ausführung
+- [ ] Commit und Push
+- [ ] Produktionsupdate durchführen
+- [ ] echten Upload einer Datei knapp über der alten Grenze verifizieren
+- [ ] Code-Graph aktualisieren
+
+## Akzeptanzkriterien
+
+- [ ] 54-MB-APK kann angehängt und im aktiven Projekt gefunden werden
+- [ ] >100-MiB-Datei hat sichtbaren Frontendfehler und HTTP-413-Backendschutz
+- [ ] >200-MiB-Gesamtauswahl wird abgelehnt
+- [ ] keine vollständige Binärdatei wird in den RAM geladen
+- [ ] keine Teil-Datei nach Abbruch oder Limitfehler
+- [ ] kein Pfad verlässt den Workspace
+- [ ] Bild-/Textupload regressionsfrei
+
+## Nicht in diesem Plan
+
+- Virenscan oder Sandboxing der hochgeladenen Datei
+- automatische Ausführung
+- Upload-Fortschrittsbalken
+- Änderung der spezialisierten VM-/ISO-Uploadwege

--- a/docs/specs/chat-upload-safety.md
+++ b/docs/specs/chat-upload-safety.md
@@ -1,0 +1,64 @@
+# Chat-Dateiupload: sichtbare Limits und sicheres Streaming
+
+## Was
+
+Der Chat akzeptiert bis zu fünf Anhänge. Pro Datei gelten maximal **100 MiB**, pro Nachricht insgesamt maximal **200 MiB**. Bilder bis 5 MiB und Textdateien bis 100 KiB werden wie bisher als LLM-Inhalt verarbeitet; größere oder binäre Dateien werden blockweise in den aktiven Workspace geschrieben und dem Agenten über ihren Pfad angekündigt.
+
+## Warum
+
+Der bisherige Client verwirft Nicht-Bild-Dateien über 51.200.000 Bytes (ca. 48,8 MiB) ohne Rückmeldung. Eine knapp 54 MB große APK erscheint deshalb nicht als Anhang und nur der Nachrichtentext wird gesendet. Gleichzeitig liest das Backend Binärdateien vollständig in den RAM und speichert Projekt-Anhänge im generischen Agent-Workspace statt im aktiven Projekt-Workspace.
+
+## Verhalten
+
+### Grenzen
+
+- maximal 5 Dateien pro Nachricht
+- maximal 100 MiB pro Datei (`100 * 1024 * 1024` Bytes)
+- maximal 200 MiB über alle Anhänge einer Nachricht (`200 * 1024 * 1024` Bytes)
+- Bilder werden nur bis 5 MiB als Base64-Bildblock an das LLM gegeben
+- erkannte Textdateien werden nur bis 100 KiB in den Prompt eingebettet
+- größere Bilder, größere Textdateien und Binärdateien innerhalb der allgemeinen Grenzen werden als Dateien gespeichert
+
+### Frontend
+
+- APK, EXE und andere Binärdateien sind auswählbar; es gibt keine Dateiendungs-Whitelist.
+- Abgelehnte Dateien verschwinden nicht still.
+- Bei zu großer Einzeldatei, überschrittenem Gesamtlimit oder mehr als fünf Dateien erscheint eine lokalisierte Fehlermeldung.
+- Akzeptierte Dateien erscheinen weiterhin als Dateichip.
+- Wird nach einer Ablehnung eine gültige Datei gewählt, kann sie normal angehängt werden.
+
+### Backend
+
+- Das Backend erzwingt dieselben Einzel- und Gesamtgrenzen unabhängig vom Client.
+- Binärdateien werden in festen Chunks geschrieben; es wird keine 100-MiB-Datei vollständig in einen Python-Bytestring geladen.
+- Nginx und eine ASGI-Middleware begrenzen Chat-Message-Requests inklusive Multipart-Overhead auf 205 MiB, bevor FastAPI den Multipart-Body parst.
+- Bei Überschreitung wird HTTP 413 mit strukturiertem, im Chat lokalisiertem Fehlercode geliefert.
+- Uploads landen in einem eindeutigen Batch-Ordner unter `.hydrahive/uploads/`; bestehende Projektdateien werden niemals überschrieben.
+- Mehrere gleichnamige Anhänge erhalten eindeutige Zieldateinamen.
+- Unvollständige temporäre Dateien und der gesamte Batch werden bei Fehlern entfernt.
+- Anhänge akzeptieren nur einen reinen Basis-Dateinamen; Pfadbestandteile, `.` und `..` werden abgelehnt.
+- Bei einer Session mit gültiger `project_id` liegt der Batch im Projekt-Workspace; sonst im Agent-Workspace.
+- Uploadvalidierung erfolgt bei Resend vor dem Löschen der bisherigen History.
+- Hochgeladene APK/EXE werden nur gespeichert und niemals ausgeführt.
+
+## Akzeptanzkriterien
+
+- Eine Datei mit knapp 54 MB wird im Chat akzeptiert und im aktiven Projekt-Workspace gespeichert.
+- Eine Datei über 100 MiB wird im Frontend sichtbar abgelehnt und serverseitig mit HTTP 413 abgewehrt.
+- Mehrere Dateien über insgesamt 200 MiB werden sichtbar bzw. serverseitig abgelehnt.
+- Dateien mit `../` im Namen können den Workspace nicht verlassen.
+- Binär-Upload verwendet Chunk-Schreiben und hinterlässt bei Abbruch weder Teil-Datei noch verwaisten Batch.
+- Bestehende Projektdateien bleiben auch bei gleichnamigem Upload unverändert.
+- Mehrere gleichnamige Anhänge bleiben als getrennte Dateien erhalten.
+- Projekt-Session und projektlose Session speichern in ihrem jeweils korrekten Workspace.
+- Ein fehlgeschlagener Resend lässt die bisherige History unverändert.
+- Bestehender Bild- und Textupload bleibt funktionsfähig.
+- Frontend-Typecheck, ESLint und relevante Pytests sind grün.
+
+## Nicht enthalten
+
+- Uploads größer als 100 MiB pro Datei
+- ISO-/VM-Disk-Uploads; dafür bleiben die spezialisierten Uploadwege zuständig
+- Ausführung oder Installation hochgeladener Programme
+- automatische Übermittlung von Dateien an externe Malware-Scanner
+- Fortschrittsanzeige auf Byte-Ebene

--- a/frontend/src/features/chat/MessageInput.tsx
+++ b/frontend/src/features/chat/MessageInput.tsx
@@ -7,8 +7,10 @@ import { EmotePicker } from "./EmotePicker"
 import { PromptArchivePicker } from "./PromptArchivePicker"
 
 const MAX_FILES = 5
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024
-const MAX_TEXT_BYTES = 100 * 1024
+const MAX_FILE_BYTES = 100 * 1024 * 1024
+const MAX_TOTAL_BYTES = 200 * 1024 * 1024
+const MAX_FILE_MIB = MAX_FILE_BYTES / (1024 * 1024)
+const MAX_TOTAL_MIB = MAX_TOTAL_BYTES / (1024 * 1024)
 
 interface Props {
   onSend: (text: string, files: File[]) => void
@@ -28,6 +30,7 @@ export function MessageInput({ onSend, onCancel, busy, disabled, quickActions }:
     setText((prev) => (prev ? prev + " " + transcript : transcript))
   })
   const [files, setFiles] = useState<File[]>([])
+  const [uploadError, setUploadError] = useState<string | null>(null)
   const [dragOver, setDragOver] = useState(false)
   const textRef = useRef<HTMLTextAreaElement>(null)
   const fileRef = useRef<HTMLInputElement>(null)
@@ -38,6 +41,7 @@ export function MessageInput({ onSend, onCancel, busy, disabled, quickActions }:
     onSend(trimmed, files)
     setText("")
     setFiles([])
+    setUploadError(null)
     if (textRef.current) textRef.current.style.height = "auto"
   }
 
@@ -65,12 +69,26 @@ export function MessageInput({ onSend, onCancel, busy, disabled, quickActions }:
   function addFiles(incoming: FileList | null) {
     if (!incoming) return
     const next = [...files]
-    for (const f of Array.from(incoming)) {
-      if (next.length >= MAX_FILES) break
-      const limit = f.type.startsWith("image/") ? MAX_IMAGE_BYTES : MAX_TEXT_BYTES * 500
-      if (f.size <= limit) next.push(f)
+    let total = next.reduce((sum, file) => sum + file.size, 0)
+    let error: string | null = null
+    for (const file of Array.from(incoming)) {
+      if (next.length >= MAX_FILES) {
+        error ??= t("upload.too_many", { maxFiles: MAX_FILES })
+        break
+      }
+      if (file.size > MAX_FILE_BYTES) {
+        error ??= t("upload.file_too_large", { name: file.name, maxMiB: MAX_FILE_MIB })
+        continue
+      }
+      if (total + file.size > MAX_TOTAL_BYTES) {
+        error ??= t("upload.total_too_large", { maxMiB: MAX_TOTAL_MIB })
+        continue
+      }
+      next.push(file)
+      total += file.size
     }
     setFiles(next)
+    setUploadError(error)
   }
 
   function handleDrop(e: React.DragEvent) {
@@ -85,9 +103,16 @@ export function MessageInput({ onSend, onCancel, busy, disabled, quickActions }:
     >
       {files.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-2">
-          {files.map((f, i) => <MessageFileChip key={i} file={f} onRemove={() => setFiles(files.filter((_, j) => j !== i))} />)}
+          {files.map((f, i) => (
+            <MessageFileChip
+              key={i}
+              file={f}
+              onRemove={() => { setFiles(files.filter((_, j) => j !== i)); setUploadError(null) }}
+            />
+          ))}
         </div>
       )}
+      {uploadError && <p role="alert" className="mb-2 text-xs text-rose-400">{uploadError}</p>}
       <div className={`flex items-end gap-2 rounded-[4px] border bg-[#080d15] px-3 py-2 transition-colors
         ${dragOver ? "border-[#69d7ff]/60 bg-[#0d1420]" : "border-[#2a364b] focus-within:border-[#46617f]"}`}>
         <button

--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -1,5 +1,5 @@
 import { useAuthStore } from "@/features/auth/useAuthStore"
-import { api } from "@/shared/api-client"
+import { api, buildErrorMessage } from "@/shared/api-client"
 import type { AgentBrief, Message, RunnerEvent, Session } from "./types"
 
 export interface ProjectBrief {
@@ -68,10 +68,9 @@ export async function* sendMessage(
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
-    const detail = body.detail
     const msg = res.status === 409
       ? "Agent läuft noch – bitte kurz warten"
-      : typeof detail === "string" ? detail : (detail?.code ?? `HTTP ${res.status}`)
+      : buildErrorMessage(body, res.status)
     throw new Error(msg)
   }
   if (!res.body) throw new Error("Kein Response-Body")

--- a/frontend/src/i18n/locales/de/chat.json
+++ b/frontend/src/i18n/locales/de/chat.json
@@ -70,7 +70,10 @@
     "stop_title": "Stop — Antwort abbrechen"
   },
   "upload": {
-    "button_title": "Datei anhängen"
+    "button_title": "Datei anhängen",
+    "file_too_large": "{{name}} ist zu groß. Maximal {{maxMiB}} MiB pro Datei.",
+    "total_too_large": "Die Anhänge sind zusammen zu groß. Maximal {{maxMiB}} MiB pro Nachricht.",
+    "too_many": "Es sind maximal {{maxFiles}} Dateien pro Nachricht erlaubt."
   },
   "messages": {
     "empty": "Schreibe eine Nachricht um zu starten…",

--- a/frontend/src/i18n/locales/de/errors.json
+++ b/frontend/src/i18n/locales/de/errors.json
@@ -26,6 +26,10 @@
 
   "session_not_found": "Session nicht gefunden",
   "session_no_access": "Kein Zugriff auf diese Session",
+  "upload_file_too_large": "{{filename}} ist zu groß. Maximal {{max_mib}} MiB pro Datei.",
+  "upload_total_too_large": "Die Anhänge sind zusammen zu groß. Maximal {{max_mib}} MiB pro Nachricht.",
+  "upload_too_many_files": "Es sind maximal {{max_files}} Dateien pro Nachricht erlaubt.",
+  "upload_size_unknown": "Die Dateigröße konnte nicht bestimmt werden.",
 
   "project_not_found": "Projekt nicht gefunden",
   "project_no_access": "Kein Zugriff auf dieses Projekt",
@@ -131,6 +135,12 @@
   "incus_stop_failed": "incus stop fehlgeschlagen: {{stderr}}",
   "incus_restart_failed": "incus restart fehlgeschlagen: {{stderr}}",
   "incus_delete_failed": "incus delete fehlgeschlagen: {{stderr}}",
+
+  "upload_file_too_large": "Die Datei „{{filename}}“ ist größer als {{max_mib}} MiB.",
+  "upload_total_too_large": "Die Anhänge sind zusammen größer als {{max_mib}} MiB.",
+  "upload_too_many_files": "Pro Nachricht sind höchstens {{max_files}} Anhänge erlaubt.",
+  "upload_size_unknown": "Die Größe eines Anhangs konnte nicht sicher bestimmt werden.",
+  "upload_request_too_large": "Die Upload-Anfrage ist inklusive Übertragungsdaten größer als {{max_mib}} MiB.",
 
   "validation_error": "{{message}}"
 }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -70,7 +70,10 @@
     "stop_title": "Stop — cancel response"
   },
   "upload": {
-    "button_title": "Attach file"
+    "button_title": "Attach file",
+    "file_too_large": "{{name}} is too large. Maximum {{maxMiB}} MiB per file.",
+    "total_too_large": "The attachments are too large in total. Maximum {{maxMiB}} MiB per message.",
+    "too_many": "A maximum of {{maxFiles}} files per message is allowed."
   },
   "messages": {
     "empty": "Write a message to start…",

--- a/frontend/src/i18n/locales/en/errors.json
+++ b/frontend/src/i18n/locales/en/errors.json
@@ -26,6 +26,10 @@
 
   "session_not_found": "Session not found",
   "session_no_access": "No access to this session",
+  "upload_file_too_large": "{{filename}} is too large. Maximum {{max_mib}} MiB per file.",
+  "upload_total_too_large": "The attachments are too large in total. Maximum {{max_mib}} MiB per message.",
+  "upload_too_many_files": "A maximum of {{max_files}} files per message is allowed.",
+  "upload_size_unknown": "The file size could not be determined.",
 
   "project_not_found": "Project not found",
   "project_no_access": "No access to this project",
@@ -131,6 +135,12 @@
   "incus_stop_failed": "incus stop failed: {{stderr}}",
   "incus_restart_failed": "incus restart failed: {{stderr}}",
   "incus_delete_failed": "incus delete failed: {{stderr}}",
+
+  "upload_file_too_large": "The file “{{filename}}” is larger than {{max_mib}} MiB.",
+  "upload_total_too_large": "The attachments exceed the combined {{max_mib}} MiB limit.",
+  "upload_too_many_files": "A message can contain at most {{max_files}} attachments.",
+  "upload_size_unknown": "The size of an attachment could not be determined safely.",
+  "upload_request_too_large": "The upload request, including transfer overhead, exceeds {{max_mib}} MiB.",
 
   "validation_error": "{{message}}"
 }

--- a/frontend/src/shared/api-client.ts
+++ b/frontend/src/shared/api-client.ts
@@ -10,7 +10,7 @@ function isCoded(detail: unknown): detail is CodedDetail {
   return typeof detail === "object" && detail !== null && "code" in detail && typeof (detail as CodedDetail).code === "string"
 }
 
-function buildErrorMessage(body: { detail?: unknown }, status: number): string {
+export function buildErrorMessage(body: { detail?: unknown }, status: number): string {
   if (isCoded(body.detail)) {
     const { code, params } = body.detail
     const key = `errors:${code}`

--- a/installer/modules-mac/60-nginx.sh
+++ b/installer/modules-mac/60-nginx.sh
@@ -48,6 +48,25 @@ server {
         try_files \$uri \$uri/ /index.html;
     }
 
+    # chat-upload-limit: 200 MiB Nutzdaten + Multipart-Overhead vor FastAPI begrenzen.
+    location ~ ^/api/sessions/[^/]+/messages(?:/[^/]+/resend)?/?$ {
+        proxy_pass http://127.0.0.1:${HH_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        client_max_body_size 205M;
+        error_page 413 = @chat_upload_limit_error;
+    }
+
+    location @chat_upload_limit_error {
+        default_type application/json;
+        return 413 '{"detail":{"code":"upload_request_too_large","params":{"max_mib":205}}}';
+    }
+
     location /api/ {
         proxy_pass http://127.0.0.1:${HH_PORT};
         proxy_http_version 1.1;

--- a/installer/modules/60-nginx.sh
+++ b/installer/modules/60-nginx.sh
@@ -142,6 +142,27 @@ server {
         client_max_body_size 64k;
     }
 
+    # chat-upload-limit: 200 MiB Nutzdaten + Multipart-Overhead vor FastAPI begrenzen.
+    location ~ ^/api/sessions/[^/]+/messages(?:/[^/]+/resend)?/?$ {
+        proxy_pass http://$HH_HOST:$HH_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        client_max_body_size 205M;
+        error_page 413 = @chat_upload_limit_error;
+    }
+
+    location @chat_upload_limit_error {
+        default_type application/json;
+        return 413 '{"detail":{"code":"upload_request_too_large","params":{"max_mib":205}}}';
+    }
+
     location /api/ {
         proxy_pass http://$HH_HOST:$HH_PORT;
         proxy_http_version 1.1;

--- a/installer/update.sh
+++ b/installer/update.sh
@@ -505,6 +505,7 @@ else
   grep -q "assets.coingecko.com"         "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "resources.cryptocompare.com" "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "hh_cache_control"            "$NGINX_CONF" || NEEDS_REWRITE=1
+  grep -q "chat-upload-limit"           "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "/api/compute/agent/connect"   "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "ssl_verify_client optional"   "$NGINX_CONF" || NEEDS_REWRITE=1
   grep -q "hydrahive-compute-secret.conf" "$NGINX_CONF" || NEEDS_REWRITE=1


### PR DESCRIPTION
## Problem

Der Chat verwarf Nicht-Bild-Dateien über ~48,8 MiB **still** — eine ~54 MB APK erschien gar nicht als Anhang, nur der Nachrichtentext ging raus. Zudem las das Backend Binärdateien komplett in den RAM und speicherte Projekt-Anhänge im generischen Agent-Workspace statt im aktiven Projekt-Workspace.

## Änderung

**Grenzen (sichtbar, client + server):**
- max. 5 Dateien / Nachricht
- max. 100 MiB / Datei
- max. 200 MiB gesamt

**Frontend:** APK/EXE/Binär auswählbar (keine Endungs-Whitelist), abgelehnte Dateien verschwinden nicht still, lokalisierte Fehlermeldung (de/en).

**Backend:** erzwingt dieselben Grenzen client-unabhängig; neue ASGI-`upload_limit`-Middleware + Nginx-Limit (205 MiB) greifen vor dem Multipart-Parsing → HTTP 413 mit strukturiertem, im Chat lokalisiertem Fehlercode. Binäruploads via **Chunk-Schreiben** in eindeutigen Batch-Ordner unter `.hydrahive/uploads/`; Pfad-Traversal (`../`, `.`) abgewehrt, bestehende Projektdateien werden nie überschrieben, Cleanup bei Fehlern. Projekt-Session speichert im Projekt-Workspace, sonst Agent-Workspace.

## Verifikation

| Gate | Ergebnis |
|------|----------|
| `pytest core/tests/test_chat_uploads.py` | 20 passed |
| Ruff (Backend) | All checks passed |
| Frontend-Build/Typecheck | built, Exit 0 |
| Shell-Syntax (3 Installer) | OK |
| hh-review | keine neuen Verstöße |

## Nicht enthalten
Uploads >100 MiB, ISO-/VM-Disk-Uploads (eigene Wege), Ausführung hochgeladener Programme, externe Malware-Scans, Byte-genaue Fortschrittsanzeige.

Spec: `docs/specs/chat-upload-safety.md`