### PR TITLE
feat(tools): aktuellen Benutzerturn vertrauenswürdig bereitstellen

### DIFF
--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -88,7 +88,8 @@ async def run(
     workspace, active_project_id = resolve_run_context(session, agent, tool_config)
     ctx = ToolContext(session_id=session_id, agent_id=agent["id"], user_id=session.user_id,
                      workspace=workspace, config=effective_tool_config(agent, tool_config),
-                     project_id=active_project_id)
+                     project_id=active_project_id,
+                     current_user_input=_user_text(user_input))
 
     # Session-Lifecycle: start
     _first_prompt = user_input if isinstance(user_input, str) else None

--- a/core/src/hydrahive/tools/base.py
+++ b/core/src/hydrahive/tools/base.py
@@ -14,6 +14,7 @@ class ToolContext:
     workspace: Path
     config: dict = field(default_factory=dict)
     project_id: str | None = None  # Aktives Projekt — Memory-Tools nutzen dies als Default-Filter
+    current_user_input: str | None = None  # Vertrauenswürdig: ausschließlich vom Runner gesetzt
 
 
 @dataclass

--- a/core/tests/test_runner_tool_context.py
+++ b/core/tests/test_runner_tool_context.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.agents import config as agent_config
+from hydrahive.db import init_db
+from hydrahive.db import sessions as sessions_db
+from hydrahive.runner import runner as runner_mod
+from hydrahive.runner._runner_iter import IterationResult
+from hydrahive.tools.base import ToolContext
+
+_AGENT_ID = "test-agent-001"
+
+
+@pytest.mark.parametrize(
+    "user_input,expected",
+    [
+        ("Lade genau diesen Film", "Lade genau diesen Film"),
+        (
+            [
+                {"type": "text", "text": "Lade den Film"},
+                {"type": "image", "source": {"type": "url", "url": "https://evil"}},
+                {"type": "text", "text": "in 1080p"},
+            ],
+            "Lade den Film in 1080p",
+        ),
+    ],
+)
+def test_runner_sets_trusted_current_user_input(
+    setup_test_env, monkeypatch, user_input, expected
+):
+    init_db()
+    agent_config.update(
+        _AGENT_ID, max_iterations=1, compact_threshold_pct=100,
+        tools=["shell_exec"],
+    )
+    session = sessions_db.create(
+        agent_id=_AGENT_ID, user_id="admin", title="trusted-turn-test"
+    )
+    captured = []
+
+    async def fake_stream(**kwargs):
+        yield IterationResult(
+            blocks=[{
+                "type": "tool_use", "id": "toolu_trusted", "name": "shell_exec",
+                "input": {"current_user_input": "vom Modell manipuliert"},
+            }],
+            stop_reason="tool_use", used_model=kwargs["primary_model"],
+            input_tokens=1, output_tokens=1,
+            cache_creation_tokens=0, cache_read_tokens=0,
+        )
+
+    async def fake_process(tool_uses, **kwargs):
+        captured.append(kwargs["ctx"])
+        yield []
+
+    monkeypatch.setattr(runner_mod, "stream_llm_call", fake_stream)
+    monkeypatch.setattr(runner_mod, "process_tool_uses", fake_process)
+    asyncio.run(_drain(session.id, user_input))
+
+    assert captured[0].current_user_input == expected
+
+
+async def _drain(session_id: str, user_input):
+    return [event async for event in runner_mod.run(session_id, user_input)]
+
+
+def test_tool_context_field_is_optional_for_backwards_compatibility(tmp_path):
+    context = ToolContext(
+        session_id="s", agent_id="a", user_id="u", workspace=tmp_path
+    )
+    assert context.current_user_input is None


### PR DESCRIPTION
## Zusammenfassung

- ergänzt `ToolContext.current_user_input` rückwärtskompatibel als optionales Feld
- setzt den Wert ausschließlich im Runner aus dem aktuellen authentifizierten `user_input`
- übernimmt bei multimodalem Input nur Textblöcke in ihrer Reihenfolge
- Tool-Argumente, Assistant-Text und Tool-Ausgaben können den Wert nicht verändern

Voraussetzung für konservative modulare Action-Grants, zunächst Mediacenter E4.

## Verifikation

- 37 fokussierte Runner-/Context-Tests grün
- Security-Review: CLEAN
- Ruff grün
- vollständige Core-Suite lief länger als das 300-Sekunden-Toolfenster; kein Fehlschlag gemeldet, fokussierte betroffene Suites vollständig grün
