### PR TITLE
feat(video): E1 — VideoBackend-Protocol + Registry (Fundament lokale Backends)

### DIFF
--- a/core/src/hydrahive/llm/video_backends/__init__.py
+++ b/core/src/hydrahive/llm/video_backends/__init__.py
@@ -1,0 +1,35 @@
+"""Video-/Bild-Generierungs-Backends hinter einem gemeinsamen Protocol.
+
+E1-Fundament (Spec: docs/specs/local-video-backends.md). Ziel: die heute hart
+auf OpenRouter verdrahtete Video-Generierung so kapseln, dass lokale Backends
+(ComfyUI, node-lokaler Switch-Wrapper) als weitere Adapter danebentreten können —
+ohne den OpenRouter-Pfad zu ändern.
+
+Öffentliche API:
+- VideoBackend (Protocol), JobRef, JobStatus, VideoModel, VideoParams
+- resolve_backend(model_id, config) -> (backend, provider) — mappt eine Modell-ID
+  auf den zuständigen Adapter. Default (kein `local:`-Prefix) = OpenRouter.
+"""
+from __future__ import annotations
+
+from hydrahive.llm.video_backends._base import (
+    JobRef,
+    JobStatus,
+    VideoBackend,
+    VideoModel,
+    VideoParams,
+)
+from hydrahive.llm.video_backends._registry import (
+    LOCAL_PREFIX,
+    resolve_backend,
+)
+
+__all__ = [
+    "VideoBackend",
+    "JobRef",
+    "JobStatus",
+    "VideoModel",
+    "VideoParams",
+    "resolve_backend",
+    "LOCAL_PREFIX",
+]

