### PR TITLE
feat: Ollama als LLM-Provider

### DIFF
--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -55,6 +55,9 @@ STATIC_MODELS = {
 PROVIDER_PREFIX = {
     "openai": "openai/", "nvidia": "nvidia_nim/", "groq": "groq/",
     "mistral": "mistral/", "openrouter": "openrouter/", "gemini": "gemini/",
+    # Ollama: OpenAI-kompatibel, LiteLLM-Route "ollama/". Modelle kommen live
+    # vom user-eigenen Endpoint (keine STATIC_MODELS-Hardcodes).
+    "ollama": "ollama/",
 }
 
 # Interne Metadata-Tabelle. Per Modell-ID (mit Prefix) → Eigenschaften.

--- a/core/src/hydrahive/llm/_config.py
+++ b/core/src/hydrahive/llm/_config.py
@@ -14,6 +14,10 @@ _ENV_MAP = {
     "mistral": "MISTRAL_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "nvidia": "NVIDIA_NIM_API_KEY",
+    # Ollama kennt optional einen Key (Ollama-Cloud / geschützte Instanzen);
+    # lokal läuft es ohne Key. Trotzdem in _ENV_MAP, damit ein gesetzter Key
+    # via provider_env_vars() automatisch in der shell_exec-Denylist landet.
+    "ollama": "OLLAMA_API_KEY",
 }
 
 def provider_env_vars() -> set[str]:
@@ -40,6 +44,18 @@ def load_config() -> dict:
     data = json.loads(path.read_text())
     _config_cache = (mtime, data)
     return data
+
+
+def provider_api_base(config: dict, provider_id: str) -> str | None:
+    """Liefert die konfigurierte `api_base` eines Providers aus der llm.json.
+
+    Für OpenAI-kompatible Provider mit user-eigenem Endpoint (Ollama, LM Studio,
+    vLLM …). None, wenn der Provider keine api_base gesetzt hat."""
+    for p in config.get("providers", []):
+        if p.get("id", "") == provider_id:
+            base = p.get("api_base") or None
+            return base.rstrip("/") if base else None
+    return None
 
 
 def apply_keys(config: dict) -> None:

--- a/core/src/hydrahive/llm/catalog.py
+++ b/core/src/hydrahive/llm/catalog.py
@@ -132,6 +132,29 @@ async def _fetch_live_models(provider_id: str, api_key: str) -> list[dict]:
         return []
 
 
+async def _fetch_ollama_models(provider: dict) -> list[dict]:
+    """Holt Ollama-Modelle live vom user-eigenen Endpoint (OpenAI-kompatibel).
+
+    Anders als die Cloud-Provider kommt die Base-URL aus der llm.json (`api_base`),
+    nicht aus PROVIDER_ENDPOINTS. Ollama braucht lokal keinen Key; ein optionaler
+    Key (Ollama-Cloud) wird als Bearer mitgegeben. Bei Fehler: leere Liste."""
+    base = (provider.get("api_base") or "").rstrip("/")
+    if not base:
+        return []
+    key = provider.get("api_key", "") or ""
+    url = f"{base}/v1/models"
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return _parse_models_response("ollama", data)
+    except Exception as e:
+        logger.warning("Catalog: Ollama live-fetch (%s) fehlgeschlagen: %s", url, e)
+        return []
+
+
 def _enrich(provider_id: str, entry: dict) -> dict[str, Any]:
     """Joint Live-Eintrag mit METADATA. Live-context_window hat Vorrang."""
     from hydrahive.llm._anthropic import _uses_effort_param
@@ -159,6 +182,17 @@ async def catalog_for_providers(providers: list[dict]) -> list[dict]:
     """
     async def one(p: dict) -> dict:
         pid = p.get("id", "")
+        # Ollama: user-eigener Endpoint. api_base statt Cloud-URL, kein Key nötig.
+        if pid == "ollama":
+            entries = await _fetch_ollama_models(p)
+            models = [_enrich(pid, e) for e in entries]
+            return {
+                "provider_id": pid,
+                "provider_name": p.get("name", pid),
+                "configured": bool(p.get("api_base")),
+                "models": models,
+                "live_count": len(entries),
+            }
         key = p.get("api_key", "") or (p.get("oauth") or {}).get("access", "")
         entries = await _cached_fetch(pid, key)
         if not entries:

--- a/core/src/hydrahive/runner/_llm_bridge_backends.py
+++ b/core/src/hydrahive/runner/_llm_bridge_backends.py
@@ -127,6 +127,7 @@ async def litellm_call(
     tools: list[dict],
     temperature: float,
     max_tokens: int,
+    api_base: str | None = None,
 ) -> tuple[list[dict], str, dict[str, int]]:
     """Tool-Loop-fähiger Call für alle non-Anthropic/non-MiniMax Provider via LiteLLM.
 
@@ -160,6 +161,10 @@ async def litellm_call(
     if oai_tools:
         kwargs["tools"] = oai_tools
         kwargs["tool_choice"] = "auto"
+    # User-eigener Endpoint (Ollama, LM Studio, vLLM …). Nur setzen wenn gegeben,
+    # damit Cloud-Provider ihr Default-Routing behalten.
+    if api_base:
+        kwargs["api_base"] = api_base
 
     try:
         resp = await litellm.acompletion(**kwargs)

--- a/core/src/hydrahive/runner/llm_bridge.py
+++ b/core/src/hydrahive/runner/llm_bridge.py
@@ -94,11 +94,15 @@ async def call_with_tools(
         )
 
     # Alle anderen Provider (OpenAI mit API-Key, NVIDIA, Groq, Mistral, Gemini,
-    # OpenRouter, …) gehen über LiteLLM. apply_keys setzt die ENV-Variablen aus
-    # llm.json.
+    # OpenRouter, Ollama …) gehen über LiteLLM. apply_keys setzt die ENV-Variablen
+    # aus llm.json.
     apply_keys(cfg)
     parts = [p for p in [system_prompt, summary_system, volatile_system] if p]
     full_system = "\n\n".join(parts)
+    # Provider mit user-eigenem Endpoint (Ollama, LM Studio, vLLM …): die api_base
+    # aus der llm.json an LiteLLM durchreichen. Der Provider-Prefix im Modell-String
+    # (z.B. "ollama/llama3.1") mappt auf die provider_id.
+    api_base = _resolve_api_base(cfg, target)
     return await litellm_call(
         model=target,
         system_prompt=full_system,
@@ -106,4 +110,21 @@ async def call_with_tools(
         tools=tools,
         temperature=temperature,
         max_tokens=max_tokens,
+        api_base=api_base,
     )
+
+
+def _resolve_api_base(cfg: dict, model: str) -> str | None:
+    """Findet die api_base des Providers, zu dem `model` gehört.
+
+    Mappt den LiteLLM-Prefix aus dem Modell-String (z.B. "ollama/") zurück auf
+    die provider_id und liest deren api_base aus der Config. None, wenn kein
+    Provider mit api_base passt (Cloud-Provider behalten Default-Routing)."""
+    from hydrahive.llm._catalog_data import PROVIDER_PREFIX
+    from hydrahive.llm._config import provider_api_base
+    for provider_id, prefix in PROVIDER_PREFIX.items():
+        if prefix and model.startswith(prefix):
+            base = provider_api_base(cfg, provider_id)
+            if base:
+                return base
+    return None

--- a/core/tests/test_ollama_provider.py
+++ b/core/tests/test_ollama_provider.py
@@ -1,0 +1,155 @@
+"""Tests für die Ollama-Provider-Unterstützung.
+
+Ollama spricht eine OpenAI-kompatible API und läuft über den LiteLLM-Pfad.
+Anders als die Cloud-Provider kommt die Base-URL aus der user-eigenen llm.json
+(`api_base`), nicht aus hardcodierten PROVIDER_ENDPOINTS. Diese Tests sichern:
+1. api_base wird aus der Config gelesen (provider_api_base).
+2. litellm_call reicht api_base an litellm.acompletion durch.
+3. Nicht-Ollama-Provider setzen kein api_base-kwarg (Regression-Schutz).
+4. Catalog listet Ollama-Modelle live vom user-Endpoint.
+5. Ollama gilt ohne Key als configured, wenn api_base gesetzt ist.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.llm import catalog
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    catalog._cache_clear()
+    yield
+    catalog._cache_clear()
+
+
+# --- 1. provider_api_base() liest die api_base aus der Config ---------------
+
+def test_provider_api_base_returns_configured_url():
+    from hydrahive.llm._config import provider_api_base
+    cfg = {"providers": [
+        {"id": "ollama", "api_base": "http://localhost:11434"},
+        {"id": "openai", "api_key": "sk-x"},
+    ]}
+    assert provider_api_base(cfg, "ollama") == "http://localhost:11434"
+
+
+def test_provider_api_base_none_when_not_set():
+    from hydrahive.llm._config import provider_api_base
+    cfg = {"providers": [{"id": "openai", "api_key": "sk-x"}]}
+    assert provider_api_base(cfg, "openai") is None
+    assert provider_api_base(cfg, "ollama") is None
+
+
+def test_ollama_in_env_map():
+    from hydrahive.llm._config import provider_env_vars
+    # Ollama-Key muss geschützt sein (shell_exec-Denylist speist sich hieraus).
+    assert "OLLAMA_API_KEY" in provider_env_vars()
+
+
+# --- 2. litellm_call reicht api_base durch ----------------------------------
+
+def test_litellm_call_passes_api_base(monkeypatch):
+    from hydrahive.runner import _llm_bridge_backends as backends
+
+    captured: dict = {}
+
+    class _Msg:
+        content = "hi"
+        tool_calls = None
+
+    class _Choice:
+        message = _Msg()
+        finish_reason = "stop"
+
+    class _Resp:
+        choices = [_Choice()]
+        usage = None
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _Resp()
+
+    import litellm
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    asyncio.run(backends.litellm_call(
+        model="ollama/llama3.1",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        temperature=0.0,
+        max_tokens=100,
+        api_base="http://localhost:11434",
+    ))
+    assert captured.get("api_base") == "http://localhost:11434"
+
+
+def test_litellm_call_no_api_base_kwarg_when_none(monkeypatch):
+    """Regression: Provider ohne api_base dürfen KEIN api_base-kwarg bekommen."""
+    from hydrahive.runner import _llm_bridge_backends as backends
+
+    captured: dict = {}
+
+    class _Msg:
+        content = "hi"
+        tool_calls = None
+
+    class _Choice:
+        message = _Msg()
+        finish_reason = "stop"
+
+    class _Resp:
+        choices = [_Choice()]
+        usage = None
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _Resp()
+
+    import litellm
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    asyncio.run(backends.litellm_call(
+        model="openai/gpt-4o",
+        system_prompt="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        temperature=0.0,
+        max_tokens=100,
+    ))
+    assert "api_base" not in captured
+
+
+# --- 3. Catalog: Ollama live vom user-Endpoint ------------------------------
+
+def test_ollama_prefix_registered():
+    from hydrahive.llm._catalog_data import PROVIDER_PREFIX
+    assert PROVIDER_PREFIX.get("ollama") == "ollama/"
+
+
+def test_catalog_ollama_configured_without_key(monkeypatch):
+    """Ollama gilt als configured, wenn api_base gesetzt ist — auch ohne Key."""
+    async def fake_fetch_ollama(provider):
+        return [{"id": "ollama/llama3.1", "context_window": None, "is_free": None,
+                 "price_prompt": None, "price_completion": None}]
+
+    monkeypatch.setattr(catalog, "_fetch_ollama_models", fake_fetch_ollama, raising=False)
+
+    providers = [{"id": "ollama", "api_base": "http://localhost:11434"}]
+    result = asyncio.run(catalog.catalog_for_providers(providers))
+    entry = result[0]
+    assert entry["provider_id"] == "ollama"
+    assert entry["configured"] is True
+    assert any(m["id"] == "ollama/llama3.1" for m in entry["models"])
+
+
+def test_catalog_ollama_no_api_base_empty(monkeypatch):
+    """Ohne api_base: leere Modell-Liste, kein Crash."""
+    providers = [{"id": "ollama"}]
+    result = asyncio.run(catalog.catalog_for_providers(providers))
+    entry = result[0]
+    assert entry["provider_id"] == "ollama"
+    assert entry["models"] == []

--- a/docs/ollama-provider.md
+++ b/docs/ollama-provider.md
@@ -1,0 +1,61 @@
+# Ollama als LLM-Provider
+
+HydraHive kann lokale Modelle über [Ollama](https://ollama.com) nutzen. Ollama
+spricht eine OpenAI-kompatible API und läuft über den bestehenden LiteLLM-Pfad.
+
+## Einrichtung
+
+1. Ollama starten (z.B. `ollama serve`, Default-Port `11434`) und mindestens ein
+   Modell ziehen, z.B. `ollama pull llama3.1`.
+
+2. In der Provider-Konfiguration (`llm.json` bzw. Provider-Maske) einen Provider
+   anlegen:
+
+   ```json
+   {
+     "id": "ollama",
+     "name": "Ollama (lokal)",
+     "api_base": "http://localhost:11434",
+     "api_key": ""
+   }
+   ```
+
+   - `api_base` ist **Pflicht** — hierüber routet HydraHive die Anfragen.
+     Sie ist **frei wählbar**: auch ein Remote-Ollama auf einem anderen Host geht
+     (`http://192.168.x.y:11434`).
+   - `api_key` bleibt **leer** für lokale Instanzen. Nur Ollama-Cloud oder eine
+     geschützte Instanz braucht einen Key (wird als Bearer-Token gesendet).
+
+3. Modelle erscheinen automatisch im Catalog — sie werden **live** vom Endpoint
+   (`{api_base}/v1/models`) geladen. Es gibt keine fest eingebaute Modell-Liste;
+   jeder sieht genau seine installierten Modelle. Im Modell-Dropdown erscheinen
+   sie mit dem Prefix `ollama/`, z.B. `ollama/llama3.1`.
+
+## Tool-Use (Agenten-Aktionen)
+
+Ob ein Agent auf einem Ollama-Modell **Tools** aufrufen kann, hängt vom Modell ab:
+
+- **Modelle mit nativem Function-Calling** (z.B. `llama3.1`, `mistral-nemo`,
+  `qwen2.5`, `firefunction-v2`) funktionieren direkt — sie liefern strukturierte
+  Tool-Calls, die HydraHive ausführt.
+- **Modelle ohne Function-Calling** (viele kleine Modelle wie `llama3.2:3b`)
+  geben Tool-Calls u.U. als reinen **Text/JSON** aus. Das wird **nicht** als
+  echter Tool-Call interpretiert (bewusste Sicherheitsentscheidung — sonst könnte
+  legitimes JSON fälschlich als z.B. `shell_exec` ausgeführt werden). Solche
+  Modelle sind praktisch **chat-only**.
+
+**Symptom bei fehlendem Function-Calling:** Der Agent gibt einen Tool-Call als
+rohen JSON-Text im Chat aus, statt ihn auszuführen. Dann ein Modell mit nativem
+Tool-Support wählen.
+
+## Sicherheitshinweis
+
+Die `api_base` ist frei wählbar. Ein Admin, der einen Ollama-Provider anlegt,
+kann HydraHive damit HTTP-Requests an beliebige (auch interne) URLs schicken
+lassen (SSRF-Fläche). Das liegt in der Verantwortung des Provider-Admins, der
+ohnehin privilegierten Zugriff hat.
+
+## Kein Streaming
+
+Ollama läuft über den non-streaming LiteLLM-Pfad. Der Chat aktualisiert erst,
+wenn die Antwort vollständig ist (kein Token-für-Token-Streaming wie bei Claude).

--- a/docs/specs/ollama-provider.md
+++ b/docs/specs/ollama-provider.md
@@ -1,0 +1,74 @@
+# Spec: Ollama als LLM-Provider
+
+## Was
+Offizielle Unterstützung von Ollama als LLM-Provider in HydraHive2. User können
+einen Provider vom Typ `ollama` in der `llm.json` anlegen (mit user-eigener
+`api_base`, z.B. `http://localhost:11434`) und ihre lokal installierten Modelle
+für Agenten nutzen — ohne den Source zu forken.
+
+## Warum
+- Bisher gibt es keine Ollama-Anbindung. Ein Kunde hat es selbst gepatcht, ist
+  aber gescheitert: Unser `apply_keys()` reicht die `api_base` nicht an LiteLLM
+  durch, und `litellm_call()` übergibt kein `api_base` an `litellm.acompletion()`.
+  → LiteLLM weiß nicht, wohin die Anfrage soll.
+- Lokale Modelle (Datenschutz, Kosten, Offline) sind ein wiederkehrender Wunsch.
+
+## Wie (grob)
+Ollama spricht eine OpenAI-kompatible API. Damit läuft es über den bestehenden
+LiteLLM-Pfad — es fehlen nur zwei Dinge: die **Base-URL durchreichen** und das
+**Live-Model-Listing** gegen die user-eigene URL.
+
+1. **`_config.py`** — neuer Helper `provider_api_base(config, provider_id)`, der
+   die `api_base` eines Providers aus der `llm.json` liest. `ollama` wird in
+   `_ENV_MAP` aufgenommen (`OLLAMA_API_KEY`), da Ollama optional einen Key kennt
+   (Ollama-Cloud/geschützte Instanzen) — lokal wird kein Key gesetzt.
+
+2. **`_llm_bridge_backends.py` / `llm_bridge.py`** — `litellm_call()` bekommt
+   optional `api_base` und reicht es an `litellm.acompletion(api_base=...)` durch.
+   `call_with_tools()` liest die `api_base` des Ziel-Providers aus der Config und
+   gibt sie weiter. Nicht-Ollama-Provider bleiben unberührt (api_base=None → kein
+   kwarg gesetzt).
+
+3. **`catalog.py`** — Ollama-Live-Listing: die URL kommt aus der user-`api_base`
+   (`{api_base}/v1/models`), nicht aus hardcodierten `PROVIDER_ENDPOINTS`. Ollama
+   braucht lokal keinen API-Key → der `configured`/`key`-Gate wird für Ollama
+   gelockert (Provider mit gesetzter `api_base` gilt als konfiguriert).
+
+4. **`_catalog_data.py`** — `PROVIDER_PREFIX["ollama"] = "ollama/"` (LiteLLM-Route).
+   Keine STATIC_MODELS-Hardcodes — Modelle kommen live vom user-Endpoint. Modelle
+   ohne METADATA-Eintrag werden als `unknown: True` markiert (bestehendes Verhalten),
+   `tool_use: None` (unbekannt) — kein falsches Versprechen.
+
+## Tool-Calls
+Ollama-Modelle mit nativem Function-Calling (llama3.1+, mistral-nemo, qwen2.5,
+firefunction etc.) funktionieren direkt über den bestehenden `tool_calls`-Pfad.
+Modelle **ohne** natives Function-Calling geben Tool-Calls u.U. als Text-JSON aus
+— das wird **nicht** geparst (bewusste Entscheidung: ein Text-Fallback-Parser wäre
+ein Security-Risiko, weil legitimes JSON fälschlich als Tool-Call ausgeführt werden
+könnte). Solche Modelle sind chat-only. Wird dokumentiert.
+
+## Sicherheit
+- `api_base` ist **frei wählbar** (bewusste Entscheidung, Option a): erlaubt auch
+  Remote-Ollama auf anderem Host. Damit besteht eine SSRF-Fläche — ein Admin, der
+  einen Provider anlegt, kann HydraHive HTTP-Requests an beliebige (auch interne)
+  URLs schicken lassen. Das liegt in der Verantwortung des Provider-Admins, der
+  ohnehin privilegierten Zugriff hat. Kein automatisches Whitelisting.
+- `OLLAMA_API_KEY` wird über `provider_env_vars()` automatisch in die
+  shell_exec-Denylist aufgenommen (bestehender Mechanismus via `_ENV_MAP`).
+
+## Akzeptanzkriterien
+- [ ] Ein `ollama`-Provider mit `api_base` in `llm.json` reicht die Base-URL an
+      `litellm.acompletion()` durch (Test mit gemocktem litellm).
+- [ ] `provider_api_base()` liefert die api_base des richtigen Providers, `None`
+      wenn nicht gesetzt.
+- [ ] Nicht-Ollama-Provider setzen **kein** `api_base`-kwarg (Regression-Schutz).
+- [ ] Catalog listet Ollama-Modelle live vom user-Endpoint; ohne api_base leere
+      Liste, kein Crash.
+- [ ] Ollama gilt auch ohne API-Key als `configured`, wenn `api_base` gesetzt ist.
+- [ ] `ruff` + bestehende Tests grün, keine zirkulären Imports.
+
+## Nicht in diesem Plan
+- Text-basierter Tool-Call-Fallback-Parser (Security-Risiko, separat + Review).
+- Kosten-/Pricing-Feinheiten für Ollama (bleibt beim bestehenden „ollama"-Label).
+- Frontend-UI-Änderungen (Provider wird über bestehende llm.json/Provider-Maske
+  angelegt).


### PR DESCRIPTION
## Was
Offizielle Ollama-Unterstützung — User können lokale (oder remote) Ollama-Modelle für Agenten nutzen, ohne den Source zu forken.

## Warum
Bisher keine Ollama-Anbindung. Ein Kunde hat es selbst gepatcht und ist gescheitert: `apply_keys()` reichte die `api_base` nicht an LiteLLM durch, und `litellm_call()` übergab kein `api_base` → LiteLLM wusste nicht, wohin. Symptom beim Kunden: Tool-Calls landeten als roher JSON-Text im Chat.

## Änderungen
- **`_config.py`**: `provider_api_base()` Helper; `ollama` in `_ENV_MAP` (`OLLAMA_API_KEY` → automatisch in shell_exec-Denylist).
- **`_llm_bridge_backends.py`**: `litellm_call` reicht optionales `api_base` an `litellm.acompletion` durch. Cloud-Provider unverändert (kein kwarg wenn None).
- **`llm_bridge.py`**: `_resolve_api_base()` mappt Modell-Prefix (`ollama/`) auf die Provider-`api_base` aus der llm.json.
- **`catalog.py`**: Ollama-Live-Listing vom user-Endpoint (`{api_base}/v1/models`), kein Key nötig, `configured` wenn `api_base` gesetzt.
- **`_catalog_data.py`**: `PROVIDER_PREFIX["ollama"] = "ollama/"` (keine Static-Hardcodes — Modelle kommen live).

## Bewusste Entscheidungen
- **Kein Text-Tool-Call-Fallback-Parser** — Security-Risiko (legitimes JSON würde fälschlich als z.B. `shell_exec` ausgeführt). Modelle ohne natives Function-Calling bleiben chat-only. Dokumentiert.
- **`api_base` frei wählbar** (auch Remote-Ollama) — SSRF-Fläche liegt beim Provider-Admin (privilegiert). Dokumentiert.

## Tests
- 8 neue Tests in `test_ollama_provider.py` (api_base-Durchreichung, Catalog-Listing, **Regressions-Schutz**: Nicht-Ollama-Provider setzen kein api_base-kwarg).
- 24 Tests grün gesamt, keine bestehende Regression.

## Nicht verifiziert
Kein Live-Round-Trip gegen eine laufende Ollama-Instanz (auf dem Build-Host läuft kein Ollama). Unit-Tests decken den Mechanismus mit Mocks ab — der echte End-to-End-Test steht noch aus.

## Hinweise für Review
- `catalog.py` ist jetzt 210 Zeilen (+10, knapp über der ~200-Richtlinie) — kein Split für 10 Zeilen, aber vermerkt.

Spec: `docs/specs/ollama-provider.md` · User-Doku: `docs/ollama-provider.md`