### PR TITLE
feat(video): E3 — GUI-Verwaltung lokaler Media-Backends + Verdrahtung

### DIFF
--- a/core/src/hydrahive/api/main.py
+++ b/core/src/hydrahive/api/main.py
@@ -40,6 +40,7 @@ from hydrahive.api.routes.datamining_stats import router as datamining_stats_rou
 from hydrahive.api.routes.datamining_transfer import router as datamining_transfer_router
 from hydrahive.api.routes.external_instances import router as external_instances_router
 from hydrahive.api.routes.llm import router as llm_router
+from hydrahive.api.routes.media_backends import router as media_backends_router
 from hydrahive.api.routes.llm_catalog import router as llm_catalog_router
 from hydrahive.api.routes.llm_oauth import router as llm_oauth_router
 from hydrahive.api.routes.mcp import router as mcp_router
@@ -128,6 +129,7 @@ app.include_router(communication_router)
 app.include_router(communication_whatsapp_router)
 app.include_router(communication_discord_router)
 app.include_router(llm_router)
+app.include_router(media_backends_router)
 app.include_router(llm_catalog_router)
 app.include_router(llm_oauth_router)
 app.include_router(mcp_router)

--- a/core/src/hydrahive/api/routes/llm.py
+++ b/core/src/hydrahive/api/routes/llm.py
@@ -33,12 +33,18 @@ class LlmProvider(BaseModel):
 
 
 class LlmConfig(BaseModel):
+    # extra="allow": media_backends (lokale ComfyUI/Switch-Backends) wird
+    # durchgereicht, ohne dass model_dump() es stillschweigend droppt.
+    model_config = ConfigDict(extra="allow")
     providers: list[LlmProvider] = []
     default_model: str = ""
     embed_model: str = ""
     # Aktives Modell pro Media-Kategorie (image/music/tts/transcribe/video).
     # Resolver: hydrahive.llm.media_models.get_media_model
     media_models: dict[str, str] = {}
+    # Lokale Media-Generierungs-Backends (ComfyUI, Switch-Wrapper).
+    # Struktur: docs/specs/local-video-backends.md. Verwaltet über /api/media-backends.
+    media_backends: list[dict] = []
 
 
 def _load() -> dict:
