### PR TITLE
fix(ollama): Provider im Frontend anlegbar machen

### DIFF
--- a/core/tests/test_llm_provider_api_base_persist.py
+++ b/core/tests/test_llm_provider_api_base_persist.py
@@ -1,0 +1,33 @@
+"""Sichert die Frontend→Backend-Kette für den Ollama-Provider ab.
+
+Das Frontend schickt beim Anlegen eines Ollama-Providers ein `api_base`-Feld.
+Das Pydantic-Modell `LlmProvider` listet api_base nicht explizit — es wird über
+`model_config = ConfigDict(extra="allow")` durchgereicht. Dieser Test stellt
+sicher, dass model_dump() das Feld NICHT droppt (sonst käme es nie in die
+llm.json und der ganze Provider wäre unbrauchbar)."""
+from __future__ import annotations
+
+from hydrahive.api.routes.llm import LlmConfig, LlmProvider
+
+
+def test_api_base_survives_model_dump():
+    p = LlmProvider(
+        id="ollama", name="Ollama (lokal)", api_key="", models=[],
+        api_base="http://localhost:11434",
+    )
+    dumped = p.model_dump()
+    assert dumped["api_base"] == "http://localhost:11434"
+
+
+def test_api_base_survives_full_config_dump():
+    cfg = LlmConfig(providers=[
+        LlmProvider(id="ollama", name="Ollama", api_key="", models=[],
+                    api_base="http://localhost:11434"),
+        LlmProvider(id="openai", name="OpenAI", api_key="sk-x", models=[]),
+    ])
+    dumped = cfg.model_dump()
+    ollama = next(p for p in dumped["providers"] if p["id"] == "ollama")
+    openai = next(p for p in dumped["providers"] if p["id"] == "openai")
+    assert ollama["api_base"] == "http://localhost:11434"
+    # Nicht-Ollama-Provider haben kein api_base (kein leeres Feld untergejubelt).
+    assert "api_base" not in openai

--- a/core/tests/test_llm_provider_api_base_persist.py
+++ b/core/tests/test_llm_provider_api_base_persist.py
@@ -4,13 +4,18 @@ Das Frontend schickt beim Anlegen eines Ollama-Providers ein `api_base`-Feld.
 Das Pydantic-Modell `LlmProvider` listet api_base nicht explizit — es wird über
 `model_config = ConfigDict(extra="allow")` durchgereicht. Dieser Test stellt
 sicher, dass model_dump() das Feld NICHT droppt (sonst käme es nie in die
-llm.json und der ganze Provider wäre unbrauchbar)."""
-from __future__ import annotations
+llm.json und der ganze Provider wäre unbrauchbar).
 
-from hydrahive.api.routes.llm import LlmConfig, LlmProvider
+Import von `hydrahive.api.routes.llm` bewusst LAZY (in der Funktion), damit das
+settings-Singleton nicht zur Collection-Zeit auf das echte /var/lib/hydrahive2
+festgenagelt wird (bricht sonst die tmp-Isolation anderer Tests). Gleiches
+Muster wie test_llm_media_models_config.py.
+"""
+from __future__ import annotations
 
 
 def test_api_base_survives_model_dump():
