### PR TITLE
fix(agents): Modul-Default-Tools nach Startup migrieren

### DIFF
--- a/core/src/hydrahive/agents/bootstrap.py
+++ b/core/src/hydrahive/agents/bootstrap.py
@@ -24,11 +24,11 @@ def _write_startup(agent: dict) -> None:
     startup.write_text(_STARTUP_TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8")
 
 
-def migrate_tools() -> None:
-    """Stellt sicher dass alle bestehenden Agenten die Tools aus _BASE_TOOLS haben.
+def migrate_tools(*, include_module_defaults: bool = False) -> None:
+    """Stellt sicher dass bestehende Agenten ihre kanonischen Default-Tools haben.
 
-    Läuft bei jedem Start — idempotent. Neue Tools in _BASE_TOOLS werden so
-    automatisch in bestehende Agent-Configs übernommen ohne manuellen Eingriff.
+    Läuft bei jedem Start idempotent. Nach dem Modul-Load ergänzt der optionale
+    zweite Lauf auch Tools aus Modulen mit ``default_agent_tools=true`` bei Mastern.
 
     Nutzt direktes save_atomic statt config.update, damit Agenten mit Plugin-Tools
     (plugin__*) nicht an der Validation scheitern — wir fügen nur hinzu, nie entfernen.
@@ -36,13 +36,23 @@ def migrate_tools() -> None:
     from hydrahive.agents._config_utils import list_all, save_atomic
     from hydrahive.agents._paths import config_path
     from hydrahive.db._utils import now_iso
+    if include_module_defaults:
+        from hydrahive.agents._defaults import _module_default_tool_names
+        from hydrahive.tools import REGISTRY
+        module_defaults = [
+            name for name in _module_default_tool_names() if name in REGISTRY
+        ]
+    else:
+        module_defaults = []
     for agent in list_all():
         agent_type = agent.get("type", "")
         if agent_type not in _BASE_TOOLS:
             continue
         current: list[str] = agent.get("tools", [])
-        canonical: list[str] = _BASE_TOOLS[agent_type]
-        missing = [t for t in canonical if t not in current]
+        canonical = list(_BASE_TOOLS[agent_type])
+        if agent_type == "master":
+            canonical.extend(module_defaults)
+        missing = [t for t in dict.fromkeys(canonical) if t not in current]
         if not missing:
             continue
         try:

--- a/core/src/hydrahive/api/lifespan.py
+++ b/core/src/hydrahive/api/lifespan.py
@@ -138,6 +138,7 @@ async def lifespan(app: FastAPI):
         t for m in _module_registry.values()
         if m.loaded and m.ctx for t in m.ctx.tools
     ])
+    agent_bootstrap.migrate_tools(include_module_defaults=True)
     from hydrahive.llm import registry as llm_registry
     # Hintergrund-Warm: blockiert den Start nicht (Provider-Fetch-Timeouts);
     # validate ist failopen während des kurzen kalten Fensters.

--- a/core/tests/test_module_default_tools.py
+++ b/core/tests/test_module_default_tools.py
@@ -59,6 +59,26 @@ def test_master_defaults_deduped(monkeypatch):
         tools.register_module_tools([])
 
 
+def test_existing_master_receives_module_defaults_after_load(monkeypatch):
+    from hydrahive.agents import bootstrap
+    from hydrahive.agents import _config_utils
+    from hydrahive.agents import _paths
+    from hydrahive import tools
+
+    _install_fake_module(monkeypatch, flag=True, tool_name="fakemod_migrated")
+    agent = {"id": "master-1", "name": "Master", "type": "master", "tools": []}
+    saved = []
+    monkeypatch.setattr(_config_utils, "list_all", lambda: [agent])
+    monkeypatch.setattr(_config_utils, "save_atomic", lambda path, value: saved.append(value.copy()))
+    monkeypatch.setattr(_paths, "config_path", lambda _: Path("/tmp/fake-agent.json"))
+    try:
+        bootstrap.migrate_tools(include_module_defaults=True)
+        assert "fakemod_migrated" in agent["tools"]
+        assert len(saved) == 1
+    finally:
+        tools.register_module_tools([])
+
+
 def test_unregistered_module_tool_filtered(monkeypatch):
     # Flag gesetzt, aber Tool NICHT in tools.REGISTRY → muss rausgefiltert werden.
     from hydrahive import tools
@@ -70,3 +90,11 @@ def test_unregistered_module_tool_filtered(monkeypatch):
                                      ctx=ctx, loaded=True))
     from hydrahive.agents._defaults import DEFAULT_TOOLS
     assert "ghost_tool" not in DEFAULT_TOOLS["master"]
+
+    from hydrahive.agents import _config_utils, _paths, bootstrap
+    agent = {"id": "master-ghost", "name": "Master", "type": "master", "tools": []}
+    monkeypatch.setattr(_config_utils, "list_all", lambda: [agent])
+    monkeypatch.setattr(_config_utils, "save_atomic", lambda *args: None)
+    monkeypatch.setattr(_paths, "config_path", lambda _: Path("/tmp/ghost.json"))
+    bootstrap.migrate_tools(include_module_defaults=True)
+    assert "ghost_tool" not in agent["tools"]


### PR DESCRIPTION
## Zusammenfassung

Behebt die Startup-Reihenfolge für Module mit `default_agent_tools: true`:

- nach Modul-Load und Tool-Registrierung läuft eine zweite idempotente Tool-Migration
- nur Master-Agenten erhalten Modul-Defaults
- bestehende Agenten und der initiale Master werden erfasst
- nur tatsächlich registrierte Tool-Namen werden persistiert
- Projekt-/Spezialisten-Tools bleiben unverändert

## Verifikation

- 15 betroffene Modul-/Runner-Tests grün
- Ruff grün
- Registry-Negativtest für nicht registrierte Modul-Tools