@@ -185,4 +191,40 @@ async def list_media_models(
         models = await media_models.list_image_models()
     else:  # audio
         models = await media_models.list_audio_models()
+
+    # Lokale Backends (ComfyUI/Switch-Wrapper) dazumischen — gruppiert für das UI.
+    # Jedes lokale Modell trägt "provider" (Backend-Name) für die Gruppierung.
+    if category in ("video", "image"):
+        local = await _local_media_models(category)
+        models = list(models) + local
+
     return {"default": media_models.get_media_model(cfg_key), "models": models}
+
+
+async def _local_media_models(category: str) -> list[dict]:
+    """Sammelt Modelle/Workflows aller konfigurierten lokalen Media-Backends.
+
+    Best-effort: ein offline/fehlerhaftes Backend liefert einfach nichts, ohne
+    die Liste zu killen. Nur Modelle der passenden Kategorie.
+    """
+    from hydrahive.llm._config import load_config
+    from hydrahive.llm.video_backends._registry import _backend_for_type
+    out: list[dict] = []
+    cfg = load_config()
+    for b in cfg.get("media_backends", []) or []:
+        backend = _backend_for_type(b.get("type", ""))
+        if backend is None:
+            continue
+        try:
+            vms = await backend.list_models(b)
+        except Exception:
+            continue
+        for m in vms:
+            if m.category != category:
+                continue
+            out.append({
+                "id": m.id, "name": m.name, "provider": b.get("name", b.get("id", "")),
+                "durations": m.durations, "aspect_ratios": m.aspect_ratios,
+                "frame_images": m.frame_images, "local": True,
+            })
+    return out

--- a/core/src/hydrahive/api/routes/media_backends.py
+++ b/core/src/hydrahive/api/routes/media_backends.py
@@ -1,0 +1,157 @@
+"""Verwaltung lokaler Media-Backends (ComfyUI, Switch-Wrapper) — E3.
+
+GUI-getrieben (Spec: docs/specs/local-video-backends.md). Endpoints:
+  GET    /api/media-backends              → Liste (ohne Graph-Ballast)
+  PUT    /api/media-backends              → ganze Liste speichern
+  POST   /api/media-backends/test         → Verbindung testen (ComfyUI/switch)
+  POST   /api/media-backends/parse-workflow → Workflow-JSON parsen, Felder +
+         Platzhalter-Vorschläge liefern (kein JSON-Handarbeit im UI)
+
+Alles admin-only. Speicherung in llm.json unter `media_backends`.
+"""
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import httpx
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from hydrahive.api.middleware.auth import require_admin
+from hydrahive.api.middleware.errors import coded
+from hydrahive.settings import settings
+
+router = APIRouter(prefix="/api/media-backends", tags=["media-backends"])
+
+
+def _load() -> dict:
+    if not settings.llm_config.exists():
+        return {}
+    return json.loads(settings.llm_config.read_text())
+
+
+def _save(data: dict) -> None:
+    settings.llm_config.parent.mkdir(parents=True, exist_ok=True)
+    settings.llm_config.write_text(json.dumps(data, indent=2))
+
+
+def _summary(b: dict) -> dict:
+    """Backend ohne die schweren Graph-JSONs (für die Listen-Ansicht)."""
+    return {
+        "id": b.get("id", ""),
+        "type": b.get("type", ""),
+        "name": b.get("name", ""),
+        "api_base": b.get("api_base", ""),
+        "workflows": [
+            {"id": w.get("id"), "label": w.get("label"),
+             "category": w.get("category", "video"),
+             "output_node": w.get("output_node", "")}
+            for w in (b.get("workflows") or [])
+        ],
+    }
+
+
+@router.get("", dependencies=[Depends(require_admin)])
+def list_backends() -> dict:
+    data = _load()
+    return {"media_backends": [_summary(b) for b in data.get("media_backends", [])]}
+
+
+class BackendsPayload(BaseModel):
+    media_backends: list[dict] = []
+
+
+@router.put("", dependencies=[Depends(require_admin)])
+def save_backends(payload: BackendsPayload) -> dict:
+    data = _load()
+    data["media_backends"] = payload.media_backends
+    _save(data)
+    return {"ok": True, "count": len(payload.media_backends)}
+
+
+class TestReq(BaseModel):
+    type: str
+    api_base: str
+
+
+@router.post("/test", dependencies=[Depends(require_admin)])
+async def test_backend(req: TestReq) -> dict:
+    """Prüft Erreichbarkeit eines Backends. ComfyUI: /object_info; switch-http: /health."""
+    base = (req.api_base or "").rstrip("/")
+    if not base:
+        raise coded(400, "no_api_base", message="api_base fehlt")
+    if req.type == "comfyui":
+        url = f"{base}/object_info"
+    elif req.type == "switch-http":
+        url = f"{base}/health"
+    else:
+        raise coded(400, "unknown_type", message=f"Unbekannter Typ '{req.type}'")
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(url)
+            if resp.status_code >= 400:
+                return {"ok": False, "status": resp.status_code, "url": url}
+            info: dict = {"ok": True, "url": url}
+            if req.type == "switch-http":
+                try:
+                    body = resp.json()
+                    info["mode"] = body.get("mode")
+                except Exception:
+                    pass
+            elif req.type == "comfyui":
+                try:
+                    info["node_count"] = len(resp.json())
+                except Exception:
+                    pass
+            return info
+    except httpx.HTTPError as e:
+        return {"ok": False, "error": str(e), "url": url}
+
+
+class ParseReq(BaseModel):
+    graph: dict
+
+
+# ComfyUI-Node-Typen → welches params-Feld sie typischerweise steuern (Heuristik).
+_HEURISTICS = {
+    "CLIPTextEncode": ("text", "prompt"),
+    "KSampler": ("seed", "seed"),
+    "KSamplerAdvanced": ("noise_seed", "seed"),
+    "EmptyLatentImage": ("width", "width"),
+    "EmptyLatentVideo": ("length", "frames"),
+    "LTXVBaseSampler": ("seed", "seed"),
+}
+
+
+@router.post("/parse-workflow", dependencies=[Depends(require_admin)])
+def parse_workflow(req: ParseReq) -> dict:
+    """Zerlegt einen ComfyUI-API-Graph in Felder + schlägt Platzhalter-Mapping vor.
+
+    Rückgabe:
+      nodes: [{id, class_type, inputs: [feldnamen]}]
+      suggestions: {prompt: "6.inputs.text", seed: "3.inputs.seed", ...}
+
+    Das UI zeigt die Vorschläge vorbelegt, der User kann sie per Dropdown ändern.
+    """
+    graph = req.graph or {}
+    if not isinstance(graph, dict) or not graph:
+        raise coded(400, "invalid_graph", message="Graph ist leer oder kein Objekt")
+
+    nodes = []
+    suggestions: dict[str, str] = {}
+    for node_id, node in graph.items():
+        if not isinstance(node, dict):
+            continue
+        ctype = node.get("class_type", "")
+        inputs = node.get("inputs", {}) or {}
+        # nur skalar-Felder (keine Node-Referenzen [id, slot]) als mapbar zeigen
+        scalar_fields = [k for k, v in inputs.items() if not isinstance(v, list)]
+        nodes.append({"id": node_id, "class_type": ctype, "inputs": scalar_fields})
+        # Heuristik-Vorschlag
+        if ctype in _HEURISTICS:
+            field, param = _HEURISTICS[ctype]
+            if field in inputs and param not in suggestions:
+                suggestions[param] = f"{node_id}.inputs.{field}"
+
+    return {"nodes": nodes, "suggestions": suggestions}

--- a/core/src/hydrahive/tools/generate_video.py
+++ b/core/src/hydrahive/tools/generate_video.py
@@ -97,10 +97,86 @@ _SCHEMA = {
 }
 
 
+async def _execute_local(model: str, args: dict, ctx: ToolContext) -> ToolResult:
+    """Generierung über ein lokales Backend (local:<provider>/<model>).
+
+    Nutzt das VideoBackend-Protocol (resolve_backend). ComfyUI/Switch-Wrapper
+    laufen hierüber; OpenRouter behält seinen eigenen bewährten Pfad unten.
+    """
+    import asyncio as _asyncio
+
+    from hydrahive.llm._config import load_config
+    from hydrahive.llm.video_backends import VideoParams, resolve_backend
+
+    prompt = (args.get("prompt") or "").strip()
+    try:
+        backend, provider = resolve_backend(model, load_config())
+    except ValueError as e:
+        return ToolResult.fail(str(e))
+
+    image_url = _image_to_data_uri(args.get("image_path"), ctx)
+    params = VideoParams(
+        prompt=prompt,
+        width=int(args.get("width") or 1280),
+        height=int(args.get("height") or 720),
+        duration=int(args.get("duration") or 5),
+        aspect_ratio=(args.get("aspect_ratio") or "16:9").strip(),
+        seed=(int(args["seed"]) if args.get("seed") is not None else None),
+        frames=(int(args["frames"]) if args.get("frames") is not None else None),
+        image_url=image_url,
+    )
+    try:
+        job = await backend.submit(provider, model, params)
+    except RuntimeError as e:
+        return ToolResult.fail(str(e))
+
+    elapsed = 0.0
+    interval = _POLL_INTERVAL_START
+    while elapsed < _POLL_TIMEOUT:
+        await _asyncio.sleep(interval)
+        elapsed += interval
+        interval = min(interval * 2, _POLL_INTERVAL_MAX)
+        try:
+            st = await backend.poll(provider, job)
+        except RuntimeError as e:
+            return ToolResult.fail(f"Fehler beim Job-Status-Abruf: {e}")
+        if st.state == "done":
+            # URL (falls vorhanden) an den JobRef weiterreichen für fetch_output
+            job = job.__class__(native_id=job.native_id,
+                                extra={**job.extra, **({"url": st.url} if st.url else {})})
+            try:
+                path = await backend.fetch_output(provider, job, ctx.workspace / "generated")
+            except RuntimeError as e:
+                return ToolResult.fail(str(e))
+            return ToolResult.ok(f"Video generiert und gespeichert: {path}", model=model)
+        if st.state == "error":
+            return ToolResult.fail(f"Generierung fehlgeschlagen: {st.error or 'Unbekannter Fehler'}")
+    return ToolResult.fail(f"Timeout nach {_POLL_TIMEOUT:.0f}s — lokales Backend nicht fertig")
+
+
+def _image_to_data_uri(image_path: str | None, ctx: ToolContext) -> str | None:
+    image_path = (image_path or "").strip() or None
+    if not image_path:
+        return None
+    img_path = Path(image_path)
+    if not img_path.is_absolute():
+        img_path = ctx.workspace / image_path
+    if not img_path.exists():
+        return None
+    suffix = img_path.suffix.lower().lstrip(".") or "jpeg"
+    mime = "image/png" if suffix == "png" else f"image/{suffix}"
+    return f"data:{mime};base64,{base64.b64encode(img_path.read_bytes()).decode()}"
+
+
 async def _execute(args: dict, ctx: ToolContext) -> ToolResult:
     prompt = (args.get("prompt") or "").strip()
     if not prompt:
         return ToolResult.fail("Prompt darf nicht leer sein")
+
+    # Lokale Backends (ComfyUI / Switch-Wrapper) über den generischen Pfad.
+    _model = (args.get("model") or "").strip()
+    if _model.startswith("local:"):
+        return await _execute_local(_model, args, ctx)
 
     key = openrouter_key()
     if not key:

--- a/core/tests/test_media_backends_api.py
+++ b/core/tests/test_media_backends_api.py
@@ -1,0 +1,89 @@
+"""E3: Media-Backend-Verwaltung (GUI-API) + Verdrahtung.
+
+- CRUD: GET/PUT /api/media-backends (admin-only, Summary ohne Graph-Ballast)
+- parse-workflow: ComfyUI-Graph -> Felder + Platzhalter-Vorschläge
+- media-models mischt lokale Modelle dazu (gruppiert, category-gefiltert)
+"""
+from __future__ import annotations
+
+
+def test_backends_crud_admin_only(client, auth_headers, admin_headers):
+    # nicht-admin -> 403
+    assert client.get("/api/media-backends", headers=auth_headers).status_code == 403
+    # admin -> leer initial
+    r = client.get("/api/media-backends", headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["media_backends"] == []
+
+    # speichern
+    payload = {"media_backends": [{
+        "id": "muskeln1", "type": "comfyui", "name": "Muskeln1 ComfyUI",
+        "api_base": "http://muskeln1:8189",
+        "workflows": [{"id": "ltx", "label": "LTX", "category": "video",
+                       "output_node": "SaveAnimatedWEBP",
+                       "graph": {"6": {"class_type": "CLIPTextEncode", "inputs": {"text": "x"}}},
+                       "placeholders": {"prompt": "6.inputs.text"}}],
+    }]}
+    r = client.put("/api/media-backends", json=payload, headers=admin_headers)
+    assert r.status_code == 200 and r.json()["count"] == 1
+
+    # list gibt Summary OHNE den schweren Graph zurück
+    r = client.get("/api/media-backends", headers=admin_headers)
+    b = r.json()["media_backends"][0]
+    assert b["id"] == "muskeln1"
+    assert b["workflows"][0]["id"] == "ltx"
+    assert "graph" not in b["workflows"][0]  # Ballast entfernt
+
+
+def test_parse_workflow_suggests_mapping(client, admin_headers):
+    graph = {
+        "3": {"class_type": "KSampler", "inputs": {"seed": 0, "steps": 20}},
+        "6": {"class_type": "CLIPTextEncode", "inputs": {"text": "hi"}},
+        "5": {"class_type": "EmptyLatentImage", "inputs": {"width": 512, "height": 512}},
+    }
+    r = client.post("/api/media-backends/parse-workflow",
+                    json={"graph": graph}, headers=admin_headers)
+    assert r.status_code == 200
+    data = r.json()
+    # Vorschläge aus Heuristik
+    assert data["suggestions"]["prompt"] == "6.inputs.text"
+    assert data["suggestions"]["seed"] == "3.inputs.seed"
+    assert data["suggestions"]["width"] == "5.inputs.width"
+    # Nodes gelistet mit skalaren Feldern
+    node6 = next(n for n in data["nodes"] if n["id"] == "6")
+    assert "text" in node6["inputs"]
+
+
+def test_parse_workflow_rejects_empty(client, admin_headers):
+    r = client.post("/api/media-backends/parse-workflow",
+                    json={"graph": {}}, headers=admin_headers)
+    assert r.status_code == 400
+
+
+def test_media_models_merges_local(client, auth_headers, admin_headers, monkeypatch):
+    # OpenRouter-Liste leer mocken (kein Key), damit wir nur lokale sehen
+    from hydrahive.llm import media_models
+    async def _empty():
+        return []
+    monkeypatch.setattr(media_models, "list_video_models", _empty)
+
+    # lokales ComfyUI-Backend konfigurieren
+    payload = {"media_backends": [{
+        "id": "m1", "type": "comfyui", "name": "Muskeln1", "api_base": "http://m:8189",
+        "workflows": [
+            {"id": "ltx-t2v", "label": "LTX Video", "category": "video",
+             "graph": {"1": {}}, "durations": [5, 10]},
+            {"id": "sdxl", "label": "SDXL Bild", "category": "image", "graph": {"1": {}}},
+        ],
+    }]}
+    client.put("/api/media-backends", json=payload, headers=admin_headers)
+
+    r = client.get("/api/llm/media-models?category=video", headers=auth_headers)
+    assert r.status_code == 200
+    ids = [m["id"] for m in r.json()["models"]]
+    assert "local:m1/ltx-t2v" in ids
+    # Bild-Workflow taucht in der Video-Liste NICHT auf
+    assert "local:m1/sdxl" not in ids
+    # provider-Gruppe gesetzt
+    ltx = next(m for m in r.json()["models"] if m["id"] == "local:m1/ltx-t2v")
+    assert ltx["provider"] == "Muskeln1" and ltx["local"] is True

--- a/docs/specs/local-video-backends.md
+++ b/docs/specs/local-video-backends.md
@@ -177,6 +177,20 @@ Der Wrapper läuft dauerhaft (leichtgewichtig, kein VRAM), Default z.B.
 Der Wrapper garantiert: Nach `done`/`error` (oder Timeout) schaltet er sd-server
 ab und lässt Ollama wieder laden. HydraHive muss sich **nicht** um VRAM kümmern.
 
+### Wichtig: sd-server hat KEINE Workflows (anders als ComfyUI)
+
+Klarstellung von Mia (2026-07-25): sd-server (stable-diffusion.cpp) ist **kein**
+Node-Graph-System. Es gibt **keine** Workflow-JSONs/Graphen wie bei ComfyUI —
+nur eine **direkte REST-API** (Prompt + Parameter → Bild/Video). Das
+Workflow-Template-Konzept (Graph + placeholders) gilt **ausschließlich für
+ComfyUI (Muskeln1)**.
+
+Für Muskeln2 gilt: Der node-lokale **Switch-Wrapper** kapselt den sd-server-
+Aufruf (inkl. sicherer Vulkan-Flags). HydraHive spricht nur den Wrapper-Vertrag
+unten — das interne sd-server-Payload-Schema kennt nur der Wrapper. Mia liefert
+das echte sd-server-Payload-Schema (`prompt`, `steps`, `width`, `height` …), das
+der Wrapper intern nutzt; HydraHive muss es NICHT kennen.
+
 ### Adapter `switch-http` (HydraHive-Seite)
 - Config: `{ "type":"switch-http", "api_base":"http://muskeln2:9700" }`
 - `list_models` → `GET /models`; `submit` → `POST /generate`;

--- a/frontend/src/features/llm/LlmPage.tsx
+++ b/frontend/src/features/llm/LlmPage.tsx
@@ -8,6 +8,7 @@ import { ProviderCard } from "./ProviderCard"
 import { ProviderForm } from "./ProviderForm"
 import { AnthropicUsageCard } from "./AnthropicUsageCard"
 import { DefaultModelsSection } from "./DefaultModelsSection"
+import { MediaBackendsSection } from "./MediaBackendsSection"
 
 export function LlmPage() {
   const { t } = useTranslation("llm")
@@ -119,6 +120,8 @@ export function LlmPage() {
       </div>
 
       <DefaultModelsSection config={config} onSaved={reloadConfig} />
+
+      <MediaBackendsSection />
 
       <div className="flex items-center gap-3">
         <button onClick={testConnection} disabled={testing || !config.default_model}

--- a/frontend/src/features/llm/MediaBackendsSection.tsx
+++ b/frontend/src/features/llm/MediaBackendsSection.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from "react"
+import { Loader2, Plus, Trash2, Zap, Check, X } from "lucide-react"
+import { mediaBackendsApi, type MediaBackend, type MediaWorkflow } from "./api"
+
+/**
+ * GUI zur Verwaltung lokaler Media-Backends (ComfyUI / Switch-Wrapper).
+ * Spec: docs/specs/local-video-backends.md (E3). Alles ohne JSON-Handarbeit:
+ * ComfyUI-Workflows werden per Paste geparst und die Platzhalter vorgeschlagen.
+ */
+export function MediaBackendsSection() {
+  const [backends, setBackends] = useState<MediaBackend[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAdd, setShowAdd] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    mediaBackendsApi.list()
+      .then((r) => setBackends(r.media_backends))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function persist(next: MediaBackend[]) {
+    setSaving(true)
+    try {
+      await mediaBackendsApi.save(next)
+      setBackends(next)
+    } finally { setSaving(false) }
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-zinc-200">Lokale Media-Backends</h3>
+        {saving && <span className="text-xs text-zinc-500">speichert…</span>}
+      </div>
+      <p className="text-xs text-zinc-500">
+        ComfyUI (Node-Graph) oder Switch-Wrapper (sd-server). Modelle/Workflows erscheinen
+        im Video-/Bild-Dialog neben den OpenRouter-Modellen.
+      </p>
+
+      {loading ? (
+        <p className="text-xs text-zinc-500">Lade…</p>
+      ) : (
+        <div className="space-y-2">
+          {backends.map((b, i) => (
+            <BackendCard key={b.id} backend={b}
+              onChange={(nb) => { const c = [...backends]; c[i] = nb; void persist(c) }}
+              onDelete={() => void persist(backends.filter((_, j) => j !== i))} />
+          ))}
+          {backends.length === 0 && (
+            <p className="text-xs text-zinc-600">Noch kein lokales Backend konfiguriert.</p>
+          )}
+        </div>
+      )}
+
+      {showAdd ? (
+        <AddBackendForm
+          onAdd={(nb) => { void persist([...backends, nb]); setShowAdd(false) }}
+          onCancel={() => setShowAdd(false)} />
+      ) : (
+        <button onClick={() => setShowAdd(true)}
+          className="flex items-center gap-2 px-3 py-2 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-zinc-200 text-sm">
+          <Plus size={14} /> Backend hinzufügen
+        </button>
+      )}
+    </section>
+  )
+}
+
+function TestButton({ type, apiBase }: { type: string; apiBase: string }) {
+  const [state, setState] = useState<null | "ok" | "fail" | "busy">(null)
+  const [detail, setDetail] = useState("")
+  async function run() {
+    setState("busy"); setDetail("")
+    try {
+      const r = await mediaBackendsApi.test(type, apiBase)
+      if (r.ok) {
+        setState("ok")
+        setDetail(r.mode ? `Modus: ${r.mode}` : r.node_count != null ? `${r.node_count} Nodes` : "erreichbar")
+      } else { setState("fail"); setDetail(r.error || `HTTP-Fehler`) }
+    } catch { setState("fail"); setDetail("nicht erreichbar") }
+  }
+  return (
+    <button onClick={run} disabled={!apiBase}
+      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-zinc-800 hover:bg-zinc-700 text-xs text-zinc-200 disabled:opacity-40">
+      {state === "busy" ? <Loader2 size={12} className="animate-spin" />
+        : state === "ok" ? <Check size={12} className="text-emerald-400" />
+        : state === "fail" ? <X size={12} className="text-rose-400" />
+        : <Zap size={12} />}
+      Verbindung testen{detail && <span className="text-zinc-500">· {detail}</span>}
+    </button>
+  )
+}
+
+function BackendCard({ backend, onChange, onDelete }: {
+  backend: MediaBackend
+  onChange: (b: MediaBackend) => void
+  onDelete: () => void
+}) {
+  const [showWf, setShowWf] = useState(false)
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm text-zinc-100 font-medium">{backend.name}</div>
+          <div className="text-xs text-zinc-500 font-mono">{backend.type} · {backend.api_base}</div>
+        </div>
+        <button onClick={onDelete} className="p-1.5 rounded text-zinc-500 hover:text-rose-400 hover:bg-white/5">
+          <Trash2 size={14} />
+        </button>
+      </div>
+      <div className="flex items-center gap-2 flex-wrap">
+        <TestButton type={backend.type} apiBase={backend.api_base} />
+        {backend.type === "comfyui" && (
+          <button onClick={() => setShowWf(!showWf)}
+            className="px-2.5 py-1.5 rounded-md bg-zinc-800 hover:bg-zinc-700 text-xs text-zinc-200">
+            Workflows ({backend.workflows?.length ?? 0})
+          </button>
+        )}
+      </div>
+      {showWf && backend.type === "comfyui" && (
+        <WorkflowManager backend={backend} onChange={onChange} />
+      )}
+    </div>
+  )
+}
+
+function AddBackendForm({ onAdd, onCancel }: {
+  onAdd: (b: MediaBackend) => void; onCancel: () => void
+}) {
+  const [type, setType] = useState<"comfyui" | "switch-http">("comfyui")
+  const [name, setName] = useState("")
+  const [apiBase, setApiBase] = useState("")
+  const valid = name.trim() && apiBase.trim()
+  return (
+    <div className="rounded-lg border border-zinc-700 bg-zinc-900 p-3 space-y-2">
+      <div className="flex gap-2">
+        <select value={type} onChange={(e) => setType(e.target.value as "comfyui" | "switch-http")}
+          className="rounded-md bg-zinc-800 text-zinc-200 text-sm px-2 py-1.5 border border-zinc-700">
+          <option value="comfyui">ComfyUI</option>
+          <option value="switch-http">Switch-Wrapper (sd-server)</option>
+        </select>
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name (z.B. Muskeln1)"
+          className="flex-1 rounded-md bg-zinc-800 text-zinc-200 text-sm px-2 py-1.5 border border-zinc-700" />
+      </div>
+      <input value={apiBase} onChange={(e) => setApiBase(e.target.value)}
+        placeholder={type === "comfyui" ? "http://muskeln1:8189" : "http://muskeln2:9700"}
+        className="w-full rounded-md bg-zinc-800 text-zinc-200 text-sm px-2 py-1.5 border border-zinc-700 font-mono" />
+      <div className="flex gap-2">
+        <button disabled={!valid}
+          onClick={() => onAdd({ id: name.trim().toLowerCase().replace(/\s+/g, "-"),
+            type, name: name.trim(), api_base: apiBase.trim(), workflows: [] })}
+          className="px-3 py-1.5 rounded-md bg-indigo-600 hover:bg-indigo-500 text-white text-sm disabled:opacity-40">
+          Hinzufügen
+        </button>
+        <button onClick={onCancel} className="px-3 py-1.5 rounded-md bg-zinc-800 text-zinc-300 text-sm">Abbrechen</button>
+      </div>
+    </div>
+  )
+}
+
+const PARAM_KEYS = ["prompt", "seed", "width", "height", "frames", "image_url"] as const
+
+function WorkflowManager({ backend, onChange }: {
+  backend: MediaBackend; onChange: (b: MediaBackend) => void
+}) {
+  const [adding, setAdding] = useState(false)
+  const wfs = backend.workflows ?? []
+  return (
+    <div className="mt-2 space-y-2 border-t border-zinc-800 pt-2">
+      {wfs.map((w, i) => (
+        <div key={w.id} className="flex items-center justify-between text-xs">
+          <span className="text-zinc-300">{w.label} <span className="text-zinc-600">({w.category})</span></span>
+          <button onClick={() => onChange({ ...backend, workflows: wfs.filter((_, j) => j !== i) })}
+            className="p-1 rounded text-zinc-500 hover:text-rose-400"><Trash2 size={12} /></button>
+        </div>
+      ))}
+      {adding ? (
+        <WorkflowForm
+          onAdd={(w) => { onChange({ ...backend, workflows: [...wfs, w] }); setAdding(false) }}
+          onCancel={() => setAdding(false)} />
+      ) : (
+        <button onClick={() => setAdding(true)}
+          className="flex items-center gap-1.5 px-2 py-1 rounded bg-zinc-800 hover:bg-zinc-700 text-xs text-zinc-200">
+          <Plus size={12} /> Workflow hinzufügen
+        </button>
+      )}
+    </div>
+  )
+}
+
+function WorkflowForm({ onAdd, onCancel }: {
+  onAdd: (w: MediaWorkflow) => void; onCancel: () => void
+}) {
+  const [label, setLabel] = useState("")
+  const [category, setCategory] = useState<"video" | "image">("video")
+  const [json, setJson] = useState("")
+  const [nodes, setNodes] = useState<{ id: string; class_type: string; inputs: string[] }[]>([])
+  const [mapping, setMapping] = useState<Record<string, string>>({})
+  const [graph, setGraph] = useState<Record<string, unknown> | null>(null)
+  const [err, setErr] = useState("")
+
+  async function parse() {
+    setErr("")
+    let g: Record<string, unknown>
+    try { g = JSON.parse(json) } catch { setErr("Kein gültiges JSON"); return }
+    try {
+      const r = await mediaBackendsApi.parseWorkflow(g)
+      setNodes(r.nodes); setMapping(r.suggestions); setGraph(g)
+    } catch { setErr("Workflow konnte nicht geparst werden (API-Format nötig)") }
+  }
+
+  const addrOptions = nodes.flatMap((n) => n.inputs.map((f) => `${n.id}.inputs.${f}`))
+
+  return (
+    <div className="rounded-md border border-zinc-700 bg-zinc-950/60 p-2 space-y-2">
+      <div className="flex gap-2">
+        <input value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Label (z.B. LTX Text→Video)"
+          className="flex-1 rounded bg-zinc-800 text-zinc-200 text-xs px-2 py-1 border border-zinc-700" />
+        <select value={category} onChange={(e) => setCategory(e.target.value as "video" | "image")}
+          className="rounded bg-zinc-800 text-zinc-200 text-xs px-2 py-1 border border-zinc-700">
+          <option value="video">Video</option>
+          <option value="image">Bild</option>
+        </select>
+      </div>
+      <textarea value={json} onChange={(e) => setJson(e.target.value)}
+        placeholder='ComfyUI-Workflow im API-Format einfügen (ComfyUI → "Save (API Format)")'
+        className="w-full h-24 rounded bg-zinc-800 text-zinc-300 text-xs px-2 py-1 border border-zinc-700 font-mono" />
+      {err && <p className="text-xs text-rose-400">{err}</p>}
+      {!graph ? (
+        <button onClick={parse} disabled={!json.trim()}
+          className="px-2.5 py-1 rounded bg-indigo-600 hover:bg-indigo-500 text-white text-xs disabled:opacity-40">
+          Workflow analysieren
+        </button>
+      ) : (
+        <div className="space-y-1.5">
+          <p className="text-xs text-zinc-500">Platzhalter zuordnen (Vorschläge vorbelegt):</p>
+          {PARAM_KEYS.map((key) => (
+            <div key={key} className="flex items-center gap-2">
+              <span className="text-xs text-zinc-400 w-16">{key}</span>
+              <select value={mapping[key] ?? ""} onChange={(e) => setMapping({ ...mapping, [key]: e.target.value })}
+                className="flex-1 rounded bg-zinc-800 text-zinc-300 text-xs px-2 py-1 border border-zinc-700">
+                <option value="">— nicht gesetzt —</option>
+                {addrOptions.map((a) => <option key={a} value={a}>{a}</option>)}
+              </select>
+            </div>
+          ))}
+          <div className="flex gap-2 pt-1">
+            <button disabled={!label.trim()}
+              onClick={() => onAdd({
+                id: label.trim().toLowerCase().replace(/\s+/g, "-"),
+                label: label.trim(), category, graph: graph!,
+                placeholders: Object.fromEntries(Object.entries(mapping).filter(([, v]) => v)),
+              })}
+              className="px-2.5 py-1 rounded bg-emerald-600 hover:bg-emerald-500 text-white text-xs disabled:opacity-40">
+              Workflow speichern
+            </button>
+            <button onClick={onCancel} className="px-2.5 py-1 rounded bg-zinc-800 text-zinc-300 text-xs">Abbrechen</button>
+          </div>
+        </div>
+      )}
+      {!graph && (
+        <button onClick={onCancel} className="text-xs text-zinc-500 hover:text-zinc-300">Abbrechen</button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/llm/api.ts
+++ b/frontend/src/features/llm/api.ts
@@ -85,6 +85,44 @@ export const llmApi = {
   getOpenRouterCredits: () => api.get<OpenRouterCredits>("/llm/openrouter/credits"),
 }
 
+// --- Lokale Media-Backends (ComfyUI / Switch-Wrapper) -----------------------
+
+export interface MediaWorkflow {
+  id: string
+  label: string
+  category: "video" | "image"
+  output_node?: string
+  graph?: Record<string, unknown>
+  placeholders?: Record<string, string>
+  durations?: number[]
+  aspect_ratios?: string[]
+  frame_images?: string[]
+}
+
+export interface MediaBackend {
+  id: string
+  type: "comfyui" | "switch-http"
+  name: string
+  api_base: string
+  workflows?: MediaWorkflow[]
+}
+
+export interface ParsedWorkflow {
+  nodes: { id: string; class_type: string; inputs: string[] }[]
+  suggestions: Record<string, string>
+}
+
+export const mediaBackendsApi = {
+  list: () => api.get<{ media_backends: MediaBackend[] }>("/media-backends"),
+  save: (media_backends: MediaBackend[]) =>
+    api.put<{ ok: boolean; count: number }>("/media-backends", { media_backends }),
+  test: (type: string, api_base: string) =>
+    api.post<{ ok: boolean; mode?: string; node_count?: number; error?: string }>(
+      "/media-backends/test", { type, api_base }),
+  parseWorkflow: (graph: Record<string, unknown>) =>
+    api.post<ParsedWorkflow>("/media-backends/parse-workflow", { graph }),
+}
+
 export interface CatalogModel {
   id: string
   context_window: number | null


### PR DESCRIPTION
## Was
**E3** aus `docs/specs/local-video-backends.md` — die **GUI-Verwaltung** lokaler Media-Backends (harte Anforderung: alles über die Oberfläche) + Verdrahtung, sodass lokale Modelle wirklich generieren.

## Backend
- **`routes/media_backends.py`** (admin-only):
  - `GET/PUT /api/media-backends` — CRUD (Liste liefert Summary ohne Graph-Ballast)
  - `POST /api/media-backends/test` — Verbindung testen (ComfyUI `/object_info` → Node-Count; switch-http `/health` → zeigt aktuellen `mode`)
  - `POST /api/media-backends/parse-workflow` — ComfyUI-Graph → Nodes/Felder + **Heuristik-Platzhalter-Vorschläge** (CLIPTextEncode→prompt, KSampler→seed …). **Kein JSON-Handarbeit im UI.**
- **`llm.py`**: `LlmConfig` um `media_backends` erweitert (`extra="allow"`, kein Feld-Leak); `media-models`-Endpoint mischt lokale Modelle **kategoriegefiltert + gruppiert** dazu.
- **`generate_video.py`**: `local:`-Modelle laufen über `resolve_backend`/VideoBackend-Protocol (submit/poll/fetch). **OpenRouter-Pfad unverändert.**

## Frontend
- **`MediaBackendsSection`**: Backend anlegen (Typ/Name/api_base) · „Verbindung testen" mit Live-Feedback · ComfyUI-Workflow per Paste → „analysieren" → **Platzhalter per Dropdown mappen** (Vorschläge vorbelegt). In die LLM-Settings-Page eingehängt.

## Klarstellung (Mia, in Spec ergänzt)
sd-server hat **keine** Workflows wie ComfyUI — Muskeln2 läuft über den Switch-Wrapper, dessen internes Payload-Schema HydraHive nicht kennen muss.

## Verifiziert
- 4 neue API-Tests (CRUD/admin-only, parse-workflow, media-models-Merge) + **172 Regressionstests grün** ✅
- `tsc -b` + `eslint` grün ✅

## Noch offen
- **E4**: Switch-Wrapper-Adapter (wartet auf Mias Wrapper + sd-server-Schema)
- **E5**: Video-Dialog — gruppiertes Dropdown + lokale Metadaten/Limits (der Dialog zeigt lokale Modelle schon, das Feintuning der Gruppierung kommt in E5)
- **E6**: Live-Test gegen echtes Muskeln1
