### PR TITLE
fix(catalog): Nemotron 3 Ultra 550B context_window (NIM meldet None)

### DIFF
--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -173,6 +173,12 @@ METADATA: dict[str, dict[str, Any]] = {
     "nvidia_nim/nvidia/nemotron-4-340b-instruct":            {"context_window": 4_096,   "tool_use": True,  "category": "chat",   "family": "nemotron", "params": "340B"},
     "nvidia_nim/nvidia/nemotron-4-340b-reward":              {"context_window": 4_096,   "tool_use": False, "category": "specialized", "family": "nemotron", "params": "340B"},
     "nvidia_nim/nvidia/nemotron-3-super-120b-a12b":          {"context_window": 128_000, "tool_use": True,  "category": "chat",   "family": "nemotron", "params": "120B-MoE"},
+    # Ultra 550B: NIM meldet über /v1/models KEIN context_length (kommt als None
+    # rein) — Fallback-Metadata nötig, sonst rechnet die Compaction mit dem
+    # 32k-Default statt dem echten Fenster. NIM-Default = 262144 (256K, offizielle
+    # Doku docs.nvidia.com/nim/.../get-started-nemotron-3-ultra).
+    "nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b":          {"context_window": 262_144, "tool_use": True,  "category": "chat",   "family": "nemotron", "params": "550B-MoE"},
+    "nvidia_nim/nvidia/nemotron-3.5-content-safety":         {"context_window": 128_000, "tool_use": False, "category": "safety", "family": "nemotron"},
     "nvidia_nim/nvidia/nemotron-3-nano-30b-a3b":             {"context_window": 32_768,  "tool_use": False, "category": "chat",   "family": "nemotron", "params": "30B-MoE"},
     "nvidia_nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {"context_window": 32_768, "tool_use": False, "category": "reasoning", "family": "nemotron", "params": "30B-MoE"},
     "nvidia_nim/nvidia/nemotron-nano-3-30b-a3b":             {"context_window": 128_000, "tool_use": True,  "category": "chat",   "family": "nemotron", "params": "30B-MoE"},

--- a/core/tests/test_nemotron_ultra_context.py
+++ b/core/tests/test_nemotron_ultra_context.py
@@ -1,0 +1,21 @@
+"""Regression: Nemotron 3 Ultra 550B braucht ein korrektes Kontextfenster.
+
+Bug (Kunde): Der NVIDIA-NIM-Endpoint /v1/models meldet für dieses Modell KEIN
+context_length (kommt als None rein). Ohne METADATA-Fallback fiel die Compaction
+auf den 32k-Default (im UI als kleiner Wert sichtbar) statt auf das echte
+Fenster. NIM-Default = 262144 (256K, offizielle NVIDIA-Doku).
+"""
+from __future__ import annotations
+
+
+def test_nemotron_ultra_550b_has_metadata_context():
+    from hydrahive.llm._catalog_data import METADATA
+    mid = "nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b"
+    assert mid in METADATA, "Nemotron Ultra 550B fehlt in METADATA"
+    assert METADATA[mid]["context_window"] == 262_144
+
+
+def test_context_window_for_ultra_uses_metadata():
+    from hydrahive.compaction.tokens import context_window_for
+    # Kein 32k-Default mehr — echtes Fenster aus METADATA.
+    assert context_window_for("nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b") == 262_144


### PR DESCRIPTION
## Bug (Kundensystem, NVIDIA NIM)
`nvidia_nim/nvidia/nemotron-3-ultra-550b-a55b` (Nemotron Ultra) wurde mit einem viel zu kleinen Kontextfenster angezeigt und in der Compaction genutzt.

## Root-Cause (live reproduziert)
- Der NVIDIA-NIM-Endpoint `/v1/models` meldet für dieses Modell **kein `context_length`** → kommt als `None` in den Catalog.
- Es gab **keinen METADATA-Eintrag** für das Ultra-550B (die verwandten Super-120B / Ultra-253B haben welche).
- Folge: `context_window_for()` fiel auf den **32k-Default** → falsche Compaction-Rechnung, im UI ein Mini-Wert.

Verifiziert per Live-Abfrage gegen den echten NIM-Endpoint: `ctx=None` für das Ultra-Modell, während alle Modelle mit METADATA korrekt sind.

## Fix
- METADATA-Eintrag für `nemotron-3-ultra-550b-a55b` mit **262144** (256K — offizieller NIM-Default laut NVIDIA-Doku: „natively supports a context window of 262,144 tokens"; docs.nvidia.com/nim/.../get-started-nemotron-3-ultra).
- `nemotron-3.5-content-safety` gleich mit ergänzt (kam ebenfalls als `None`).

## Verifiziert
- Live gegen echten NIM-Endpoint: Ultra zeigt jetzt **262144** statt None/32k ✅
- 2 Regressionstests grün ✅
