### PR TITLE
feat(tools): aktuellen Benutzerturn eindeutig binden

### DIFF
--- a/core/src/hydrahive/runner/runner.py
+++ b/core/src/hydrahive/runner/runner.py
@@ -119,7 +119,8 @@ async def run(
 
     from hydrahive.handover import prompt_for_new_session
     handover_system = prompt_for_new_session(session_id)
-    messages_db.append(session_id, "user", user_input)
+    user_message = messages_db.append(session_id, "user", user_input)
+    ctx.current_user_turn_id = user_message.id
 
     last_assistant_id: str | None = None
     recent_tool_calls: list[str] = []

--- a/core/src/hydrahive/tools/base.py
+++ b/core/src/hydrahive/tools/base.py
@@ -15,6 +15,7 @@ class ToolContext:
     config: dict = field(default_factory=dict)
     project_id: str | None = None  # Aktives Projekt — Memory-Tools nutzen dies als Default-Filter
     current_user_input: str | None = None  # Vertrauenswürdig: ausschließlich vom Runner gesetzt
+    current_user_turn_id: str | None = None  # ID der vom Runner persistierten User-Nachricht
 
 
 @dataclass

--- a/core/tests/test_runner_tool_context.py
+++ b/core/tests/test_runner_tool_context.py
@@ -45,7 +45,10 @@ def test_runner_sets_trusted_current_user_input(
         yield IterationResult(
             blocks=[{
                 "type": "tool_use", "id": "toolu_trusted", "name": "shell_exec",
-                "input": {"current_user_input": "vom Modell manipuliert"},
+                "input": {
+                    "current_user_input": "vom Modell manipuliert",
+                    "current_user_turn_id": "vom Modell manipuliert",
+                },
             }],
             stop_reason="tool_use", used_model=kwargs["primary_model"],
             input_tokens=1, output_tokens=1,
@@ -61,6 +64,8 @@ def test_runner_sets_trusted_current_user_input(
     asyncio.run(_drain(session.id, user_input))
 
     assert captured[0].current_user_input == expected
+    assert captured[0].current_user_turn_id
+    assert captured[0].current_user_turn_id != "vom Modell manipuliert"
 
 
 async def _drain(session_id: str, user_input):
@@ -72,3 +77,4 @@ def test_tool_context_field_is_optional_for_backwards_compatibility(tmp_path):
         session_id="s", agent_id="a", user_id="u", workspace=tmp_path
     )
     assert context.current_user_input is None
+    assert context.current_user_turn_id is None


### PR DESCRIPTION
## Zusammenfassung

Ergänzt die bereits gemergte vertrauenswürdige `current_user_input`-Grenze um `current_user_turn_id`:

- ID stammt ausschließlich von der gerade im Runner persistierten User-Nachricht
- über alle Tool-Aufrufe desselben Runs stabil
- optional und rückwärtskompatibel
- nicht über Tool-Argumente manipulierbar

Dies verhindert, dass identischer Text in zwei echten Benutzerturns mit demselben Action-Grant verwechselt wird, während wiederholte Tool-Aufrufe im selben Turn erkennbar bleiben.

## Verifikation

- 37 Runner-/Context-Tests grün
- Ruff grün
- Security-Review CLEAN