--- a/core/src/hydrahive/llm/video_backends/_base.py
+++ b/core/src/hydrahive/llm/video_backends/_base.py
@@ -1,0 +1,91 @@
+"""Protocol + Datentypen für Video-/Bild-Backends.
+
+Ein Backend kapselt einen kompletten Generierungs-Anbieter (OpenRouter, ComfyUI,
+Switch-Wrapper). Der Aufruf-Lebenszyklus ist immer gleich:
+
+    models = await backend.list_models(provider)
+    job    = await backend.submit(provider, model, params)
+    while (st := await backend.poll(provider, job)).state in ("pending","running"):
+        await asyncio.sleep(...)
+    if st.state == "done":
+        data = await backend.fetch_output(provider, job)   # bytes (mp4/png) oder Path
+
+`provider` ist das Config-Dict des jeweiligen Backends aus llm.json
+(media_backends[]). Für OpenRouter ist es ein synthetischer Eintrag ohne
+api_base — der Adapter zieht seinen Key selbst.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+JobState = Literal["pending", "running", "done", "error"]
+Category = Literal["video", "image"]
+
+
+@dataclass(frozen=True)
+class VideoModel:
+    """Ein anbietbares Modell/Workflow im Picker."""
+    id: str                       # z.B. "minimax/hailuo-2.3" oder "local:muskeln1/ltx-t2v"
+    name: str
+    category: Category = "video"
+    durations: list[int] = field(default_factory=list)
+    aspect_ratios: list[str] = field(default_factory=list)
+    frame_images: list[str] = field(default_factory=list)  # z.B. ["first_frame"]
+
+
+@dataclass(frozen=True)
+class VideoParams:
+    """Generierungs-Parameter — backend-neutral."""
+    prompt: str
+    width: int = 1280
+    height: int = 720
+    duration: int = 5
+    aspect_ratio: str = "16:9"
+    seed: int | None = None
+    frames: int | None = None
+    image_url: str | None = None  # Startframe (data-URI/https) für I2V
+
+
+@dataclass(frozen=True)
+class JobRef:
+    """Opaker Job-Handle. Jedes Backend füllt `native_id` mit seiner eigenen ID."""
+    native_id: str
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class JobStatus:
+    state: JobState
+    url: str | None = None       # falls das Ergebnis eine URL ist
+    error: str | None = None
+    message: str | None = None   # z.B. "schalte um / generiere …" (Switch-Wrapper)
+    raw: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class VideoBackend(Protocol):
+    """Gemeinsame Schnittstelle aller Generierungs-Backends.
+
+    Adapter sind zustandslos — der Zustand steckt in `provider` (Config) und
+    `JobRef` (laufender Job).
+    """
+
+    type: str  # "openrouter" | "comfyui" | "switch-http"
+
+    async def list_models(self, provider: dict) -> list[VideoModel]:
+        """Verfügbare Modelle/Workflows. Leere Liste bei Fehler/nicht konfiguriert."""
+        ...
+
+    async def submit(self, provider: dict, model: str, params: VideoParams) -> JobRef:
+        """Startet einen Job. Raises RuntimeError bei Submit-Fehler."""
+        ...
+
+    async def poll(self, provider: dict, job: JobRef) -> JobStatus:
+        """Fragt den Job-Status ab."""
+        ...
+
+    async def fetch_output(self, provider: dict, job: JobRef, dest_dir: Path) -> Path:
+        """Holt das fertige Ergebnis und speichert es in dest_dir. Gibt Pfad zurück."""
+        ...

--- a/core/src/hydrahive/llm/video_backends/_openrouter.py
+++ b/core/src/hydrahive/llm/video_backends/_openrouter.py
@@ -1,0 +1,75 @@
+"""OpenRouter-Video-Backend — kapselt die bestehende _openrouter_video-Logik.
+
+E1: KEIN Verhaltensumbau. Dieser Adapter delegiert 1:1 an die vorhandenen
+Funktionen (submit_video_job/poll_video_job/download_video/list_video_models),
+damit der OpenRouter-Pfad exakt gleich bleibt und nur hinter das Protocol wandert.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from hydrahive.llm.video_backends._base import (
+    JobRef,
+    JobStatus,
+    VideoModel,
+    VideoParams,
+)
+
+
+class OpenRouterVideoBackend:
+    type = "openrouter"
+
+    async def list_models(self, provider: dict) -> list[VideoModel]:
+        from hydrahive.llm.media_models import list_video_models
+        raw = await list_video_models()
+        return [
+            VideoModel(
+                id=m.get("id", ""),
+                name=m.get("name") or m.get("id", ""),
+                category="video",
+                durations=m.get("durations") or [],
+                aspect_ratios=m.get("aspect_ratios") or [],
+                frame_images=m.get("frame_images") or [],
+            )
+            for m in raw if m.get("id")
+        ]
+
+    async def submit(self, provider: dict, model: str, params: VideoParams) -> JobRef:
+        from hydrahive.tools._openrouter_video import openrouter_key, submit_video_job
+        key = openrouter_key()
+        if not key:
+            raise RuntimeError("Kein OpenRouter-Key konfiguriert")
+        job_id = await submit_video_job(
+            params.prompt, model, key=key,
+            width=params.width, height=params.height,
+            duration=params.duration, aspect_ratio=params.aspect_ratio,
+            image_url=params.image_url,
+        )
+        return JobRef(native_id=job_id)
+
+    async def poll(self, provider: dict, job: JobRef) -> JobStatus:
+        from hydrahive.tools._openrouter_video import openrouter_key, poll_video_job
+        res = await poll_video_job(job.native_id, key=openrouter_key())
+        status = (res.get("status") or "pending").lower()
+        state = {
+            "completed": "done", "failed": "error",
+            "processing": "running", "pending": "pending",
+        }.get(status, "pending")
+        return JobStatus(
+            state=state,  # type: ignore[arg-type]
+            url=res.get("url"),
+            error=res.get("error"),
+            raw=res.get("_raw") or {},
+        )
+
+    async def fetch_output(self, provider: dict, job: JobRef, dest_dir: Path) -> Path:
+        from hydrahive.tools._openrouter_video import download_video, openrouter_key
+        # Die URL kommt aus dem letzten poll — der Caller reicht sie via job.extra
+        url = job.extra.get("url")
+        if not url:
+            # Fallback: nochmal pollen, um die aktuelle URL zu holen
+            st = await self.poll(provider, job)
+            url = st.url
+        if not url:
+            raise RuntimeError("Keine Download-URL für fertigen Video-Job")
+        return await download_video(url, dest_dir, key=openrouter_key())

