### PR TITLE
fix(llm): Anthropic-Modelle per OAuth aktualisieren

### DIFF
--- a/core/src/hydrahive/api/routes/llm_oauth.py
+++ b/core/src/hydrahive/api/routes/llm_oauth.py
@@ -43,6 +43,7 @@ CODEX_DEFAULT_MODELS = [
 ]
 
 ANTHROPIC_DEFAULT_MODELS = [
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",

--- a/core/src/hydrahive/llm/_anthropic.py
+++ b/core/src/hydrahive/llm/_anthropic.py
@@ -28,7 +28,7 @@ EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
 # Claude-Modelle mit adaptive thinking + output_config.effort (4.6 und neuer).
 # Alle anderen (Claude 4.5/4.1/4.0/3.x, MiniMax) nutzen den Legacy-Pfad.
 EFFORT_PARAM_MODELS = (
-    "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6",
+    "claude-opus-5", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6",
     "claude-sonnet-5", "claude-fable-5",
 )
 

--- a/core/src/hydrahive/llm/_catalog_data.py
+++ b/core/src/hydrahive/llm/_catalog_data.py
@@ -24,10 +24,10 @@ PROVIDER_ENDPOINTS = {
     "openai-codex": {"url": None, "auth": None},
 }
 
-# Static-Listen für Provider ohne /v1/models-Endpoint.
+# Static-Fallbacks für Provider ohne Listing-Endpoint oder bei Live-Fetch-Fehlern.
 STATIC_MODELS = {
     "anthropic": [
-        "claude-fable-5", "claude-sonnet-5", "claude-sonnet-4-6",
+        "claude-opus-5", "claude-fable-5", "claude-sonnet-5", "claude-sonnet-4-6",
         "claude-opus-4-8", "claude-opus-4-7",
         "claude-haiku-4-5", "claude-sonnet-4-5", "claude-3-7-sonnet-20250219",
         "claude-3-5-haiku-20241022",
@@ -64,6 +64,7 @@ PROVIDER_PREFIX = {
 # tool_use: True/False/None (None = ungetestet/unbekannt).
 METADATA: dict[str, dict[str, Any]] = {
     # Anthropic
+    "claude-opus-5":     {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-fable-5":    {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-sonnet-5":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},
     "claude-opus-4-8":   {"context_window": 1_000_000, "tool_use": True, "category": "chat", "family": "anthropic"},

--- a/core/src/hydrahive/llm/_pricing.py
+++ b/core/src/hydrahive/llm/_pricing.py
@@ -1,7 +1,7 @@
 """LLM-Pricing-Lookup für Cost-Tracking (Mikro-Cents).
 
 Preise in **Mikro-Cents pro Token** (1 Cent = 1000 Micros). Quelle: offizielle
-Anbieter-Pricing-Pages, Stand 2026-05-11. Veraltete Werte bei Modell-Refresh
+Anbieter-Pricing-Pages, Stand 2026-07-24. Veraltete Werte bei Modell-Refresh
 hier aktualisieren — diese Datei ist die einzige Quelle.
 
 Mapping `(provider, model)` → 4 Raten. Für nicht-gelistete Modelle: None →
@@ -23,6 +23,8 @@ class Pricing(NamedTuple):
 # Anthropic Claude — $/1M tokens × 100 cents × 1000 micros / 1M tokens = $-Wert × 0.1 micros/token
 # Beispiel: Sonnet $3/1M input = 3 × 0.1 = 0.3 micros/token
 _ANTHROPIC: dict[str, Pricing] = {
+    # Opus 5: $5 / $25 / cache_read $0.50 / cache_write $6.25 (Stand 2026-07, Release 24.07)
+    "claude-opus-5": Pricing(0.5, 2.5, 0.05, 0.625),
     # Fable 5: $10 / $50 / cache_read $1.00 / cache_write $12.50 (Stand 2026-06, Release 09.06)
     "claude-fable-5": Pricing(1.0, 5.0, 0.1, 1.25),
     # Sonnet 5: $2 / $10 / cache_read $0.20 / cache_write $2.50 (Intro-Preis, Stand 2026-07)

--- a/core/src/hydrahive/llm/catalog.py
+++ b/core/src/hydrahive/llm/catalog.py
@@ -13,6 +13,7 @@ Daten (Provider-Endpoints, Static-Listen, Metadata) liegen in
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
 from typing import Any
@@ -35,22 +36,30 @@ _cache_locks: dict[str, asyncio.Lock] = {}
 
 def _cache_clear() -> None:
     _cache.clear()
+    _cache_locks.clear()
+
+
+def _credential_cache_key(provider_id: str, credential: str) -> str:
+    """Isoliert Provider-Listings pro Credential, ohne Tokens im Cache abzulegen."""
+    digest = hashlib.sha256(credential.encode()).hexdigest()[:16]
+    return f"{provider_id}:{digest}"
 
 
 async def _cached_fetch(provider_id: str, api_key: str) -> list[dict]:
     """Live-Fetch mit 5-Min-TTL-Cache + Lock gegen parallele Fetches."""
+    cache_key = _credential_cache_key(provider_id, api_key)
     now = time.monotonic()
-    hit = _cache.get(provider_id)
+    hit = _cache.get(cache_key)
     if hit and now - hit[0] < _CACHE_TTL:
         return hit[1]
-    lock = _cache_locks.setdefault(provider_id, asyncio.Lock())
+    lock = _cache_locks.setdefault(cache_key, asyncio.Lock())
     async with lock:
-        hit = _cache.get(provider_id)  # zweiter Check nach Lock
+        hit = _cache.get(cache_key)  # zweiter Check nach Lock
         if hit and time.monotonic() - hit[0] < _CACHE_TTL:
             return hit[1]
         entries = await _fetch_live_models(provider_id, api_key)
         if entries:  # nur erfolgreiche Fetches cachen
-            _cache[provider_id] = (time.monotonic(), entries)
+            _cache[cache_key] = (time.monotonic(), entries)
         return entries
 
 
@@ -109,7 +118,14 @@ def _auth_for(cfg: dict, api_key: str) -> tuple[dict, dict]:
         return {"Authorization": f"Bearer {api_key}"}, {}
     if kind == "query":
         return {}, {cfg.get("query_param", "key"): api_key}
-    if kind == "x-api-key":  # Anthropic
+    if kind == "x-api-key":  # Anthropic: API-Key oder Claude-Code-OAuth-Token
+        if api_key.startswith("sk-ant-oat"):
+            from hydrahive.llm._anthropic import _OAUTH_HEADERS
+            return {
+                "Authorization": f"Bearer {api_key}",
+                "anthropic-version": "2023-06-01",
+                **_OAUTH_HEADERS,
+            }, {}
         return {"x-api-key": api_key, "anthropic-version": "2023-06-01"}, {}
     return {}, {}
 
@@ -236,6 +252,25 @@ def _enrich(provider_id: str, entry: dict) -> dict[str, Any]:
     }
 
 
+def _catalog_credentials(provider: dict) -> list[str]:
+    """Credentials in sicherer Retry-Reihenfolge, ohne sie zu persistieren.
+
+    Für Anthropic wird ein noch gültiger OAuth-Token bevorzugt. Ist er abgelaufen,
+    kommt ein paralleler API-Key zuerst. Der zweite Credential bleibt als einmaliger
+    Fallback erhalten, falls der bevorzugte widerrufen wurde.
+    """
+    api_key = provider.get("api_key", "") or ""
+    oauth = provider.get("oauth") or {}
+    access = oauth.get("access", "") or ""
+    if provider.get("id") != "anthropic":
+        return [key for key in (api_key or access,) if key]
+
+    expires_at = int(oauth.get("expires_at") or 0)
+    oauth_current = bool(access) and (expires_at == 0 or expires_at > time.time())
+    ordered = (access, api_key) if oauth_current else (api_key, access)
+    return list(dict.fromkeys(key for key in ordered if key))
+
+
 async def catalog_for_providers(providers: list[dict]) -> list[dict]:
     """Erzeugt Catalog-Einträge pro konfiguriertem Provider parallel.
 
@@ -254,8 +289,13 @@ async def catalog_for_providers(providers: list[dict]) -> list[dict]:
                 "models": models,
                 "live_count": len(entries),
             }
-        key = p.get("api_key", "") or (p.get("oauth") or {}).get("access", "")
-        entries = await _cached_fetch(pid, key)
+        credentials = _catalog_credentials(p)
+        entries: list[dict] = []
+        for credential in credentials:
+            entries = await _cached_fetch(pid, credential)
+            if entries:
+                break
+        live_count = len(entries)
         if not entries:
             entries = [{"id": _normalize_id(pid, m), "context_window": None,
                         "is_free": None, "price_prompt": None, "price_completion": None}
@@ -264,8 +304,8 @@ async def catalog_for_providers(providers: list[dict]) -> list[dict]:
         return {
             "provider_id": pid,
             "provider_name": p.get("name", pid),
-            "configured": bool(key),
+            "configured": bool(credentials),
             "models": models,
-            "live_count": len(entries),
+            "live_count": live_count,
         }
     return await asyncio.gather(*[one(p) for p in providers])

--- a/core/tests/test_catalog_live.py
+++ b/core/tests/test_catalog_live.py
@@ -86,13 +86,121 @@ def test_anthropic_endpoint_uses_x_api_key():
 
 
 def test_auth_for_x_api_key():
-    headers, params = catalog._auth_for({"auth": "x-api-key"}, "sk-ant-xxx")
-    assert headers["x-api-key"] == "sk-ant-xxx"
+    headers, params = catalog._auth_for({"auth": "x-api-key"}, "sk-ant-api03-xxx")
+    assert headers["x-api-key"] == "sk-ant-api03-xxx"
+    assert "Authorization" not in headers
     assert headers["anthropic-version"] == "2023-06-01"
     assert params == {}
 
 
+def test_auth_for_anthropic_oauth_uses_bearer_and_cli_headers():
+    headers, params = catalog._auth_for({"auth": "x-api-key"}, "sk-ant-oat01-xxx")
+    assert headers["Authorization"] == "Bearer sk-ant-oat01-xxx"
+    assert "x-api-key" not in headers
+    assert headers["anthropic-version"] == "2023-06-01"
+    assert "oauth-2025-04-20" in headers["anthropic-beta"]
+    assert headers["x-app"] == "cli"
+    assert params == {}
+
+
+def test_opus_5_is_complete_static_fallback():
+    from hydrahive.llm._catalog_data import METADATA, STATIC_MODELS
+
+    assert "claude-opus-5" in STATIC_MODELS["anthropic"]
+    assert METADATA["claude-opus-5"] == {
+        "context_window": 1_000_000,
+        "tool_use": True,
+        "category": "chat",
+        "family": "anthropic",
+    }
+
+
 import asyncio
+
+
+def test_anthropic_catalog_prefers_oauth_access_over_api_key(monkeypatch):
+    seen = []
+
+    async def fake_fetch(provider_id, key):
+        seen.append((provider_id, key))
+        return [{"id": "claude-opus-5", "context_window": 1_000_000,
+                 "is_free": None, "price_prompt": None, "price_completion": None}]
+
+    monkeypatch.setattr(catalog, "_cached_fetch", fake_fetch)
+    providers = [{
+        "id": "anthropic",
+        "api_key": "sk-ant-api03-old",
+        "oauth": {"access": "sk-ant-oat01-current"},
+    }]
+
+    result = asyncio.run(catalog.catalog_for_providers(providers))
+
+    assert seen == [("anthropic", "sk-ant-oat01-current")]
+    assert result[0]["models"][0]["id"] == "claude-opus-5"
+
+
+def test_anthropic_catalog_uses_api_key_when_oauth_is_expired(monkeypatch):
+    seen = []
+
+    async def fake_fetch(provider_id, key):
+        seen.append((provider_id, key))
+        return [{"id": "claude-opus-5", "context_window": 1_000_000,
+                 "is_free": None, "price_prompt": None, "price_completion": None}]
+
+    monkeypatch.setattr(catalog, "_cached_fetch", fake_fetch)
+    providers = [{
+        "id": "anthropic",
+        "api_key": "sk-ant-api03-current",
+        "oauth": {"access": "sk-ant-oat01-expired", "expires_at": 1},
+    }]
+
+    asyncio.run(catalog.catalog_for_providers(providers))
+
+    assert seen == [("anthropic", "sk-ant-api03-current")]
+
+
+def test_anthropic_catalog_retries_api_key_after_oauth_failure(monkeypatch):
+    seen = []
+
+    async def fake_fetch(provider_id, key):
+        seen.append((provider_id, key))
+        if key.startswith("sk-ant-oat"):
+            return []
+        return [{"id": "claude-opus-5", "context_window": 1_000_000,
+                 "is_free": None, "price_prompt": None, "price_completion": None}]
+
+    monkeypatch.setattr(catalog, "_cached_fetch", fake_fetch)
+    providers = [{
+        "id": "anthropic",
+        "api_key": "sk-ant-api03-fallback",
+        "oauth": {"access": "sk-ant-oat01-revoked", "expires_at": 9_999_999_999},
+    }]
+
+    result = asyncio.run(catalog.catalog_for_providers(providers))
+
+    assert seen == [
+        ("anthropic", "sk-ant-oat01-revoked"),
+        ("anthropic", "sk-ant-api03-fallback"),
+    ]
+    assert result[0]["models"][0]["id"] == "claude-opus-5"
+
+
+def test_cache_is_scoped_by_credential_without_storing_raw_token(monkeypatch):
+    calls = []
+
+    async def fake_fetch(pid, key):
+        calls.append((pid, key))
+        return [{"id": f"{pid}/x", "context_window": None, "is_free": True,
+                 "price_prompt": "0", "price_completion": "0"}]
+
+    monkeypatch.setattr(catalog, "_fetch_live_models", fake_fetch)
+    catalog._cache_clear()
+    asyncio.run(catalog._cached_fetch("openrouter", "first-secret-token"))
+    asyncio.run(catalog._cached_fetch("openrouter", "second-secret-token"))
+
+    assert len(calls) == 2
+    assert "first-secret-token" not in repr(catalog._cache)
+    assert "second-secret-token" not in repr(catalog._cache)
 
 
 def test_cache_hit_skips_second_fetch(monkeypatch):

--- a/core/tests/test_llm_oauth_routes.py
+++ b/core/tests/test_llm_oauth_routes.py
@@ -12,6 +12,12 @@ import json
 from unittest.mock import AsyncMock, patch
 
 
+def test_anthropic_oauth_defaults_include_opus_5():
+    from hydrahive.api.routes.llm_oauth import ANTHROPIC_DEFAULT_MODELS
+
+    assert ANTHROPIC_DEFAULT_MODELS[0] == "claude-opus-5"
+
+
 def _fake_pkce():
     return ("verifier123", "challenge123")
 

--- a/core/tests/test_llm_pricing.py
+++ b/core/tests/test_llm_pricing.py
@@ -5,7 +5,7 @@ cost_micros() darf für OpenRouter keine Exception werfen (Option A: None).
 """
 from __future__ import annotations
 
-from hydrahive.llm._pricing import cost_micros, provider_from_model
+from hydrahive.llm._pricing import Pricing, cost_micros, lookup, provider_from_model
 
 
 def test_openrouter_prefix_erkannt():
@@ -20,6 +20,15 @@ def test_andere_provider_unveraendert():
     assert provider_from_model("claude-sonnet-4-6") == "anthropic"
     assert provider_from_model("gpt-4o") == "openai"
     assert provider_from_model("unknown-model-xyz") == "other"
+
+
+def test_claude_opus_5_pricing_is_current():
+    assert lookup("anthropic", "claude-opus-5") == Pricing(
+        input=0.5,
+        output=2.5,
+        cache_read=0.05,
+        cache_creation=0.625,
+    )
 
 
 def test_cost_micros_openrouter_gibt_none_nicht_crash():

--- a/core/tests/test_reasoning_effort.py
+++ b/core/tests/test_reasoning_effort.py
@@ -177,6 +177,16 @@ def test_effort_levels_vollstaendig():
     assert EFFORT_LEVELS == ("low", "medium", "high", "xhigh", "max")
 
 
+def test_opus_5_uses_adaptive_effort_including_max():
+    assert any("claude-opus-5".startswith(p) for p in EFFORT_PARAM_MODELS)
+    assert effort_levels_for_model("claude-opus-5") == EFFORT_LEVELS
+    kwargs = {"max_tokens": 8192, "temperature": 0.4}
+    apply_effort(kwargs, "claude-opus-5", "max")
+    assert kwargs["thinking"] == {"type": "adaptive"}
+    assert kwargs["output_config"]["effort"] == "max"
+    assert kwargs["temperature"] == 0.4
+
+
 def test_opus_4_8_in_effort_param_models():
     assert any("claude-opus-4-8".startswith(p) for p in EFFORT_PARAM_MODELS)
 

--- a/docs/plans/anthropic-oauth-model-refresh.md
+++ b/docs/plans/anthropic-oauth-model-refresh.md
@@ -1,0 +1,53 @@
+# Plan: Anthropic-OAuth-Modellrefresh und Claude Opus 5
+
+## Ziel
+
+Der kanonische HydraHive-Modellkatalog lädt Anthropic-Modelle auch mit einem Claude-Code-/OAuth-Token live über `/v1/models`. Claude Opus 5 steht zusätzlich als sicherer Fallback mit vollständigen Laufzeitmetadaten bereit, sodass Buddy- und Agenten-Picker das Modell anzeigen und korrekt ausführen können.
+
+## Dateien
+
+- `core/src/hydrahive/llm/catalog.py` — tokenabhängige Anthropic-Authentifizierung für das Live-Listing.
+- `core/src/hydrahive/llm/_catalog_data.py` — Opus-5-Fallback und Metadaten.
+- `core/src/hydrahive/llm/_anthropic.py` — adaptive Effort-Unterstützung für Opus 5.
+- `core/src/hydrahive/api/routes/llm_oauth.py` — Opus 5 als Default bei neuen Anthropic-OAuth-Konfigurationen.
+- `core/src/hydrahive/llm/_pricing.py` — Opus-5-Preise für Telemetrie.
+- `core/tests/test_llm_catalog.py` — OAuth-Header, Live-Erkennung und Fallback.
+- `core/tests/test_reasoning_effort.py` — Opus-5-Effort-Pfad.
+- `core/tests/test_llm_pricing.py` — Opus-5-Kostenlookup.
+
+## Implementierungsreihenfolge
+
+### Task 1: OAuth-Live-Listing
+
+- [ ] Regressionstest: `sk-ant-oat` wird als Bearer mit Anthropic-OAuth-Headern gesendet.
+- [ ] Test schlägt mit aktuellem `x-api-key`-Verhalten fehl.
+- [ ] Auth-Header tokenabhängig erzeugen, ohne Tokens zu loggen.
+- [ ] Live gelieferte unbekannte Modelle weiterhin automatisch durchreichen.
+
+### Task 2: Opus-5-Fallback und Laufzeitmetadaten
+
+- [ ] Tests für statische Sichtbarkeit, 1M-Kontext, Tool-Use und Anthropic-Familie ergänzen.
+- [ ] `claude-opus-5` in Fallback und Metadata aufnehmen.
+- [ ] Opus 5 dem adaptiven Effort-Pfad sowie den OAuth-Defaults hinzufügen.
+
+### Task 3: Pricing und Gesamtverifikation
+
+- [ ] Pricing-Test für Opus 5 ergänzen.
+- [ ] Offizielle Preise $5/M Input und $25/M Output samt Cache-Raten hinterlegen.
+- [ ] Fokussierte und vollständige Core-Tests sowie Ruff ausführen.
+- [ ] Produktionskonfiguration read-only gegen Anthropic `/v1/models` prüfen; kein Deployment und kein Service-Neustart.
+
+## Akzeptanzkriterien
+
+- [ ] OAuth-Live-Fetch liefert ohne 401 die Anthropic-Modellliste.
+- [ ] `claude-opus-5` erscheint in Registry und Buddy-Modellliste.
+- [ ] Neue, noch nicht statisch bekannte Anthropic-Modelle werden live übernommen.
+- [ ] Bei Providerfehlern bleibt Opus 5 über den statischen Fallback auswählbar.
+- [ ] Opus 5 nutzt adaptive Thinking-/Effort-Stufen einschließlich `max`.
+- [ ] Keine Secrets erscheinen in Logs, Tests oder Diffs.
+
+## Nicht in diesem Plan
+
+- Kein automatisches Umschalten bestehender Agenten auf Opus 5.
+- Kein Deployment, Dateikopieren in die aktive Installation oder Service-Neustart.
+- Keine Änderung an anderen Provider-Authentifizierungen.


### PR DESCRIPTION
## Ursache
Der Anthropic-Katalog verwendete auch für Claude-Code-/OAuth-Tokens den Header `x-api-key`. Anthropic beantwortete `/v1/models` deshalb mit 401; HydraHive fiel unbemerkt auf eine veraltete statische Liste ohne `claude-opus-5` zurück.

## Änderung
- Anthropic-OAuth-Tokens beim Modelllisting korrekt als Bearer inklusive Claude-Code-/OAuth-Headern senden
- gültiges OAuth bevorzugen, abgelaufenes OAuth hinter einen API-Key stellen und bei widerrufenem OAuth einmal sicher auf API-Key zurückfallen
- Modellcache per gehashtem Credential-Fingerprint isolieren; rohe Tokens werden weder gespeichert noch geloggt
- `claude-opus-5` als statischen Fallback mit 1M Kontext, Tool-Use und Anthropic-Metadaten ergänzen
- adaptive Thinking-/Effort-Stufen bis `max` aktivieren
- neue Anthropic-OAuth-Konfigurationen mit Opus 5 vorbelegen
- offizielles Pricing ($5/M Input, $25/M Output plus Cache-Raten) ergänzen
- Live-/Fallback-Quelle korrekt über `live_count` unterscheiden

## Verifikation
- RED reproduziert: 6 Opus-/OAuth-Tests fehlgeschlagen; zusätzlich 3 Security-Regressionsfälle für Ablauf, Retry und Cache-Isolation
- fokussiert: 68 Tests grün
- komplett: 1937 Core-Tests grün
- Ruff und `git diff --check` grün
- Live `/v1/models`: 11 Anthropic-Modelle, `claude-opus-5` enthalten
- Registry: `claude-opus-5`, 1M Kontext, Tool-Use aktiv
- echter Mini-Call an `claude-opus-5`: `OK`
- unabhängiges Security-Re-Review: CLEAN

## Betrieb
Kein Deployment, keine aktive Konfigurationsänderung und kein Service-Neustart im Rahmen dieses PRs.
