### PR TITLE
fix(registry): unvollständige Modell-Liste nicht cachen (nur 5-6 Modelle im Projekt-Dialog)

### DIFF
--- a/core/src/hydrahive/llm/registry.py
+++ b/core/src/hydrahive/llm/registry.py
@@ -78,11 +78,22 @@ def _add(acc: dict[str, ModelEntry], entry: ModelEntry) -> None:
         )
 
 
-async def _build() -> list[ModelEntry]:
+async def _build() -> tuple[list[ModelEntry], bool]:
+    """Baut die kanonische Modell-Liste. Gibt (modelle, complete) zurück.
+
+    `complete` ist False, wenn ein konfigurierter Chat-Provider 0 Modelle
+    beisteuerte (transienter Live-Fetch-Fehler ohne STATIC-Fallback, z.B.
+    openai/openrouter). Eine unvollständige Liste darf NICHT gecacht werden —
+    sonst hängt für die Cache-TTL eine Rumpf-Auswahl in allen Pickern
+    (Bug: „Neues Projekt" zeigte nur 5-6 Modelle).
+    """
     acc: dict[str, ModelEntry] = {}
     providers = _providers()
+    complete = True
     try:
-        for prov in await catalog_for_providers(providers):
+        cat = await catalog_for_providers(providers)
+        for prov in cat:
+            n_before = len(acc)
             for m in prov.get("models", []):
                 mid = m.get("id", "")
                 if not mid:
@@ -93,8 +104,18 @@ async def _build() -> list[ModelEntry]:
                     context_window=m.get("context_window"), is_free=m.get("is_free"),
                     source="live" if prov.get("live_count") else "fallback",
                 ))
+            # Ein konfigurierter Provider, der KEIN einziges Modell beitrug, gilt
+            # als (transient) fehlgeschlagen -> Build ist unvollständig.
+            if len(acc) == n_before and not prov.get("models"):
+                complete = False
+                logger.warning(
+                    "Registry: Provider %s lieferte 0 Modelle — Build unvollständig, "
+                    "wird nicht gecacht (Retry beim nächsten Aufruf).",
+                    prov.get("provider_id", "?"),
+                )
     except Exception as e:
         logger.warning("Registry: Chat-Katalog-Build fehlgeschlagen: %s", e)
