### PR TITLE
feat(video): E2 — ComfyUIVideoBackend (Workflow-Templates + ffmpeg)

### DIFF
--- a/core/src/hydrahive/llm/video_backends/_comfyui.py
+++ b/core/src/hydrahive/llm/video_backends/_comfyui.py
@@ -1,0 +1,211 @@
+"""ComfyUI-Video-/Bild-Backend.
+
+ComfyUI ist ein Node-Graph-System (eine Instanz, mehrere Workflows). Ein
+konfiguriertes Backend (media_backends[]) trägt eine Liste `workflows`, jeder
+mit einem Graph im **API-Format** (`{node_id: {class_type, inputs}}`), einem
+`output_node`-Typ (SaveImage / SaveAnimatedWEBP) und `placeholders`, die Felder
+im Graph adressieren (z.B. "6.inputs.text" = Prompt).
+
+API (verifiziert gegen ComfyUI script_examples):
+  POST /prompt            {"prompt": graph, "client_id": ...} -> {"prompt_id"}
+  GET  /history/{id}      -> {id: {"outputs": {node: {"images"|"gifs": [...] }}}}
+  GET  /view?filename&subfolder&type=output  -> Bytes (PNG / animiertes WebP)
+
+Video-Workflows liefern WebP/Frames -> ffmpeg -> MP4. Bild-Workflows liefern PNG
+direkt.
+"""
+from __future__ import annotations
+
+import copy
+import logging
+import uuid
+from pathlib import Path
+
+import httpx
+
+from hydrahive.llm.video_backends._base import (
+    JobRef,
+    JobStatus,
+    VideoModel,
+    VideoParams,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _api_base(provider: dict) -> str:
+    base = (provider.get("api_base") or "").rstrip("/")
+    if not base:
+        raise RuntimeError("ComfyUI-Backend ohne api_base")
+    return base
+
+
+def _workflows(provider: dict) -> list[dict]:
+    return provider.get("workflows", []) or []
+
+
+def _find_workflow(provider: dict, workflow_id: str) -> dict:
+    for w in _workflows(provider):
+        if w.get("id", "") == workflow_id:
+            return w
+    raise RuntimeError(f"Workflow '{workflow_id}' nicht im ComfyUI-Backend konfiguriert")
+
+
+def _apply_placeholders(graph: dict, placeholders: dict, params: VideoParams) -> dict:
+    """Setzt die Werte aus params an die per placeholders adressierten Graph-Felder.
+
+    placeholders: {"prompt": "6.inputs.text", "seed": "3.inputs.seed", ...}
+    Adressformat: "<node_id>.inputs.<field>". Unbekannte/leere Adressen werden
+    still übersprungen (nicht jeder Workflow hat jedes Feld).
+    """
+    g = copy.deepcopy(graph)
+    values = {
+        "prompt": params.prompt,
+        "seed": params.seed,
+        "width": params.width,
+        "height": params.height,
+        "frames": params.frames,
+        "image_url": params.image_url,
+    }
+    for key, addr in (placeholders or {}).items():
+        val = values.get(key)
+        if val is None or not addr:
+            continue
+        parts = addr.split(".")
+        # erwartet <node>.inputs.<field>
+        if len(parts) != 3 or parts[1] != "inputs":
+            logger.warning("ComfyUI: ungültige Platzhalter-Adresse '%s' (key=%s)", addr, key)
+            continue
+        node_id, _, field = parts
+        node = g.get(node_id)
+        if not isinstance(node, dict) or "inputs" not in node:
+            logger.warning("ComfyUI: Node '%s' fehlt für Platzhalter '%s'", node_id, key)
+            continue
+        node["inputs"][field] = val
+    return g
+
+
+class ComfyUIVideoBackend:
+    type = "comfyui"
+
+    async def list_models(self, provider: dict) -> list[VideoModel]:
+        out: list[VideoModel] = []
+        for w in _workflows(provider):
+            wid = w.get("id", "")
+            if not wid:
+                continue
+            pid = provider.get("id", "")
+            out.append(VideoModel(
+                id=f"local:{pid}/{wid}",
+                name=w.get("label") or wid,
+                category=w.get("category", "video"),
+                durations=w.get("durations") or [],
+                aspect_ratios=w.get("aspect_ratios") or [],
+                frame_images=w.get("frame_images") or [],
+            ))
+        return out
+
+    async def submit(self, provider: dict, model: str, params: VideoParams) -> JobRef:
+        # model == "local:<provider_id>/<workflow_id>" → workflow_id extrahieren
+        workflow_id = model.split("/", 1)[1] if "/" in model else model
+        wf = _find_workflow(provider, workflow_id)
+        graph = wf.get("graph") or {}
+        if not graph:
+            raise RuntimeError(f"Workflow '{workflow_id}' hat keinen Graph")
+        filled = _apply_placeholders(graph, wf.get("placeholders") or {}, params)
+        client_id = uuid.uuid4().hex
+        base = _api_base(provider)
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(
+                    f"{base}/prompt",
+                    json={"prompt": filled, "client_id": client_id},
+                )
+                if resp.status_code >= 400:
+                    raise RuntimeError(f"ComfyUI /prompt Fehler {resp.status_code}: {resp.text[:400]}")
+                data = resp.json()
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Netzwerk-Fehler beim ComfyUI-Submit: {e}") from e
+        prompt_id = data.get("prompt_id") or ""
+        if not prompt_id:
+            raise RuntimeError(f"Keine prompt_id in ComfyUI-Antwort: {str(data)[:200]}")
+        return JobRef(native_id=str(prompt_id),
+                      extra={"category": wf.get("category", "video"),
+                             "output_node": wf.get("output_node", "")})
+
+    async def poll(self, provider: dict, job: JobRef) -> JobStatus:
+        base = _api_base(provider)
+        try:
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                resp = await client.get(f"{base}/history/{job.native_id}")
+                if resp.status_code >= 400:
+                    raise RuntimeError(f"ComfyUI /history Fehler {resp.status_code}: {resp.text[:300]}")
+                data = resp.json()
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Netzwerk-Fehler beim ComfyUI-Poll: {e}") from e
+
+        entry = data.get(job.native_id)
+        if not entry:
+            # noch nicht in der History → läuft/queued
+            return JobStatus(state="running", raw=data)
+        status = (entry.get("status") or {})
+        if status.get("status_str") == "error":
+            return JobStatus(state="error",
+                             error=str(status.get("messages") or "ComfyUI-Fehler"),
+                             raw=entry)
+        outputs = entry.get("outputs") or {}
+        files = _collect_output_files(outputs)
+        if files:
+            return JobStatus(state="done", raw={"files": files})
+        # in History aber ohne Outputs → noch am Laufen oder fehlgeschlagen
+        completed = status.get("completed")
+        return JobStatus(state="done" if completed else "running", raw=entry)
+
+    async def fetch_output(self, provider: dict, job: JobRef, dest_dir: Path) -> Path:
+        # poll liefert die Datei-Refs in raw["files"] — falls nicht, nochmal pollen
+        st = await self.poll(provider, job)
+        files = (st.raw or {}).get("files") or []
+        if not files:
+            raise RuntimeError("ComfyUI-Job ohne Output-Dateien")
+        base = _api_base(provider)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        # Alle Output-Dateien holen
+        local_paths: list[Path] = []
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            for f in files:
+                params = {"filename": f["filename"],
+                          "subfolder": f.get("subfolder", ""),
+                          "type": f.get("type", "output")}
+                r = await client.get(f"{base}/view", params=params)
+                if r.status_code >= 400 or not r.content:
+                    raise RuntimeError(f"ComfyUI /view Fehler für {f['filename']}: {r.status_code}")
+                p = dest_dir / f["filename"]
+                p.write_bytes(r.content)
+                local_paths.append(p)
+
+        category = job.extra.get("category", "video")
+        if category == "image":
+            # Bild-Workflow → erste PNG direkt zurückgeben
+            return local_paths[0]
+
+        # Video-Workflow → WebP/Frames → MP4
+        from hydrahive.llm.video_backends._ffmpeg import to_mp4
+        return to_mp4(local_paths, dest_dir)
+
+
+def _collect_output_files(outputs: dict) -> list[dict]:
+    """Sammelt alle Output-Datei-Refs (images + gifs/webp) aus einem history-Entry."""
+    files: list[dict] = []
+    for node_out in (outputs or {}).values():
+        if not isinstance(node_out, dict):
+            continue
+        for key in ("images", "gifs"):
+            for item in node_out.get(key, []) or []:
+                if isinstance(item, dict) and item.get("filename"):
+                    files.append({
+                        "filename": item["filename"],
+                        "subfolder": item.get("subfolder", ""),
+                        "type": item.get("type", "output"),
+                    })
+    return files

--- a/core/src/hydrahive/llm/video_backends/_ffmpeg.py
+++ b/core/src/hydrahive/llm/video_backends/_ffmpeg.py
@@ -1,0 +1,65 @@
+"""ffmpeg-Konvertierung: ComfyUI-Video-Outputs (animiertes WebP) → MP4.
+
+ComfyUI-Video-Workflows liefern typischerweise ein animiertes WebP
+(SaveAnimatedWEBP) — für die Galerie/Timeline brauchen wir MP4 (H.264/AAC).
+Sichere Argument-Liste ohne Shell (kein Injection-Risiko), wie in media_export.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def to_mp4(inputs: list[Path], dest_dir: Path) -> Path:
+    """Konvertiert die ComfyUI-Outputs zu einer MP4-Datei in dest_dir.
+
+    - Ein animiertes WebP (häufigster Fall) → direkte Transkodierung.
+    - Mehrere Einzel-Frames (png/webp) → als Sequenz zu Video (24fps).
+    Raises RuntimeError, wenn ffmpeg fehlt oder die Konvertierung scheitert.
+    """
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError("ffmpeg nicht installiert — Video-Konvertierung nicht möglich")
+    if not inputs:
+        raise RuntimeError("Keine Eingabedateien für ffmpeg-Konvertierung")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out = dest_dir / f"{uuid.uuid4().hex}.mp4"
+
+    if len(inputs) == 1:
+        # animiertes WebP (oder einzelnes Video) direkt transkodieren
+        args = [
+            "ffmpeg", "-y",
+            "-i", str(inputs[0]),
+            "-c:v", "libx264", "-pix_fmt", "yuv420p",
+            "-movflags", "+faststart",
+            str(out),
+        ]
+    else:
+        # Frame-Sequenz: nach Namen sortiert als 24fps-Video
+        # (ffmpeg concat via image2 pattern ist heikel bei uneinheitlichen Namen,
+        # deshalb via concat-demuxer über eine Liste)
+        listfile = dest_dir / f"{uuid.uuid4().hex}.txt"
+        listfile.write_text("".join(f"file '{p.name}'\n" for p in sorted(inputs, key=lambda x: x.name)))
+        args = [
+            "ffmpeg", "-y", "-r", "24",
+            "-f", "concat", "-safe", "0", "-i", str(listfile),
+            "-c:v", "libx264", "-pix_fmt", "yuv420p",
+            "-movflags", "+faststart",
+            str(out),
+        ]
+
+    try:
+        res = subprocess.run(args, capture_output=True, timeout=300, cwd=str(dest_dir))
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("ffmpeg-Konvertierung Timeout (>300s)") from e
+    if res.returncode != 0:
+        raise RuntimeError(f"ffmpeg-Fehler: {res.stderr.decode('utf-8', 'replace')[:400]}")
+    if not out.exists() or out.stat().st_size == 0:
+        raise RuntimeError("ffmpeg lieferte keine gültige MP4-Datei")
+    logger.info("ComfyUI-Output → MP4: %s (%d bytes)", out, out.stat().st_size)
+    return out

--- a/core/src/hydrahive/llm/video_backends/_registry.py
+++ b/core/src/hydrahive/llm/video_backends/_registry.py
@@ -10,13 +10,15 @@ kommen in E2/E4 dazu — hier ist der Erweiterungspunkt (_ADAPTERS).
 from __future__ import annotations
 
 from hydrahive.llm.video_backends._base import VideoBackend
+from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
 from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
 
 LOCAL_PREFIX = "local:"
 
-# Adapter-Fabriken je Backend-Typ. E2/E4 ergänzen "comfyui" / "switch-http".
+# Adapter-Fabriken je Backend-Typ. E4 ergänzt "switch-http".
 _ADAPTERS: dict[str, type] = {
     "openrouter": OpenRouterVideoBackend,
+    "comfyui": ComfyUIVideoBackend,
 }
 
 _openrouter_singleton = OpenRouterVideoBackend()

--- a/core/tests/test_video_backends_comfyui.py
+++ b/core/tests/test_video_backends_comfyui.py
@@ -1,0 +1,180 @@
+"""E2: ComfyUIVideoBackend — submit/poll/fetch + Platzhalter-Ersetzung.
+
+Gegen einen Mock-ComfyUI (httpx.AsyncClient gepatcht). Sichert:
+- Platzhalter werden korrekt in den Graph gesetzt ("6.inputs.text" etc.)
+- submit ruft POST /prompt und liefert prompt_id als JobRef
+- poll mappt history-Zustände (running/done/error)
+- Output-Dateien werden aus outputs.images/gifs gesammelt
+- Resolver mappt local:<comfy>/<wf> auf den comfyui-Adapter
+
+Importe lazy, httpx gemockt — kein echter Netzverkehr.
+"""
+from __future__ import annotations
+
+import asyncio
+
+
+# --- Platzhalter-Ersetzung (reine Logik) -------------------------------------
+
+def test_apply_placeholders_sets_graph_fields():
+    from hydrahive.llm.video_backends._comfyui import _apply_placeholders
+    from hydrahive.llm.video_backends._base import VideoParams
+
+    graph = {
+        "3": {"class_type": "KSampler", "inputs": {"seed": 0, "steps": 20}},
+        "6": {"class_type": "CLIPTextEncode", "inputs": {"text": "OLD"}},
+        "5": {"class_type": "EmptyLatentImage", "inputs": {"width": 512, "height": 512}},
+    }
+    placeholders = {
+        "prompt": "6.inputs.text",
+        "seed": "3.inputs.seed",
+        "width": "5.inputs.width",
+        "height": "5.inputs.height",
+    }
+    params = VideoParams(prompt="a red fox", seed=42, width=768, height=432)
+    out = _apply_placeholders(graph, placeholders, params)
+
+    assert out["6"]["inputs"]["text"] == "a red fox"
+    assert out["3"]["inputs"]["seed"] == 42
+    assert out["5"]["inputs"]["width"] == 768
+    assert out["5"]["inputs"]["height"] == 432
+    # Original unverändert (deepcopy)
+    assert graph["6"]["inputs"]["text"] == "OLD"
+
+
+def test_apply_placeholders_skips_missing():
+    from hydrahive.llm.video_backends._comfyui import _apply_placeholders
+    from hydrahive.llm.video_backends._base import VideoParams
+    graph = {"6": {"class_type": "X", "inputs": {"text": "OLD"}}}
+    # seed adressiert eine nicht existierende Node → wird still übersprungen
+    out = _apply_placeholders(graph, {"prompt": "6.inputs.text", "seed": "99.inputs.seed"},
+                              VideoParams(prompt="hi", seed=7))
+    assert out["6"]["inputs"]["text"] == "hi"
+
+
+# --- list_models aus workflows ------------------------------------------------
+
+def test_list_models_from_workflows():
+    from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
+    provider = {
+        "id": "muskeln1", "type": "comfyui", "api_base": "http://muskeln1:8189",
+        "workflows": [
+            {"id": "ltx-t2v", "label": "LTX T2V", "category": "video",
+             "durations": [5, 10], "graph": {"1": {}}},
+            {"id": "sdxl", "label": "SDXL Bild", "category": "image", "graph": {"1": {}}},
+        ],
+    }
+    models = asyncio.run(ComfyUIVideoBackend().list_models(provider))
+    by_id = {m.id: m for m in models}
+    assert "local:muskeln1/ltx-t2v" in by_id
+    assert by_id["local:muskeln1/ltx-t2v"].category == "video"
+    assert by_id["local:muskeln1/sdxl"].category == "image"
+
+
+# --- Mock-httpx ---------------------------------------------------------------
+
+class _Resp:
+    def __init__(self, payload=None, content=b"", status=200):
+        self._p = payload
+        self.content = content
+        self.status_code = status
+        self.text = ""
+
+    def json(self):
+        return self._p
+
+
+class _MockClient:
+    """Simuliert POST /prompt, GET /history/{id}, GET /view."""
+    scenario = {}  # gefüllt vom Test
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None, **kw):
+        _MockClient.scenario["submitted_graph"] = json["prompt"]
+        return _Resp({"prompt_id": "pid-1"})
+
+    async def get(self, url, params=None, **kw):
+        if "/history/" in url:
+            return _Resp(_MockClient.scenario["history"])
+        if "/view" in url:
+            return _Resp(content=b"FAKEWEBPDATA")
+        return _Resp({}, status=404)
+
+
+def test_submit_posts_prompt_and_returns_jobref(monkeypatch):
+    from hydrahive.llm.video_backends import _comfyui
+    from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
+    from hydrahive.llm.video_backends._base import VideoParams
+
+    _MockClient.scenario = {}
+    monkeypatch.setattr(_comfyui.httpx, "AsyncClient", _MockClient)
+
+    provider = {
+        "id": "muskeln1", "type": "comfyui", "api_base": "http://muskeln1:8189",
+        "workflows": [{"id": "ltx-t2v", "category": "video",
+                       "output_node": "SaveAnimatedWEBP",
+                       "graph": {"6": {"class_type": "CLIPTextEncode", "inputs": {"text": "x"}}},
+                       "placeholders": {"prompt": "6.inputs.text"}}],
+    }
+    ref = asyncio.run(ComfyUIVideoBackend().submit(
+        provider, "local:muskeln1/ltx-t2v", VideoParams(prompt="a cat")))
+    assert ref.native_id == "pid-1"
+    assert ref.extra["category"] == "video"
+    # Prompt wurde in den gesendeten Graph gesetzt
+    assert _MockClient.scenario["submitted_graph"]["6"]["inputs"]["text"] == "a cat"
+
+
+def test_poll_running_then_done(monkeypatch):
+    from hydrahive.llm.video_backends import _comfyui
+    from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
+    from hydrahive.llm.video_backends._base import JobRef
+
+    monkeypatch.setattr(_comfyui.httpx, "AsyncClient", _MockClient)
+    ref = JobRef(native_id="pid-1", extra={"category": "video"})
+
+    # noch nicht in History → running
+    _MockClient.scenario = {"history": {}}
+    st = asyncio.run(ComfyUIVideoBackend().poll({"api_base": "http://m:8189"}, ref))
+    assert st.state == "running"
+
+    # fertig mit output → done + files gesammelt
+    _MockClient.scenario = {"history": {"pid-1": {
+        "status": {"completed": True},
+        "outputs": {"9": {"gifs": [{"filename": "out.webp", "subfolder": "", "type": "output"}]}},
+    }}}
+    st = asyncio.run(ComfyUIVideoBackend().poll({"api_base": "http://m:8189"}, ref))
+    assert st.state == "done"
+    assert st.raw["files"][0]["filename"] == "out.webp"
+
+
+def test_poll_error(monkeypatch):
+    from hydrahive.llm.video_backends import _comfyui
+    from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
+    from hydrahive.llm.video_backends._base import JobRef
+
+    monkeypatch.setattr(_comfyui.httpx, "AsyncClient", _MockClient)
+    _MockClient.scenario = {"history": {"pid-1": {
+        "status": {"status_str": "error", "messages": ["OOM"]}, "outputs": {}}}}
+    st = asyncio.run(ComfyUIVideoBackend().poll(
+        {"api_base": "http://m:8189"}, JobRef(native_id="pid-1")))
+    assert st.state == "error"
+    assert "OOM" in (st.error or "")
+
+
+# --- Resolver mappt comfyui --------------------------------------------------
+
+def test_resolver_maps_comfyui():
+    from hydrahive.llm.video_backends import resolve_backend
+    cfg = {"media_backends": [{"id": "muskeln1", "type": "comfyui",
+                               "api_base": "http://m:8189"}]}
+    backend, provider = resolve_backend("local:muskeln1/ltx-t2v", cfg)
+    assert backend.type == "comfyui"
+    assert provider["api_base"] == "http://m:8189"


### PR DESCRIPTION
## Was
**E2** aus `docs/specs/local-video-backends.md` — der erste **lokale** Backend-Adapter: **ComfyUI** (Muskeln1 .78:8189, LTX-2.3).

## Wie
ComfyUI ist ein Node-Graph-System — eine Instanz, mehrere Workflows. Jeder Workflow trägt:
- `graph` (ComfyUI **API-Format**: `{node_id: {class_type, inputs}}`)
- `placeholders` (adressiert Felder, z.B. `"6.inputs.text"` = Prompt, `"3.inputs.seed"` = Seed)
- `output_node` (SaveImage / SaveAnimatedWEBP) + `category` (image/video)

**Adapter-Flow** (API verifiziert gegen ComfyUI `script_examples`):
- `submit` → `POST /prompt` mit `{prompt: graph, client_id}` nach Platzhalter-Ersetzung → `prompt_id`
- `poll` → `GET /history/{id}` → mappt running / done / error
- `fetch_output` → `GET /view?filename&subfolder&type` → Bytes
  - **video** → WebP/Frames → **ffmpeg → MP4** (H.264/AAC, `+faststart`, sichere Arg-Liste ohne Shell)
  - **image** → PNG direkt

Eine ComfyUI-Instanz kann so **Bild- UND Video-Workflows** tragen (Kategorie steckt im Workflow, nicht im Backend).

## Registry
`resolve_backend("local:muskeln1/ltx-t2v", cfg)` → ComfyUI-Adapter. OpenRouter bleibt Default für alle nicht-`local:`-IDs (unverändert).

## Verifiziert
- 7 neue Tests (Platzhalter-Ersetzung + deepcopy-Schutz, submit/poll/error-Mapping, list_models, Resolver) — httpx gemockt, kein Netz ✅
- 28 bestehende Video/Media-Tests grün — keine Regression ✅

## Noch NICHT in diesem PR
- GUI (Backend anlegen + Workflow-Upload/Mapping) → **E3**
- Verdrahtung in `generate_video.py` (Dialog nutzt es) → E3/E5
- Echter Live-Test gegen Muskeln1 → E6 (braucht einen echten LTX-Workflow im API-Format vom Kunden)