+    from hydrahive.api.routes.llm import LlmProvider
     p = LlmProvider(
         id="ollama", name="Ollama (lokal)", api_key="", models=[],
         api_base="http://localhost:11434",
@@ -20,6 +25,7 @@ def test_api_base_survives_model_dump():
 
 
 def test_api_base_survives_full_config_dump():
+    from hydrahive.api.routes.llm import LlmConfig, LlmProvider
     cfg = LlmConfig(providers=[
         LlmProvider(id="ollama", name="Ollama", api_key="", models=[],
                     api_base="http://localhost:11434"),

--- a/frontend/src/features/llm/ProviderForm.tsx
+++ b/frontend/src/features/llm/ProviderForm.tsx
@@ -25,6 +25,9 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
   const isOAuth = (known as { auth?: string } | undefined)?.auth === "oauth"
   // Hybrid-Provider (Anthropic): Key-Feld bleibt sichtbar UND zusätzlich OAuth-Login.
   const isOAuthOptional = (known as { oauthOptional?: boolean } | undefined)?.oauthOptional === true
+  // Provider mit user-eigenem Endpoint (Ollama): api_base-Feld + Key optional.
+  const needsApiBase = (known as { needsApiBase?: boolean } | undefined)?.needsApiBase === true
+  const apiBasePlaceholder = (known as { apiBasePlaceholder?: string } | undefined)?.apiBasePlaceholder ?? "https://…"
   const hasToken = !!form.oauth?.access
 
   function handleSubmit(e: React.FormEvent) {
@@ -73,6 +76,15 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
             className="w-full px-3 py-2 rounded-lg bg-white/[5%] border border-white/[8%] text-zinc-200 text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50" />
         </div>
       )}
+      {needsApiBase && (
+        <div>
+          <label className="block text-xs text-zinc-500 mb-1">Endpoint (api_base) <span className="text-zinc-600">(Pflicht)</span></label>
+          <input type="text" value={form.api_base ?? ""} onChange={(e) => setForm({ ...form, api_base: e.target.value || undefined })}
+            placeholder={apiBasePlaceholder}
+            className="w-full px-3 py-2 rounded-lg bg-white/[5%] border border-white/[8%] text-zinc-200 text-sm font-mono placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-violet-500/50" />
+          <p className="text-[10px] text-zinc-500 mt-1">URL deiner Ollama-Instanz. Modelle werden live von diesem Endpoint geladen. Key nur für Ollama-Cloud/geschützte Instanzen.</p>
+        </div>
+      )}
       {isOAuth && !hasToken && (
         <OAuthFlow
           providerId={form.id}
@@ -114,7 +126,9 @@ export function ProviderForm({ existing, onSave, onCancel, onOAuthConnected }: P
             || (isOAuth && !hasToken)
             // Hybrid (Anthropic): Key ODER OAuth-Token reicht.
             || (isOAuthOptional && !form.api_key && !hasToken)
-            || (!isOAuth && !isOAuthOptional && !form.api_key)
+            // Ollama: api_base ist Pflicht, Key optional.
+            || (needsApiBase && !form.api_base)
+            || (!isOAuth && !isOAuthOptional && !needsApiBase && !form.api_key)
           }
           className="flex items-center gap-2 px-4 py-2 rounded-lg bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white text-sm font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-all">
           <Plus size={14} /> {isEdit ? tCommon("actions.save") : tCommon("actions.add")}

--- a/frontend/src/features/llm/_llm_providers.ts
+++ b/frontend/src/features/llm/_llm_providers.ts
@@ -45,6 +45,15 @@ export const KNOWN_PROVIDERS = [
     id: "nvidia", name: "NVIDIA NIM", placeholder: "nvapi-...",
     models: [],
   },
+  {
+    // Lokaler/Remote-Ollama: user-eigener Endpoint (api_base). Kein Key nötig
+    // (nur Ollama-Cloud/geschützte Instanzen). needsApiBase blendet das
+    // Endpoint-Feld ein und macht den Key optional.
+    id: "ollama", name: "Ollama (lokal)", placeholder: "leer für lokal (nur Cloud braucht Key)",
+    needsApiBase: true as const,
+    apiBasePlaceholder: "http://localhost:11434",
+    models: [],
+  },
 ]
 
 export const EMPTY_PROVIDER: LlmProvider = { id: "", name: "", api_key: "", models: [] }

--- a/frontend/src/features/llm/api.ts
+++ b/frontend/src/features/llm/api.ts
@@ -13,6 +13,8 @@ export interface LlmProvider {
   name: string
   api_key: string
   group_id?: string
+  // Für Provider mit user-eigenem Endpoint (Ollama, LM Studio, vLLM …).
+  api_base?: string
   models: string[]
   oauth?: OAuthBlock
 }


### PR DESCRIPTION
## Problem
Der Ollama-Backend-Support aus #370 war **im Frontend nicht nutzbar** — der User konnte Ollama gar nicht über die "LLM hinzufügen"-Maske anlegen. Ein halbfertiges Feature (mein Fehler, sorry).

Ursachen:
- Ollama fehlte in `KNOWN_PROVIDERS` → tauchte im Dropdown nicht auf
- Kein `api_base`-Eingabefeld → der Pflicht-Endpoint konnte nicht gesetzt werden
- Submit-Gate verlangte einen `api_key`, den lokales Ollama nicht hat → Button blieb disabled

## Fix (genau wie die anderen Provider, mit Ollama-Sonderfeld)
- **`api.ts`**: `LlmProvider`-Typ um optionales `api_base` erweitert
- **`_llm_providers.ts`**: Ollama zu `KNOWN_PROVIDERS` (`needsApiBase`-Marker, Key optional, api_base-Placeholder `http://localhost:11434`)
- **`ProviderForm.tsx`**: api_base-Pflichtfeld eingeblendet (Muster wie MiniMax-`group_id`); Submit-Gate: Ollama verlangt `api_base` statt `api_key`

## Kette bewiesen
Frontend-Feld → Pydantic `model_dump` (`extra="allow"`) → llm.json → Backend-Routing (#370) → Live-Catalog.

## Verifiziert
- `tsc -b` (CI-Typecheck) ✅ Exit 0
- `eslint` auf die 3 Dateien ✅ Exit 0
- 10 Backend-Tests grün (neuer Persist-Test beweist: api_base überlebt model_dump, **kein** Feld-Leak bei anderen Providern)

Folge-PR zu #370.