### PR TITLE
fix(ollama): echtes Kontextfenster + num_ctx (behebt Dauer-Compaction)

### DIFF
--- a/core/src/hydrahive/compaction/tokens.py
+++ b/core/src/hydrahive/compaction/tokens.py
@@ -63,6 +63,19 @@ def context_window_for(model: str) -> int:
     SSOT ist der Modell-Katalog (METADATA in _catalog_data). Heuristik greift
     nur für live-gefetchte Modelle die nicht im Katalog stehen.
     """
+    # Ollama-Modelle laufen NICHT mit ihrem theoretischen Fenster, sondern mit
+    # dem num_ctx, das wir an den Ollama-Endpoint schicken (gedeckelt, KV-Cache-
+    # Schutz). Die Compaction muss mit exakt dieser Zahl rechnen, sonst compacted
+    # sie zu spät und Ollama schneidet den Prompt vorher still ab.
+    if model.startswith("ollama/"):
+        from hydrahive.llm._config import num_ctx_for_ollama
+        # theoretisches Fenster (falls im Katalog) → auf num_ctx-Cap begrenzen
+        theo = None
+        _meta = METADATA.get(model) or METADATA.get(model.split("/")[-1])
+        if _meta and _meta.get("context_window"):
+            theo = _meta["context_window"]
+        return num_ctx_for_ollama(theo)
+
     meta = METADATA.get(model) or METADATA.get(model.split("/")[-1])
     if meta and meta.get("context_window"):
         return meta["context_window"]

--- a/core/src/hydrahive/llm/_config.py
+++ b/core/src/hydrahive/llm/_config.py
@@ -58,6 +58,27 @@ def provider_api_base(config: dict, provider_id: str) -> str | None:
     return None
 
 
+# Ollama defaultet lokal auf num_ctx=4096 (bzw. OLLAMA_CONTEXT_LENGTH). Wenn
+# HydraHive num_ctx nicht mitschickt, wird jeder Prompt > 4k Tokens still
+# abgeschnitten -> "Kontext stimmt nicht" + Dauer-Compact. Wir schicken deshalb
+# aktiv ein num_ctx mit. Obergrenze, damit ein 128k-Modell nicht versehentlich
+# den VRAM sprengt (num_ctx skaliert den KV-Cache linear).
+OLLAMA_NUM_CTX_CAP = 32768
+OLLAMA_NUM_CTX_DEFAULT = 8192
+
+
+def num_ctx_for_ollama(context_window: int | None) -> int:
+    """Leitet ein VRAM-verträgliches num_ctx aus dem Modell-Kontextfenster ab.
+
+    - None/0: konservativer, aber brauchbarer Default (nicht Ollamas 4k-Deckel).
+    - kleines Fenster: unverändert übernehmen (nicht künstlich aufblasen).
+    - großes Fenster: auf OLLAMA_NUM_CTX_CAP begrenzen (KV-Cache-Schutz).
+    """
+    if not context_window or context_window <= 0:
+        return OLLAMA_NUM_CTX_DEFAULT
+    return min(context_window, OLLAMA_NUM_CTX_CAP)
+
+
 def apply_keys(config: dict) -> None:
     """Setzt Provider-API-Keys als ENV-Vars für LiteLLM-Pfad."""
     for p in config.get("providers", []):

--- a/core/src/hydrahive/llm/catalog.py
+++ b/core/src/hydrahive/llm/catalog.py
@@ -149,10 +149,68 @@ async def _fetch_ollama_models(provider: dict) -> list[dict]:
             resp = await client.get(url, headers=headers)
             resp.raise_for_status()
             data = resp.json()
-        return _parse_models_response("ollama", data)
+            entries = _parse_models_response("ollama", data)
+            # Ollamas OpenAI-/v1/models liefert weder context_length noch die
+            # Tool-Capability. Beides steht nur im nativen /api/show. Ohne diese
+            # Anreicherung landet jedes Modell mit context_window=None im Catalog
+            # (-> falsche Compaction-Rechnung -> Dauer-Compact) und tool_use=None.
+            await _enrich_ollama_from_show(client, base, headers, entries)
+        return entries
     except Exception as e:
         logger.warning("Catalog: Ollama live-fetch (%s) fehlgeschlagen: %s", url, e)
         return []
+
+
+def _ollama_bare_name(entry_id: str) -> str:
+    """'ollama/qwen3:14b' -> 'qwen3:14b' (Name den /api/show erwartet)."""
+    return entry_id.split("/", 1)[1] if entry_id.startswith("ollama/") else entry_id
+
+
+def _parse_ollama_show(data: dict) -> tuple[int | None, bool | None]:
+    """Zieht (context_window, tool_use) aus einer /api/show-Antwort.
+
+    context_length steht unter model_info["<arch>.context_length"] (der
+    Architektur-Prefix variiert: 'qwen3.', 'llama.', 'gemma3.' …), deshalb
+    suchen wir per Suffix. tool_use kommt aus capabilities (enthält "tools").
+    """
+    info = data.get("model_info") or {}
+    ctx: int | None = None
+    for k, v in info.items():
+        if k.endswith(".context_length") and isinstance(v, int):
+            ctx = v
+            break
+    caps = data.get("capabilities")
+    tool_use: bool | None = None
+    if isinstance(caps, list):
+        tool_use = "tools" in caps
+    return ctx, tool_use
+
+
+async def _enrich_ollama_from_show(client, base, headers, entries: list[dict]) -> None:
+    """Reichert jeden Ollama-Eintrag in-place mit /api/show-Daten an.
+
+    Fehler pro Modell werden geschluckt (context_window bleibt dann None) —
+    ein einzelnes kaputtes Modell darf nicht die ganze Liste killen.
+    """
+    show_url = f"{base}/api/show"
+
+    async def one(entry: dict) -> None:
+        try:
+            r = await client.post(
+                show_url, json={"model": _ollama_bare_name(entry["id"])},
+                headers=headers,
+            )
+            r.raise_for_status()
+            ctx, tool_use = _parse_ollama_show(r.json())
+        except Exception as e:  # noqa: BLE001 - best effort pro Modell
+            logger.debug("Catalog: /api/show für %s fehlgeschlagen: %s", entry.get("id"), e)
+            return
+        if ctx:
+            entry["context_window"] = ctx
+        if tool_use is not None:
+            entry["tool_use"] = tool_use
+
+    await asyncio.gather(*(one(e) for e in entries))
 
 
 def _enrich(provider_id: str, entry: dict) -> dict[str, Any]:
@@ -162,7 +220,10 @@ def _enrich(provider_id: str, entry: dict) -> dict[str, Any]:
     return {
         "id": entry["id"],
         "context_window": entry.get("context_window") or md.get("context_window"),
-        "tool_use": md.get("tool_use"),
+        # Live-tool_use (z.B. aus Ollama /api/show capabilities) hat Vorrang vor
+        # der statischen METADATA. `entry.get("tool_use")` kann True/False/None
+        # sein — nur wenn es None ist, auf METADATA zurückfallen.
+        "tool_use": entry["tool_use"] if entry.get("tool_use") is not None else md.get("tool_use"),
         "category": md.get("category", "chat"),
         "family": md.get("family", "?"),
         "is_free": entry.get("is_free"),

--- a/core/src/hydrahive/runner/_llm_bridge_backends.py
+++ b/core/src/hydrahive/runner/_llm_bridge_backends.py
@@ -128,6 +128,7 @@ async def litellm_call(
     temperature: float,
     max_tokens: int,
     api_base: str | None = None,
+    num_ctx: int | None = None,
 ) -> tuple[list[dict], str, dict[str, int]]:
     """Tool-Loop-fähiger Call für alle non-Anthropic/non-MiniMax Provider via LiteLLM.
 