--- a/core/src/hydrahive/llm/video_backends/_registry.py
+++ b/core/src/hydrahive/llm/video_backends/_registry.py
@@ -1,0 +1,64 @@
+"""Backend-Registry + Resolver.
+
+Mappt eine Modell-ID auf den zuständigen Adapter:
+- "local:<provider_id>/<model>" → lokales Backend (Typ aus media_backends-Config)
+- alles andere                   → OpenRouter (Default, Rückwärtskompatibilität)
+
+E1 registriert nur OpenRouter. Weitere Adaptertypen (comfyui, switch-http)
+kommen in E2/E4 dazu — hier ist der Erweiterungspunkt (_ADAPTERS).
+"""
+from __future__ import annotations
+
+from hydrahive.llm.video_backends._base import VideoBackend
+from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
+
+LOCAL_PREFIX = "local:"
+
+# Adapter-Fabriken je Backend-Typ. E2/E4 ergänzen "comfyui" / "switch-http".
+_ADAPTERS: dict[str, type] = {
+    "openrouter": OpenRouterVideoBackend,
+}
+
+_openrouter_singleton = OpenRouterVideoBackend()
+
+
+def _media_backends(config: dict) -> list[dict]:
+    """Liste der konfigurierten lokalen Media-Backends aus llm.json."""
+    return config.get("media_backends", []) or []
+
+
+def find_media_backend(config: dict, provider_id: str) -> dict | None:
+    for b in _media_backends(config):
+        if b.get("id", "") == provider_id:
+            return b
+    return None
+
+
+def _backend_for_type(btype: str) -> VideoBackend | None:
+    cls = _ADAPTERS.get(btype)
+    return cls() if cls else None
+
+
+def resolve_backend(model_id: str, config: dict) -> tuple[VideoBackend, dict]:
+    """Findet (Backend-Adapter, Provider-Config) für eine Modell-ID.
+
+    Rückwärtskompatibel: eine ID ohne `local:`-Prefix geht immer an OpenRouter,
+    mit einem synthetischen leeren Provider-Dict.
+
+    Raises:
+        ValueError: local:-ID, deren Provider/Typ nicht (mehr) konfiguriert ist.
+    """
+    if not model_id.startswith(LOCAL_PREFIX):
+        return _openrouter_singleton, {}
+
+    # local:<provider_id>/<rest>
+    rest = model_id[len(LOCAL_PREFIX):]
+    provider_id, _, _ = rest.partition("/")
+    provider = find_media_backend(config, provider_id)
+    if provider is None:
+        raise ValueError(f"Kein Media-Backend '{provider_id}' konfiguriert")
+    btype = provider.get("type", "")
+    backend = _backend_for_type(btype)
+    if backend is None:
+        raise ValueError(f"Unbekannter Media-Backend-Typ '{btype}' (Provider {provider_id})")
+    return backend, provider