+        complete = False
     try:
         for em in _embed_models():
             _add(acc, ModelEntry(id=em["model"], provider=em.get("provider", ""),
@@ -116,7 +137,7 @@ async def _build() -> list[ModelEntry]:
     await _modality(list_speech_models, "tts")
     await _modality(list_transcribe_models, "stt")
     await _modality(list_video_models, "video")
-    return sorted(acc.values(), key=lambda e: (e.provider, e.label))
+    return sorted(acc.values(), key=lambda e: (e.provider, e.label)), complete
 
 
 async def list_models(modality: str | None = None) -> list[ModelEntry]:
@@ -126,8 +147,11 @@ async def list_models(modality: str | None = None) -> list[ModelEntry]:
     if _cache is None or now - _cache[0] >= _CACHE_TTL:
         async with _lock:
             if _cache is None or time.monotonic() - _cache[0] >= _CACHE_TTL:
-                built = await _build()
-                if built:                       # leere Liste NICHT cachen → nächster Aufruf retryt
+                built, complete = await _build()
+                # Nur eine VOLLSTÄNDIGE, nicht-leere Liste cachen. Eine Teil-Liste
+                # (ein Provider transient leer) würde sonst für die Cache-TTL in
+                # allen Pickern hängen — genau der „nur 5-6 Modelle"-Bug.
+                if built and complete:
                     _cache = (time.monotonic(), built)
                 else:
                     _cache = None

--- a/core/tests/test_registry_build.py
+++ b/core/tests/test_registry_build.py
@@ -57,7 +57,7 @@ def test_is_known_empty_cache_is_failopen(monkeypatch):
 @pytest.mark.asyncio
 async def test_empty_build_not_cached(monkeypatch):
     from hydrahive.llm import registry
-    async def empty_build(): return []
+    async def empty_build(): return [], True
     monkeypatch.setattr(registry, "_build", empty_build)
     registry.invalidate()
     assert await registry.list_models() == []

--- a/core/tests/test_registry_invalidate.py
+++ b/core/tests/test_registry_invalidate.py
@@ -7,7 +7,7 @@ async def test_invalidate_clears_cache(monkeypatch):
     from hydrahive.llm.registry import ModelEntry
 
     async def fake_build():
-        return [ModelEntry("a", "p", "a", frozenset({"chat"}))]
+        return [ModelEntry("a", "p", "a", frozenset({"chat"}))], True
 
     monkeypatch.setattr(registry, "_build", fake_build)
     registry.invalidate()

--- a/core/tests/test_registry_partial_cache.py
+++ b/core/tests/test_registry_partial_cache.py
@@ -1,0 +1,104 @@
+"""Registry darf keine UNVOLLSTÄNDIGE Modell-Liste cachen.
+
+Bug (von till gefunden): Beim „Neues Projekt"-Dialog erschienen nur 5-6 Modelle
+(ein paar Claude/GPT, 1-2 OpenRouter) statt der vollen Liste — während die
+Agenten-Einstellungen alle zeigten.
+
+Root-Cause: Wenn ein konfigurierter Cloud-Provider (z.B. OpenRouter/OpenAI)
+transient fehlschlägt, liefert catalog_for_providers für ihn 0 Modelle (der
+STATIC-Fallback ist für openai/openrouter leer). Die restliche Teil-Liste
+(z.B. nur die 9 statischen Claude-Modelle) ist aber NICHT leer -> _build gab
+sie zurück und der alte Cache-Guard (`if built:`) cachte sie für 5 Minuten.
+Wer in diesem Fenster einen Picker öffnete, sah die Rumpf-Liste.
+
+Vertrag (RED): Wenn ein konfigurierter Provider 0 Modelle beisteuert, gilt der
+Build als unvollständig und wird NICHT gecacht — der nächste Aufruf retryt.
+
+Imports lazy in der Funktion (Test-Isolation).
+"""
+from __future__ import annotations
+
+import asyncio
+
+
+def _reset_registry():
+    from hydrahive.llm import registry
+    registry._cache = None
+    return registry
+
+
+def test_partial_catalog_is_not_cached(monkeypatch):
+    registry = _reset_registry()
+
+    providers = [
+        {"id": "anthropic", "api_key": "sk-a"},
+        {"id": "openrouter", "api_key": "sk-o"},
+    ]
+    monkeypatch.setattr(registry, "_providers", lambda: providers)
+    monkeypatch.setattr(registry, "_embed_models", lambda: [])
+
+    calls = {"n": 0}
+
+    async def _fake_catalog(_provs):
+        calls["n"] += 1
+        # 1. Aufruf: openrouter transient leer (Fetch-Fehler, leerer STATIC-Fallback)
+        # 2. Aufruf: openrouter liefert wieder Modelle
+        if calls["n"] == 1:
+            return [
+                {"provider_id": "anthropic", "live_count": 9,
+                 "models": [{"id": "claude-opus-4-8"}, {"id": "claude-sonnet-4-6"}]},
+                {"provider_id": "openrouter", "live_count": 0, "models": []},
+            ]
+        return [
+            {"provider_id": "anthropic", "live_count": 9,
+             "models": [{"id": "claude-opus-4-8"}, {"id": "claude-sonnet-4-6"}]},
+            {"provider_id": "openrouter", "live_count": 300,
+             "models": [{"id": f"openrouter/m{i}"} for i in range(300)]},
+        ]
+
+    monkeypatch.setattr(registry, "catalog_for_providers", _fake_catalog)
+
+    async def _noop():
+        return []
+    monkeypatch.setattr(registry, "list_speech_models", _noop)
+    monkeypatch.setattr(registry, "list_transcribe_models", _noop)
+    monkeypatch.setattr(registry, "list_video_models", _noop)
+
+    # 1. Aufruf: unvollständig -> NICHT gecacht
+    first = asyncio.run(registry.list_models("chat"))
+    assert registry._cache is None, "Teil-Liste darf nicht gecacht werden"
+
+    # 2. Aufruf: baut neu (kein Cache-Hit auf die Rumpf-Liste) -> jetzt vollständig
+    second = asyncio.run(registry.list_models("chat"))
+    assert calls["n"] == 2, "unvollständiger Build muss neu bauen statt Cache zu treffen"
+    assert len(second) > len(first)
+    assert len(second) >= 300
+
+
+def test_complete_catalog_is_cached(monkeypatch):
+    """Gegenprobe: vollständiger Build wird gecacht (kein Doppel-Fetch)."""
+    registry = _reset_registry()
+
+    providers = [{"id": "anthropic", "api_key": "sk-a"}]
+    monkeypatch.setattr(registry, "_providers", lambda: providers)
+    monkeypatch.setattr(registry, "_embed_models", lambda: [])
+
+    calls = {"n": 0}
+
+    async def _fake_catalog(_provs):
+        calls["n"] += 1
+        return [{"provider_id": "anthropic", "live_count": 2,
+                 "models": [{"id": "claude-opus-4-8"}, {"id": "claude-sonnet-4-6"}]}]
+
+    monkeypatch.setattr(registry, "catalog_for_providers", _fake_catalog)
+
+    async def _noop():
+        return []
+    monkeypatch.setattr(registry, "list_speech_models", _noop)
+    monkeypatch.setattr(registry, "list_transcribe_models", _noop)
+    monkeypatch.setattr(registry, "list_video_models", _noop)
+
+    asyncio.run(registry.list_models("chat"))
+    asyncio.run(registry.list_models("chat"))
+    assert calls["n"] == 1, "vollständiger Build muss gecacht werden"
+    assert registry._cache is not None


### PR DESCRIPTION
## Symptom (von till gefunden)
Beim „Neues Projekt"-Dialog erschienen nur **5-6 Modelle** (ein paar ChatGPT/Claude, 1-2 OpenRouter) — während die **Agenten-Einstellungen die volle Liste** zeigten. Beide nutzen denselben Endpoint (`GET /api/llm/models?modality=chat`), also war es kein statischer Frontend-Unterschied.

## Root-Cause (frisch belegt, nicht geraten)
Reproduziert gegen die echte Live-Config: Der Registry-Build liefert normal ~490 Chat-Modelle. Aber:

1. Wenn ein konfigurierter Cloud-Provider (**openai** / **openrouter**) einen transienten Live-Fetch-Fehler hat, liefert `catalog_for_providers` für ihn **0 Modelle** — und diese beiden Provider haben **keinen** `STATIC_MODELS`-Fallback (nur anthropic/minimax/openai-codex haben einen).
2. Die verbleibende Rest-Liste (z.B. nur die 9 statischen Anthropic-Modelle — deren Live-Fetch fällt ohnehin mit 401) ist **nicht leer**.
3. Der alte Cache-Guard war `if built:` (= nicht leer) → die **Rumpf-Liste wurde für die volle Cache-TTL (5 min) gecacht**.
4. Wer in dem Fenster einen Picker öffnete, sah die Rumpf-Auswahl; ein späterer Aufruf nach TTL-Ablauf sah wieder alles → **genau die beobachtete Diskrepanz**.

## Fix
`_build()` gibt jetzt `(models, complete)` zurück. `complete=False`, sobald ein **konfigurierter Provider 0 Modelle** beitrug. `list_models()` cacht nur bei `built AND complete` — eine unvollständige Liste wird **nicht** gecacht, der nächste Aufruf baut neu (Retry). Damit kann keine Rumpf-Liste mehr „festhängen".

## Tests
- Neuer RED→GREEN-Test `test_registry_partial_cache.py`: Teil-Liste wird nicht gecacht (Retry baut neu → vollständig); Gegenprobe: vollständiger Build **wird** gecacht (kein Doppel-Fetch).
- Zwei bestehende Mocks an die neue `(list, bool)`-Signatur angepasst.
- **158 Tests grün** (registry/catalog/llm/model), keine Regression.
- Live-Repro gegen die echte Config bestätigt: bei simuliertem OpenRouter-Ausfall bleibt der Cache leer.

## Ehrliche Einschränkung
- Kein End-to-End-Frontend-Test (nur Backend-Logik). Der Effekt ist im Picker sichtbar, sobald ein vollständiger Build durchläuft.
- **Nicht Teil dieses PRs:** dass openai/openrouter keinen STATIC-Fallback haben. Der Cache-Fix ist der richtige Hebel (lieber Retry als eine falsche statische Rumpf-Liste anzeigen). Falls gewünscht, kann ein STATIC-Fallback für openai/openrouter als eigener PR folgen.