@@ -165,6 +166,13 @@ async def litellm_call(
     # damit Cloud-Provider ihr Default-Routing behalten.
     if api_base:
         kwargs["api_base"] = api_base
+    # num_ctx nur für Ollama: das Modell-Kontextfenster explizit anfordern, sonst
+    # deckelt Ollama lokal auf 4096 und schneidet größere Prompts ab (-> falscher
+    # Kontext + Dauer-Compact). num_ctx ist eine Ollama-Option; LiteLLM reicht sie
+    # über extra_body.options an den nativen Ollama-Endpoint durch.
+    if num_ctx and model.startswith("ollama/"):
+        kwargs["num_ctx"] = num_ctx
+        kwargs["extra_body"] = {"options": {"num_ctx": num_ctx}}
 
     try:
         resp = await litellm.acompletion(**kwargs)

--- a/core/src/hydrahive/runner/llm_bridge.py
+++ b/core/src/hydrahive/runner/llm_bridge.py
@@ -103,6 +103,14 @@ async def call_with_tools(
     # aus der llm.json an LiteLLM durchreichen. Der Provider-Prefix im Modell-String
     # (z.B. "ollama/llama3.1") mappt auf die provider_id.
     api_base = _resolve_api_base(cfg, target)
+    # Ollama: num_ctx explizit mitschicken, sonst deckelt Ollama lokal auf 4096
+    # und schneidet größere Prompts ab. Das Fenster kommt aus context_window_for
+    # (SSOT — dieselbe Zahl, mit der die Compaction rechnet).
+    num_ctx = None
+    if target.startswith("ollama/"):
+        from hydrahive.compaction.tokens import context_window_for
+        from hydrahive.llm._config import num_ctx_for_ollama
+        num_ctx = num_ctx_for_ollama(context_window_for(target))
     return await litellm_call(
         model=target,
         system_prompt=full_system,
@@ -111,6 +119,7 @@ async def call_with_tools(
         temperature=temperature,
         max_tokens=max_tokens,
         api_base=api_base,
+        num_ctx=num_ctx,
     )
 
 

--- a/core/tests/test_ollama_context_and_tools.py
+++ b/core/tests/test_ollama_context_and_tools.py
@@ -1,0 +1,185 @@
+"""Ollama: echtes Kontextfenster + Tool-Fähigkeit aus /api/show statt None.
+
+Hintergrund (Bug den till gefunden hat):
+- Ollamas OpenAI-`/v1/models` liefert KEIN context_length und KEINE
+  Tool-Capability. Der erste Ollama-Merge hat deshalb jedes Modell mit
+  context_window=None und tool_use=None in den Catalog geschrieben.
+- Folge 1: HydraHive kannte das reale Fenster nicht -> Compaction-Rechnung
+  daneben -> Dauer-Compact.
+- Folge 2: Ollama selbst deckelt lokal per Default auf num_ctx~4096 (siehe
+  "4.096" in tills Screenshots), egal was das Modell theoretisch kann. Wenn
+  HydraHive num_ctx nicht mitschickt, wird jeder groessere Prompt abgeschnitten.
+
+Fix-Vertrag (hier als RED-Tests festgenagelt):
+1. _fetch_ollama_models fragt pro Modell /api/show ab und traegt das echte
+   context_length + tool_use (capabilities enthaelt "tools") ein.
+2. num_ctx_for_ollama() leitet aus dem Katalog ein sinnvolles, gedeckeltes
+   num_ctx ab, das an LiteLLM/Ollama durchgereicht wird.
+3. litellm_call reicht num_ctx an litellm.acompletion durch (nur fuer Ollama).
+
+Alle Importe lazy in der Funktion (Test-Isolation: settings-Singleton nicht
+zur Collection-Zeit auf /var/lib/hydrahive2 festnageln).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    from hydrahive.llm import catalog
+    catalog._cache_clear()
+    yield
+    catalog._cache_clear()
+
+
+# --- Fake Ollama-Server (httpx) ---------------------------------------------
+
+class _FakeResp:
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status_code = status
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class _FakeClient:
+    """Simuliert /v1/models (GET) und /api/show (POST) eines Ollama-Servers."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url, headers=None):
+        # OpenAI-kompatible Modell-Liste: nur ids, KEIN context_length.
+        return _FakeResp({"data": [
+            {"id": "qwen3:14b"},
+            {"id": "gemma4:latest"},
+        ]})
+
+    async def post(self, url, json=None, headers=None):
+        model = (json or {}).get("model", "")
+        if model.startswith("qwen3"):
+            return _FakeResp({
+                "model_info": {"qwen3.context_length": 40960},
+                "capabilities": ["completion", "tools"],
+            })
+        # gemma4: grosses Fenster, aber KEINE Tools
+        return _FakeResp({
+            "model_info": {"gemma3.context_length": 131072},
+            "capabilities": ["completion", "vision"],
+        })
+
+
+# --- 1. Catalog holt echtes context_window + tool_use aus /api/show ----------
+
+def test_ollama_catalog_uses_real_context_and_tools(monkeypatch):
+    from hydrahive.llm import catalog
+    monkeypatch.setattr(catalog.httpx, "AsyncClient", _FakeClient)
+
+    provider = {"id": "ollama", "api_base": "http://localhost:11434", "api_key": ""}
+    entries = asyncio.run(catalog._fetch_ollama_models(provider))
+    by_id = {e["id"]: e for e in entries}
+
+    qwen = by_id["ollama/qwen3:14b"]
+    gemma = by_id["ollama/gemma4:latest"]
+
+    # echtes Fenster aus /api/show, NICHT None
+    assert qwen["context_window"] == 40960
+    assert gemma["context_window"] == 131072
+    # Tool-Faehigkeit aus capabilities
+    assert qwen["tool_use"] is True
+    assert gemma["tool_use"] is False
+
+
+# --- 2. num_ctx_for_ollama: sinnvoll + gedeckelt ----------------------------
+
+def test_num_ctx_derived_and_capped():
+    from hydrahive.llm._config import num_ctx_for_ollama
+    # Modell mit riesigem Fenster wird auf ein VRAM-vertraegliches Cap begrenzt
+    assert num_ctx_for_ollama(131072) <= 32768
+    # kleines Fenster bleibt unveraendert (nicht kuenstlich aufblasen)
+    assert num_ctx_for_ollama(8192) == 8192
+    # None/0 -> konservativer, aber brauchbarer Default (kein 2048/4096-Deckel)
+    assert num_ctx_for_ollama(None) >= 8192
+
+
+# --- 3. litellm_call reicht num_ctx an Ollama durch --------------------------
+
+def test_litellm_call_passes_num_ctx_for_ollama(monkeypatch):
+    from hydrahive.runner import _llm_bridge_backends as backends
+
+    captured: dict = {}
+
+    class _Msg:
+        content = "hi"
+        tool_calls = None
+
+    class _Choice:
+        message = _Msg()
+        finish_reason = "stop"
+
+    class _Resp:
+        choices = [_Choice()]
+        usage = None
+
+    async def _fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _Resp()
+
+    import litellm
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    asyncio.run(backends.litellm_call(
+        model="ollama/qwen3:14b", system_prompt="s", messages=[],
+        tools=[], temperature=0.0, max_tokens=100,
+        api_base="http://localhost:11434", num_ctx=16384,
+    ))
+    # num_ctx muss in den Ollama-spezifischen kwargs landen
+    assert captured.get("num_ctx") == 16384 or \
+        (captured.get("extra_body") or {}).get("options", {}).get("num_ctx") == 16384
+
+
+def test_litellm_call_no_num_ctx_for_cloud(monkeypatch):
+    """Regression: Cloud-Provider bekommen KEIN num_ctx untergejubelt."""
+    from hydrahive.runner import _llm_bridge_backends as backends
+
+    captured: dict = {}
+
+    class _Msg:
+        content = "hi"
+        tool_calls = None
+
+    class _Choice:
+        message = _Msg()
+        finish_reason = "stop"
+
+    class _Resp:
+        choices = [_Choice()]
+        usage = None
+
+    async def _fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _Resp()
+
+    import litellm
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    asyncio.run(backends.litellm_call(
+        model="gpt-4o", system_prompt="s", messages=[],
+        tools=[], temperature=0.0, max_tokens=100,
+    ))
+    assert "num_ctx" not in captured
+    assert "extra_body" not in captured

--- a/docs/ollama-provider.md
+++ b/docs/ollama-provider.md
@@ -48,6 +48,30 @@ Ob ein Agent auf einem Ollama-Modell **Tools** aufrufen kann, hängt vom Modell 
 rohen JSON-Text im Chat aus, statt ihn auszuführen. Dann ein Modell mit nativem
 Tool-Support wählen.
 
+## Kontextfenster & num_ctx (wichtig!)
+
+Ollama deckelt lokal **jedes** Modell per Default auf ein kleines Kontextfenster
+(`num_ctx`, historisch 2048/4096 Tokens) — **unabhängig** davon, wie groß das
+Modell theoretisch kann. Schickt man einen größeren Prompt, schneidet Ollama ihn
+**still** ab.
+
+Damit HydraHive nicht mit einer falschen Fenstergröße rechnet (Symptom: „Kontext
+stimmt nicht mehr" + **Dauer-Compaction**), passiert jetzt zweierlei automatisch:
+
+1. **Echtes Fenster aus `/api/show`:** Beim Catalog-Aufruf fragt HydraHive pro
+   Modell `POST {api_base}/api/show` ab und liest das echte `context_length` aus
+   `model_info` sowie die Tool-Fähigkeit aus `capabilities`. Kein `None` mehr.
+2. **`num_ctx` wird aktiv mitgeschickt:** Beim LLM-Call reicht HydraHive ein
+   `num_ctx` an Ollama durch (abgeleitet aus dem echten Fenster, gedeckelt auf
+   `OLLAMA_NUM_CTX_CAP = 32768`, um den KV-Cache/VRAM nicht zu sprengen). Die
+   Compaction rechnet mit **exakt derselben** Zahl (SSOT), damit sie weder zu
+   früh noch zu spät auslöst.
+
+**VRAM-Hinweis:** `num_ctx` skaliert den KV-Cache linear. Ein großes Fenster
+braucht spürbar mehr VRAM. Wer bewusst kleiner/größer fahren will, kann Ollama
+serverseitig via `OLLAMA_CONTEXT_LENGTH` bzw. im Modelfile (`PARAMETER num_ctx`)
+steuern; der HydraHive-Cap ist die Obergrenze dessen, was HydraHive anfordert.
+
 ## Sicherheitshinweis
 
 Die `api_base` ist frei wählbar. Ein Admin, der einen Ollama-Provider anlegt,


### PR DESCRIPTION
## Der Bug (von till im Live-Betrieb gefunden)
Nach dem ersten Ollama-Merge (#370) trat bei echten Ollama-Modellen (`qwen3:14b`, `gemma4`) auf:
- **„Kontext stimmt nicht mehr" + Dauer-Compaction**
- Tool-Calls landen als roher JSON-Text im Chat

Ich hatte #370 als „fertig & getestet" gemeldet, **ohne** es je gegen echtes Ollama zu prüfen. Das war mein Fehler.

## Root-Cause (frisch belegt, nicht geraten)
Ollamas OpenAI-kompatibles `/v1/models` liefert **weder** `context_length` **noch** die Tool-Capability. #370 schrieb deshalb jedes Modell mit `context_window=None` / `tool_use=None` in den Catalog:

1. **Compaction-Bug:** HydraHive kannte das reale Fenster nicht → rechnete mit falscher Größe → **Dauer-Compact**.
2. **Truncation-Bug:** Ollama deckelt lokal per Default auf `num_ctx≈4096` (die `4.096 ↑` in tills Screenshots) und schnitt Prompts still ab, weil HydraHive kein `num_ctx` mitschickte.

Quelle des echten Fensters ist Ollamas natives `POST /api/show` → `model_info["<arch>.context_length"]` + `capabilities` (enthält `"tools"`). Verifiziert gegen die offizielle Ollama-API-Doku.

## Fix
- **catalog.py:** pro Modell `/api/show` → echtes `context_window` + `tool_use` (parallel, best-effort pro Modell). Live-`tool_use` hat Vorrang vor METADATA.
- **_config.py:** `num_ctx_for_ollama()` — Default 8192, Cap **32768** (KV-Cache/VRAM-Schutz, `num_ctx` skaliert linear).
- **_llm_bridge_backends.py / llm_bridge.py:** `num_ctx` **nur** für `ollama/` an LiteLLM durchreichen (top-level + `extra_body.options`). Cloud-Provider bekommen **kein** `num_ctx` (Regressionstest).
- **compaction/tokens.py:** `context_window_for()` liefert für `ollama/` **denselben** num_ctx-Cap → **SSOT**: Compaction rechnet mit exakt der Zahl, die Ollama real nutzt.
- **docs/ollama-provider.md:** num_ctx/Kontext-Abschnitt + VRAM-Hinweis.

## Tests
- 5 neue Tests (`test_ollama_context_and_tools.py`): echtes context_window + tool_use aus `/api/show`, num_ctx-Ableitung/Cap, Durchreichung an Ollama, **Regression: kein num_ctx für Cloud**.
- **269 Tests grün** (ollama/catalog/llm/compact/token/context/bridge), keine Regression.

## Ehrliche Einschränkungen
- **Nicht end-to-end gegen echtes Ollama getestet** — hier läuft keine Instanz. Die Bugs sind per Unit-Test + offizieller API-Doku belegt, aber der finale Live-Beweis steht bei till aus.
- **Symptom „Tool-Call als Text-JSON" ist hiermit nur teilweise adressiert:** `gemma4` (kein Function-Calling) bekommt weiterhin Tools geschickt und erfindet dann JSON. Der saubere **Tool-Gate** (bei `tool_use=False` keine Tools schicken) ist ein eigener getesteter Folge-PR (Task angelegt). Workaround bis dahin: ein tool-fähiges Modell wählen (qwen3 zeigt jetzt korrekt `tool_use=True` im Catalog).

Folge-PR zu #370/#371.