--- a/core/tests/test_video_backends_e1.py
+++ b/core/tests/test_video_backends_e1.py
@@ -1,0 +1,111 @@
+"""E1: VideoBackend-Protocol + Registry/Resolver.
+
+Sichert das Fundament aus docs/specs/local-video-backends.md:
+- Resolver mappt Modell-IDs auf den richtigen Adapter (Default = OpenRouter,
+  local:<provider>/... = lokales Backend nach type).
+- OpenRouter-Adapter delegiert 1:1 an die bestehende _openrouter_video-Logik
+  (kein Verhaltensumbau).
+- Unbekannte/nicht konfigurierte local:-IDs -> ValueError (kein stiller Fehler).
+
+Importe lazy in den Funktionen (Test-Isolation).
+"""
+from __future__ import annotations
+
+import asyncio
+
+
+# --- Resolver: Default = OpenRouter ------------------------------------------
+
+def test_resolve_default_is_openrouter():
+    from hydrahive.llm.video_backends import resolve_backend
+    backend, provider = resolve_backend("minimax/hailuo-2.3", {})
+    assert backend.type == "openrouter"
+    assert provider == {}
+
+
+def test_resolve_openrouter_ignores_media_backends():
+    from hydrahive.llm.video_backends import resolve_backend
+    cfg = {"media_backends": [{"id": "muskeln1", "type": "comfyui"}]}
+    backend, _ = resolve_backend("google/veo-3.1", cfg)
+    assert backend.type == "openrouter"
+
+
+# --- Resolver: local: -> lokales Backend -------------------------------------
+
+def test_resolve_local_unknown_provider_raises():
+    from hydrahive.llm.video_backends import resolve_backend
+    try:
+        resolve_backend("local:doesnotexist/ltx-t2v", {"media_backends": []})
+        assert False, "sollte ValueError werfen"
+    except ValueError as e:
+        assert "doesnotexist" in str(e)
+
+
+def test_resolve_local_unknown_type_raises():
+    from hydrahive.llm.video_backends import resolve_backend
+    cfg = {"media_backends": [{"id": "muskeln1", "type": "quantumfoo"}]}
+    try:
+        resolve_backend("local:muskeln1/x", cfg)
+        assert False, "sollte ValueError werfen"
+    except ValueError as e:
+        assert "quantumfoo" in str(e)
+
+
+# --- Typen / Protocol vorhanden ----------------------------------------------
+
+def test_protocol_and_types_exist():
+    from hydrahive.llm.video_backends import (
+        JobRef, JobStatus, VideoBackend, VideoModel, VideoParams,
+    )
+    p = VideoParams(prompt="hello", width=768, height=432, frames=121)
+    assert p.prompt == "hello" and p.frames == 121
+    ref = JobRef(native_id="abc")
+    assert ref.native_id == "abc"
+    st = JobStatus(state="done", url="http://x/y.mp4")
+    assert st.state == "done"
+    m = VideoModel(id="a", name="A", category="video")
+    assert m.category == "video"
+    # OpenRouter-Adapter erfüllt das runtime-checkable Protocol
+    from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
+    assert isinstance(OpenRouterVideoBackend(), VideoBackend)
+
+
+# --- OpenRouter-Adapter delegiert (submit/poll) ------------------------------
+
+def test_openrouter_backend_submit_delegates(monkeypatch):
+    from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
+    from hydrahive.llm.video_backends._base import VideoParams
+    import hydrahive.tools._openrouter_video as ov
+
+    captured = {}
+
+    async def fake_submit(prompt, model, *, key, **kw):
+        captured.update(prompt=prompt, model=model, key=key, **kw)
+        return "job-123"
+
+    monkeypatch.setattr(ov, "submit_video_job", fake_submit)
+    monkeypatch.setattr(ov, "openrouter_key", lambda: "sk-test")
+
+    b = OpenRouterVideoBackend()
+    ref = asyncio.run(b.submit({}, "minimax/hailuo-2.3",
+                               VideoParams(prompt="a cat", duration=10)))
+    assert ref.native_id == "job-123"
+    assert captured["model"] == "minimax/hailuo-2.3"
+    assert captured["duration"] == 10
+
+
+def test_openrouter_backend_poll_maps_state(monkeypatch):
+    from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
+    from hydrahive.llm.video_backends._base import JobRef
+    import hydrahive.tools._openrouter_video as ov
+
+    async def fake_poll(job_id, *, key):
+        return {"status": "completed", "url": "http://x/v.mp4", "error": None, "_raw": {}}
+
+    monkeypatch.setattr(ov, "poll_video_job", fake_poll)
+    monkeypatch.setattr(ov, "openrouter_key", lambda: "sk-test")
+
+    b = OpenRouterVideoBackend()
+    st = asyncio.run(b.poll({}, JobRef(native_id="job-123")))
+    assert st.state == "done"
+    assert st.url == "http://x/v.mp4"

