### PR TITLE
feat(containers/vms): Ubuntu 26.04 LTS als Quick-Image

### DIFF
--- a/core/src/hydrahive/containers/models.py
+++ b/core/src/hydrahive/containers/models.py
@@ -54,6 +54,7 @@ MAX_RAM_MB = 32768
 QUICK_IMAGES = [
     "debian/12",
     "debian/13",
+    "ubuntu/26.04",
     "ubuntu/24.04",
     "ubuntu/22.04",
     "alpine/3.21",

--- a/core/src/hydrahive/vms/models.py
+++ b/core/src/hydrahive/vms/models.py
@@ -119,6 +119,7 @@ IMAGE_RE = r"^(?:[a-zA-Z0-9][a-zA-Z0-9-]*:)?[a-zA-Z0-9][a-zA-Z0-9._/-]*$"
 # cloud images; ISO installs and imports stay a local-only workflow.
 VM_QUICK_IMAGES = [
     "images:debian/12",
+    "images:ubuntu/26.04",
     "images:ubuntu/24.04",
     "images:ubuntu/22.04",
     "images:fedora/40",


### PR DESCRIPTION
## Was
Ubuntu **26.04 „resolute" LTS** als Quick-Image-Vorlage im Container- und VM-Management.

## Warum jetzt möglich
26.04 ist im `images:`-Remote bereits verfügbar (Container + VM, Build 2026-07-23) — geprüft via `incus image list images:`. Container/VMs laufen entkoppelt vom Host, der weiterhin auf 24.04 LTS bleibt (kein Host-Upgrade nötig).

## Änderung
- `containers/models.py`: `ubuntu/26.04` in `QUICK_IMAGES` (vor 24.04)
- `vms/models.py`: `images:ubuntu/26.04` in `VM_QUICK_IMAGES` (vor 24.04)

Das Frontend (`CreateContainerDialog`) lädt die Liste dynamisch von der API — **kein Frontend-Change nötig**. Custom-Alias-Eingabe war ohnehin schon möglich; das hier ist nur der bequeme Quick-Pick.

## Verifiziert
- `IMAGE_RE` akzeptiert `ubuntu/26.04` + `images:ubuntu/26.04` ✅
- 19 Tests `test_container_image_validation` grün ✅
- Image im Remote real vorhanden (CONTAINER + VIRTUAL-MACHINE) ✅