--- a/docs/specs/local-video-backends.md
+++ b/docs/specs/local-video-backends.md
@@ -1,0 +1,271 @@
+# Spec: Lokale Video-/Bild-Backends (ComfyUI + sd-server)
+
+Status: DRAFT — Design-Freigabe ausstehend
+Autor: Buddy (mit till)
+Datum: 2026-07-25
+
+## Problem
+
+Die Video- (und Bild-)Generierung im Atelier ist hart auf **OpenRouter**
+verdrahtet (`llm/media_models.py` → `list_video_models`, `tools/_openrouter_video.py`).
+Der Video-Dialog kann deshalb ausschließlich OpenRouter-Modelle anbieten.
+
+Ein Kunde betreibt **zwei verschiedene lokale Backends** übers Netz:
+
+| Node | Backend | API | Port (Bsp.) | Modelle |
+|------|---------|-----|-------------|---------|
+| Muskeln1 (.78) | **ComfyUI** + LTX-2.3 22B | HTTP-Workflow-API | 8189 | LTX-2.3 (T2V/T2V+A/I2V), SDXL/Flux (Bild) |
+| Muskeln2 (.81) | **stable-diffusion.cpp** (`sd-server`) | HTTP-API (`--host 0.0.0.0`) | 8080 | LTX-2.3 GGUF (Video), RealVisXL (Bild) |
+
+Ziel: Der User soll **über die GUI** lokale Backends anlegen und deren Modelle/
+Workflows im Video-Dialog auswählen können — neben den OpenRouter-Modellen.
+Flexibel genug, dass ein **drittes** Backend später nicht alles bricht.
+
+### Wichtig: ComfyUI ist EINE Instanz, Kategorie steckt im Workflow
+
+ComfyUI ist **kein Programm pro Aufgabe**, sondern ein Node-Graph-System. Bild
+UND Video laufen über **dieselbe Instanz auf einem Port** (Muskeln1: 8189).
+Ob Bild oder Video herauskommt, entscheidet **allein der Workflow** (die Nodes):
+
+- **Bild:** `KSampler → VAEDecode → SaveImage`
+- **Video:** `KSampler → VAEDecode → SaveAnimatedWEBP` (+ Audio-Pfad bei T2V+A)
+
+Design-Konsequenz: Die **Kategorie (image/video) ist eine Eigenschaft des
+Workflows, nicht des Backends**. Ein einziges konfiguriertes ComfyUI-Backend
+kann daher sowohl Bild- als auch Video-Workflows bereitstellen — sie tauchen je
+nach `category` im Bild- bzw. Video-Dialog auf. Das output-Node bestimmt zudem
+die Ergebnis-Behandlung (SaveImage→PNG direkt; SaveAnimatedWEBP→WebP-Frames→
+ffmpeg→MP4).
+
+## Nicht-Ziele (bewusst ausgeschlossen)
+
+- Kein SSH-/CLI-Ausführungspfad. Nur HTTP-erreichbare Dienste (`sd-cli` direkt
+  wird NICHT unterstützt — dafür gibt es `sd-server`).
+- Keine automatische Workflow-Konvertierung UI→API-Format in v1 (der User
+  hinterlegt Workflows im **API-Format**; ComfyUI: „Save (API Format)"). Ein
+  optionaler Konverter kann später folgen.
+- Keine GPU-/VRAM-Verwaltung durch HydraHive — das regelt das Backend selbst.
+
+## Architektur: Backend-Typ + Adapter-Pattern
+
+Vorbild: bestehendes Adapter-Pattern in `communication/base.py`
+(Protocol/ABC + konkrete Adapter je Backend) und die **Ollama-Provider-UX**
+(Provider mit `api_base` in `llm.json`, GUI-konfigurierbar).
+
+### VideoBackend-Protocol (core)
+
+```python
+class VideoBackend(Protocol):
+    async def list_models(provider: dict) -> list[MediaModel]: ...
+    async def submit(provider, model, prompt, params, image_url=None) -> JobRef: ...
+    async def poll(provider, job: JobRef) -> JobStatus: ...   # pending|done|error + output-ref
+    async def fetch_output(provider, job) -> bytes|Path: ...  # Roh-Output holen
+```
+
+Konkrete Adapter:
+- `OpenRouterVideoBackend` — bestehender Code, refactored hinter das Protocol.
+- `ComfyUIVideoBackend` — `POST /prompt` (Workflow-Graph mit Platzhaltern),
+  `GET /history/{id}` (poll), `GET /view?...` (WebP/FLAC holen) →
+  ffmpeg-Konvertierung zu MP4 (die Kette existiert schon im media_workspace).
+- `SwitchHttpVideoBackend` — spricht den node-lokalen Switch-Wrapper auf
+  Muskeln2 (submit/poll/fetch), der intern Ollama↔sd-server umschaltet. Der
+  Wrapper (Kunde/Mia) kapselt die VRAM-Orchestrierung + sicheren Vulkan-Flags.
+  (Ein direkter `SdServerVideoBackend` ohne Wrapper wäre nur sinnvoll, wenn
+  sd-server dauerhaft liefe — hier NICHT der Fall wegen VRAM-Konflikt mit Ollama.)
+
+### Config in llm.json (GUI-verwaltet)
+
+Neuer Provider-Typ neben den LLM-Providern — Wiederverwendung der
+Ollama-`api_base`-Mechanik:
+
+```json
+{
+  "media_backends": [
+    {
+      "id": "muskeln1-comfy",
+      "type": "comfyui",
+      "name": "Muskeln1 ComfyUI (LTX-2.3)",
+      "api_base": "http://192.168.1.78:8189",
+      "workflows": [
+        {
+          "id": "ltx-t2v",
+          "label": "LTX-2.3 Text→Video",
+          "category": "video",
+          "output_node": "SaveAnimatedWEBP",
+          "graph": { /* ComfyUI API-Format JSON */ },
+          "placeholders": {
+            "prompt": "6.inputs.text",
+            "seed": "3.inputs.seed",
+            "width": "...", "height": "...", "frames": "..."
+          },
+          "durations": [5, 10], "aspect_ratios": ["16:9","9:16"],
+          "frame_images": ["first_frame"]
+        },
+        {
+          "id": "sdxl-image",
+          "label": "SDXL Text→Bild",
+          "category": "image",
+          "output_node": "SaveImage",
+          "graph": { /* ComfyUI API-Format JSON */ },
+          "placeholders": { "prompt": "...", "seed": "...", "width": "...", "height": "..." }
+        }
+      ]
+    },
+    {
+      "id": "muskeln2-sd",
+      "type": "switch-http",
+      "name": "Muskeln2 (RealVisXL / LTX-GGUF, On-Demand-Switch)",
+      "api_base": "http://muskeln2:9700",
+      "note": "Wrapper schaltet Ollama<->sd-server; Modelle via GET /models live"
+    }
+  ]
+}
+```
+
+Modell-ID-Schema im Dialog: `local:<provider_id>/<workflow_or_model_id>`
+(analog zu `ollama/…`). So bleiben lokale und OpenRouter-Modelle unterscheidbar
+und im selben Dropdown mischbar.
+
+## Muskeln2 (.81): VRAM-Konflikt & On-Demand-Switch (Modus 2 + Option A)
+
+**Entschieden (till + Kunde/Mia, 2026-07-25):** Muskeln2 fährt im Alltag **Ollama**
+(Sprachmodell). Bild/Video über sd-server ist nur möglich, wenn Ollama **entladen**
+ist — VRAM ist ein Nullsummenspiel (Radeon VII 16GB + RX 470 8GB, ~30GB RAM,
+`--offload-to-cpu` = System-Freeze). Beides gleichzeitig = OOM/Crash.
+
+Deshalb: **KEIN permanenter sd-server-Service.** Stattdessen ein **node-lokaler
+Switch-Wrapper** (Option A), der die Umschaltung kapselt:
+
+```
+Kill/Unload Ollama → Start sd-server (sichere Vulkan-Flags) → Wait ready
+  → Generate → Fetch result → Kill sd-server → Ollama lädt wieder
+```
+
+### Warum node-lokal (nicht HydraHive orchestriert das direkt)
+Die sicheren Flags sind fragil und hardware-spezifisch:
+`--auto-fit --max-vram vulkan0=15,vulkan1=7 --vae-tiling`, **niemals**
+`--offload-to-cpu`. Dieses Wissen bleibt auf der Node — ein Fehler übers Netz
+würde die Kundenmaschine einfrieren. HydraHive sendet nur „mach Bild/Video",
+der Wrapper weiß, wie er *seine* GPUs sicher bedient.
+
+### Aufgabenteilung
+- **Kunde/Mia baut** den node-lokalen Wrapper auf Muskeln2 (kennt die sicheren
+  Flags am besten). Klein (~HTTP-Dienst), hält Ollama↔sd-server-Umschaltung.
+- **HydraHive baut** den generischen `switch-http`-Adapter, der gegen die unten
+  definierte API spricht — egal was dahinter steckt.
+
+### Wrapper-API-Vertrag (HydraHive spricht GENAU das an)
+Der Wrapper läuft dauerhaft (leichtgewichtig, kein VRAM), Default z.B.
+`http://muskeln2:9700`:
+
+| Endpoint | Zweck | Antwort |
+|----------|-------|---------|
+| `GET  /health` | lebt der Wrapper? aktueller Modus | `{"status":"ok","mode":"ollama\|sd\|switching"}` |
+| `GET  /models` | verfügbare sd-Modelle/Presets | `[{"id","name","category":"image\|video"}]` |
+| `POST /generate` | Job starten (kapselt Ollama-Unload + sd-server-Start) | `{"job_id"}` |
+| `GET  /status/{job_id}` | pollen | `{"state":"pending\|running\|done\|error","message?"}` |
+| `GET  /result/{job_id}` | Ergebnis holen (MP4/PNG bytes oder URL) | binär oder `{"url"}` |
+| `POST /release` (optional) | sd-server beenden, zurück zu Ollama | `{"ok":true}` |
+
+`POST /generate` Payload:
+```json
+{ "model": "realvisxl-image", "category": "image|video",
+  "prompt": "...", "seed": 123, "width": 768, "height": 432,
+  "frames": 121, "image_url": "data:...optional (I2V)" }
+```
+
+Der Wrapper garantiert: Nach `done`/`error` (oder Timeout) schaltet er sd-server
+ab und lässt Ollama wieder laden. HydraHive muss sich **nicht** um VRAM kümmern.
+
+### Adapter `switch-http` (HydraHive-Seite)
+- Config: `{ "type":"switch-http", "api_base":"http://muskeln2:9700" }`
+- `list_models` → `GET /models`; `submit` → `POST /generate`;
+  `poll` → `GET /status/{id}`; `fetch_output` → `GET /result/{id}`.
+- „Verbindung testen" → `GET /health` (zeigt auch den aktuellen `mode`).
+- **Unterschied zu ComfyUI/OpenRouter:** Ein Generate kann Minuten dauern
+  (inkl. Modell-Switch). UI zeigt „schalte um / generiere …" mit dem `mode`.
+
+### Netzwerk-Erreichbarkeit (Mias Hinweis, Modus-2-tauglich)
+- **NUR der Wrapper** (`:9700`) läuft permanent und muss erreichbar sein —
+  sd-server (`:8080`) startet der Wrapper selbst on-demand, ist von außen egal.
+- Empfehlung: `muskeln2` in `/etc/hosts` der Master-Node (oder mDNS
+  `muskeln2.local`), damit die Config einen stabilen Hostnamen nutzt statt IP.
+- Kein Reverse-Proxy nötig für v1 (Direktzugriff Master → Wrapper reicht).
+
+## GUI (alles über die Oberfläche — harte Anforderung)
+
+### 1. Media-Backend-Verwaltung (Admin/Cockpit → LLM/Media-Bereich)
+- **Backend hinzufügen**: Typ wählen (ComfyUI / sd-server), Name, `api_base`.
+- **„Verbindung testen"**-Button: pingt `/object_info` (ComfyUI) bzw. den
+  sd-server-Health-Endpoint → grün/rot + erkannte Version.
+- **ComfyUI — Workflow hinzufügen** (das Herz von Option A, komplett GUI):
+  - Workflow-JSON (API-Format) per **Textfeld einfügen ODER Datei-Upload**.
+  - HydraHive parst den Graphen, listet die Nodes/Felder und lässt den User
+    per Dropdown die **Platzhalter mappen** (welches Feld = Prompt, Seed,
+    Breite, Höhe, Frames, Startbild). Vorschläge automatisch (Heuristik:
+    CLIPTextEncode→prompt, EmptyLatentVideo→frames/w/h, KSampler→seed).
+    → Kein manuelles JSON-Editieren nötig.
+  - Label + Kategorie (video/image) + Dauer-/Seitenverhältnis-Optionen setzen.
+- **sd-server**: Modelle werden (wenn die API es hergibt) live gelistet; sonst
+  trägt der User Modell-Namen + Default-Flags (`--vae-tiling`, `--auto-fit …`)
+  als Preset im UI ein.
+
+### 2. Video-Dialog (Atelier)
+- Modell-Dropdown zeigt **gruppiert**: „OpenRouter", „Muskeln1 (ComfyUI)",
+  „Muskeln2 (sd-server)".
+- Dauer/Seitenverhältnis/Startbild-Felder respektieren die Metadaten des
+  gewählten lokalen Modells (z.B. LTX max ~257 Frames / 768×432 als Grenzen).
+
+## Backend-Flow (submit→poll→convert→save)
+
+1. Dialog schickt `model="local:muskeln1-comfy/ltx-t2v"` + prompt/params.
+2. Router erkennt `local:`-Prefix → wählt Adapter über `type` des Providers.
+3. **ComfyUI**: nimmt das Workflow-`graph`, ersetzt Platzhalter (prompt/seed/
+   frames/w/h/image), `POST /prompt` → `prompt_id`; poll `GET /history/{id}`;
+   Output (WebP-Frames [+FLAC]) via `GET /view` holen → ffmpeg → MP4 in
+   `generated/`. (ffmpeg-Kette existiert bereits in `media_workspace`.)
+4. **sd-server**: submit an dessen HTTP-API, poll, MP4/PNG holen, speichern.
+5. Ergebnis landet wie heute in der Atelier-Galerie/Timeline.
+
+## Sicherheit
+
+- `api_base` ist frei wählbar → SSRF-Fläche (wie beim Ollama-Provider bewusst
+  akzeptiert; Media-Backend anzulegen ist eine Admin-/privilegierte Aktion).
+- Workflow-JSON wird nur an das konfigurierte ComfyUI geschickt, nicht
+  ausgeführt in HydraHive. Größenlimit + JSON-Schema-Validierung beim Upload.
+- Timeouts + Job-Abbruch (lange Video-Renders).
+
+## Akzeptanzkriterien
+
+1. Admin kann in der GUI ein ComfyUI-Backend anlegen, „Verbindung testen" ist grün.
+2. Admin kann per GUI einen LTX-Workflow (API-JSON) hinzufügen und die
+   Platzhalter mappen — ohne JSON-Handarbeit.
+3. Admin kann ein sd-server-Backend anlegen (IP+Port, „Verbindung testen" grün).
+4. Der Atelier-Video-Dialog zeigt lokale Modelle gruppiert neben OpenRouter.
+5. Ein T2V-Job über ComfyUI-LTX läuft durch: submit→poll→ffmpeg→MP4 in Galerie.
+6. OpenRouter-Pfad bleibt unverändert (Regression-Schutz, Tests grün).
+7. Kein konfiguriertes Backend / Backend offline → sauberer Fehler, kein Crash,
+   OpenRouter-Modelle weiterhin wählbar.
+
+## Umsetzungs-Etappen (jede mit Tests, klein & mergebar)
+
+- **E1**: `media_backends`-Config + `VideoBackend`-Protocol + OpenRouter refactored
+  dahinter (kein Verhaltensänderung, reine Struktur). Registry mischt Quellen.
+- **E2**: `ComfyUIVideoBackend` (submit/poll/view + ffmpeg) + Workflow-Template-Modell.
+- **E3**: GUI — Media-Backend-Verwaltung + „Verbindung testen" + Workflow-Upload/Mapping.
+- **E4**: `SwitchHttpVideoBackend` (Adapter gegen den Wrapper-API-Vertrag) +
+  GUI-Preset. Voraussetzung: Kunde/Mia stellt den node-lokalen Wrapper bereit,
+  der den API-Vertrag erfüllt. HydraHive-Adapter ist gegen Mock testbar.
+- **E5**: Video-Dialog: gruppiertes Dropdown + lokale Metadaten/Limits.
+- **E6**: Doku (`docs/local-video-backends.md`) + Live-Test beim Kunden.
+
+## Offene Punkte / Risiken
+
+- **Switch-Wrapper wird vom Kunden/Mia gebaut** gegen den oben definierten
+  API-Vertrag. HydraHive-Adapter kann gegen einen Mock des Vertrags entwickelt+
+  getestet werden — echter End-to-End-Test erst mit fertigem Wrapper. Der
+  interne sd-server-CLI-Aufruf (sichere Vulkan-Flags) ist Sache des Wrappers,
+  NICHT von HydraHive.
+- **ComfyUI UI→API-Format**: v1 verlangt API-Format vom User (Save API Format).
+  Konverter optional als Folge-Feature.
+- **Job-Dauer**: Video-Renders dauern Minuten → async Job-Handling + Timeouts.


### PR DESCRIPTION
## Was
**E1** aus `docs/specs/local-video-backends.md` — das risikolose Fundament für lokale Video-/Bild-Backends (ComfyUI + node-lokaler Switch-Wrapper).

Kapselt die heute hart auf OpenRouter verdrahtete Video-Generierung hinter ein `VideoBackend`-Protocol, damit lokale Backends als weitere Adapter danebentreten können — **ohne Verhaltensänderung** am OpenRouter-Pfad.

## Änderungen
- **`llm/video_backends/_base.py`**: `VideoBackend`-Protocol + backend-neutrale Typen (`JobRef`, `JobStatus`, `VideoModel`, `VideoParams`). Lebenszyklus: `list_models → submit → poll → fetch_output`.
- **`_openrouter.py`**: `OpenRouterVideoBackend` delegiert **1:1** an die bestehende `_openrouter_video`-Logik (submit/poll/download/list) — kein Logik-Umbau.
- **`_registry.py`**: `resolve_backend(model_id, config)` — `local:<provider>/<model>` → Adapter nach `media_backends`-Typ; alles andere → OpenRouter (Default, **rückwärtskompatibel**). Erweiterungspunkt `_ADAPTERS` für E2 (comfyui) / E4 (switch-http).
- **Spec finalisiert**: Modus 2 (On-Demand-Switch) + Option A (node-lokaler Wrapper), Wrapper-API-Vertrag, Aufgabenteilung Kunde/HydraHive.

## Kontext (Kunden-Setup)
- **Muskeln1** (.78): ComfyUI + LTX-2.3, HTTP-Workflow-API (E2)
- **Muskeln2** (.81): stable-diffusion.cpp — VRAM-Konflikt mit Ollama → node-lokaler Switch-Wrapper, den der Kunde/Mia baut; HydraHive spricht nur dessen API-Vertrag (E4)

## Verifiziert
- 7 neue Tests (Resolver-Mapping, Typen, OpenRouter-Delegation) ✅
- 35 bestehende Video/Media-Tests grün — **keine Regression** ✅

## Noch NICHT in diesem PR
- Verdrahtung in `generate_video.py` (kommt mit E2, wenn der erste lokale Adapter existiert — vorher gäbe es nichts zu resolven)
- Der reine Struktur-Charakter macht E1 risikolos mergebar.
