### PR TITLE
feat(runner): Tool-Gate für Modelle ohne Function-Calling

### DIFF
--- a/core/src/hydrahive/llm/registry.py
+++ b/core/src/hydrahive/llm/registry.py
@@ -32,6 +32,10 @@ class ModelEntry:
     is_free: bool | None = None
     embed_dim: int | None = None
     source: str = "live"  # "live" | "fallback"
+    # Function-Calling-Fähigkeit. None = unbekannt (Provider meldet nichts).
+    # Für Ollama kommt das aus /api/show capabilities — die Registry ist die
+    # einzige Ebene, auf der lokale und Cloud-Modelle zusammenlaufen.
+    tool_use: bool | None = None
 
 
 def _classify_catalog_entry(entry: dict) -> frozenset[str]:
@@ -75,6 +79,7 @@ def _add(acc: dict[str, ModelEntry], entry: ModelEntry) -> None:
             is_free=prev.is_free if prev.is_free is not None else entry.is_free,
             embed_dim=prev.embed_dim or entry.embed_dim,
             source=prev.source,
+            tool_use=prev.tool_use if prev.tool_use is not None else entry.tool_use,
         )
 
 
@@ -103,6 +108,7 @@ async def _build() -> tuple[list[ModelEntry], bool]:
                     purposes=_classify_catalog_entry(m),
                     context_window=m.get("context_window"), is_free=m.get("is_free"),
                     source="live" if prov.get("live_count") else "fallback",
+                    tool_use=m.get("tool_use"),
                 ))
             # Ein konfigurierter Provider, der KEIN einziges Modell beitrug, gilt
             # als (transient) fehlgeschlagen -> Build ist unvollständig.

--- a/core/src/hydrahive/llm/tool_support.py
+++ b/core/src/hydrahive/llm/tool_support.py
@@ -1,0 +1,57 @@
+"""SSOT für die Frage: kann dieses Modell Function-Calling?
+
+Wird vom Runner genutzt, um Modellen ohne Tool-Support gar nicht erst
+`tool_schemas` zu schicken. Ohne dieses Gate erfinden solche Modelle Tool-Calls
+als Text-JSON, das HydraHive (korrekt) nicht ausführt — das JSON landet dann
+stumpf im Chat.
+
+Spec: docs/specs/tool-gate-non-tool-models.md
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _from_registry(model: str) -> bool | None:
+    """Tool-Fähigkeit aus dem gewärmten Registry-Cache — ohne Netzwerk-Call.
+
+    Die Registry ist die einzige Ebene, auf der lokale (Ollama, via /api/show)
+    und Cloud-Modelle zusammenlaufen. Ollama-Modelle stehen weder in METADATA
+    noch im catalog._cache, weil catalog_for_providers sie in einem Sonderzweig
+    an _cached_fetch vorbei holt.
+    """
+    from hydrahive.llm import registry
+    cache = registry._cache
+    if not cache:
+        return None
+    for entry in cache[1]:
+        if entry.id == model:
+            return entry.tool_use
+    return None
+
+
+def _from_metadata(model: str) -> bool | None:
+    """Statische Katalog-Metadata: exakter Key, dann ohne Provider-Prefix."""
+    from hydrahive.llm._catalog_data import METADATA
+    meta = METADATA.get(model) or METADATA.get(model.split("/")[-1])
+    return meta.get("tool_use") if meta else None
+
+
+def model_supports_tools(model: str) -> bool:
+    """True, wenn `model` Function-Calling beherrscht.
+
+    Reihenfolge: Registry (live) → statische METADATA → True.
+
+    Der Default ist bewusst fail-open: ein Modell fälschlich ohne Tools zu
+    lassen würde einen funktionierenden Agenten stillschweigend entmachten.
+    Der umgekehrte Fehler ist sichtbar und harmloser.
+    """
+    if not model:
+        return True
+    for source in (_from_registry, _from_metadata):
+        value = source(model)
+        if value is not None:
+            return bool(value)
+    return True

--- a/core/src/hydrahive/runner/_call.py
+++ b/core/src/hydrahive/runner/_call.py
@@ -64,6 +64,26 @@ def _sanitize_blocks(blocks: list[dict]) -> list[dict]:
     return out
 
 
+def _tools_for(model: str, tools: list[dict]) -> list[dict]:
+    """Tools nur an Modelle geben, die Function-Calling können.
+
+    Modelle ohne Tool-Support erfinden sonst Tool-Calls als Text-JSON, das wir
+    (korrekt) nicht ausführen — es landet stumpf im Chat. Das Gate greift PRO
+    MODELL, weil die Fallback-Kette auf ein Modell mit anderer Fähigkeit
+    wechseln kann. Die übergebene Liste wird nie mutiert.
+    """
+    if not tools:
+        return tools
+    from hydrahive.llm.tool_support import model_supports_tools
+    if model_supports_tools(model):
+        return tools
+    logger.info(
+        "Modell %s kann kein Function-Calling — %d Tool-Schemas werden nicht gesendet",
+        model, len(tools),
+    )
+    return []
+
+
 async def call_with_stream_or_fallback(
     *,
     models: list[str],
@@ -90,7 +110,7 @@ async def call_with_stream_or_fallback(
     _stream_kwargs = dict(
         model=primary, system_prompt=system_prompt, volatile_system=volatile_system,
         summary_system=summary_system, cache_ttl=cache_ttl, messages=messages,
-        tools=tools, temperature=temperature, max_tokens=max_tokens,
+        tools=_tools_for(primary, tools), temperature=temperature, max_tokens=max_tokens,
         reasoning_effort=reasoning_effort,
     )
     # Retry einmal bei transientem Connection-Fehler — aber nur solange noch
@@ -144,7 +164,7 @@ async def call_with_stream_or_fallback(
             fallback_blocks, fallback_stop, fallback_usage = await call_with_tools(
                 model=model, system_prompt=system_prompt, volatile_system=volatile_system,
                 summary_system=summary_system,
-                cache_ttl=cache_ttl, messages=messages, tools=tools,
+                cache_ttl=cache_ttl, messages=messages, tools=_tools_for(model, tools),
                 temperature=temperature, max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort,
             )

--- a/core/tests/test_tool_gate_non_tool_models.py
+++ b/core/tests/test_tool_gate_non_tool_models.py
@@ -1,0 +1,214 @@
+"""Tool-Gate: Modelle ohne Function-Calling bekommen keine tool_schemas.
+
+Hintergrund (Bug den till gefunden hat):
+- Der Runner schickte IMMER tool_schemas ans Modell, auch wenn das Modell laut
+  Catalog tool_use=False hat (z.B. lokale Ollama-Modelle ohne Tool-Capability).
+- Folge: das Modell kann keine echten Tool-Calls emittieren und erfindet sie als
+  Text-JSON. HydraHive fuehrt das (korrekt) NICHT aus -> rohes JSON landet
+  stumpf im Chat statt einer Antwort.
+
+Fix-Vertrag (hier als RED-Tests festgenagelt):
+1. model_supports_tools() liest zuerst den Registry-Cache (dort landen ueber
+   catalog_for_providers auch die Ollama-Modelle mit ihrer /api/show-
+   Capability), dann statische METADATA, sonst True.
+2. call_with_stream_or_fallback filtert die Tools PRO MODELL — auch fuer
+   Fallback-Modelle, die eine andere Tool-Faehigkeit haben koennen.
+3. Unbekannte Modelle behalten Tools (fail-open).
+
+WICHTIG zur Quellenwahl: Ollama-Modelle stehen NICHT in METADATA und auch NICHT
+im catalog._cache — catalog_for_providers behandelt Ollama in einem Sonderzweig,
+der _cached_fetch komplett umgeht. Nur die Registry sieht beide Welten.
+
+Alle Importe lazy in der Funktion (Test-Isolation: settings-Singleton nicht
+zur Collection-Zeit festnageln).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry_cache():
+    from hydrahive.llm import registry
+    registry.invalidate()
+    yield
+    registry.invalidate()
+
+
+def _seed_registry(*entries: tuple[str, bool | None]) -> None:
+    """Setzt den Registry-Cache direkt (kein Netzwerk)."""
+    import time
+
+    from hydrahive.llm import registry
+    built = [
+        registry.ModelEntry(
+            id=mid, provider="x", label=mid, purposes=frozenset({"chat"}),
+            tool_use=tu,
+        )
+        for mid, tu in entries
+    ]
+    registry._cache = (time.monotonic(), built)
+
+
+# --- 1. model_supports_tools: die SSOT-Aufloesung ---------------------------
+
+def test_metadata_modell_ohne_toolsupport_wird_erkannt():
+    """abab5.5-chat steht mit tool_use=False in METADATA."""
+    from hydrahive.llm.tool_support import model_supports_tools
+    assert model_supports_tools("abab5.5-chat") is False
+
+
+def test_metadata_modell_mit_toolsupport_bleibt_true():
+    from hydrahive.llm.tool_support import model_supports_tools
+    assert model_supports_tools("claude-sonnet-4-5") is True
+
+
+def test_unbekanntes_modell_behaelt_tools_fail_open():
+    """Fail-open: lieber Tools an ein Modell das sie nicht kann (sichtbar,
+    harmlos) als einen funktionierenden Agenten stumm entmachten."""
+    from hydrahive.llm.tool_support import model_supports_tools
+    assert model_supports_tools("irgendein/unbekanntes-modell") is True
+
+
+def test_metadata_lookup_auch_ohne_provider_prefix():
+    """'openrouter/abab5.5-chat' muss auf den METADATA-Key ohne Prefix fallen."""
+    from hydrahive.llm.tool_support import model_supports_tools
+    assert model_supports_tools("openrouter/abab5.5-chat") is False
+
+
+def test_ollama_capability_aus_registry():
+    """DER KERNFALL: Ollama-Modelle stehen NICHT in METADATA. Ihre Tool-
+    Faehigkeit kommt aus /api/show und landet ueber den Catalog in der
+    Registry. Ein reiner METADATA-Lookup wuerde diesen Bug-Fall verfehlen."""
+    from hydrahive.llm.tool_support import model_supports_tools
+
+    _seed_registry(("ollama/gemma4:27b", False), ("ollama/qwen3:14b", True))
+    assert model_supports_tools("ollama/gemma4:27b") is False
+    assert model_supports_tools("ollama/qwen3:14b") is True
+
+
+def test_registry_hat_vorrang_vor_metadata():
+    """Wenn ein Modell live als tool-los gemeldet wird, gewinnt das gegen eine
+    veraltete statische METADATA-Angabe."""
+    from hydrahive.llm.tool_support import model_supports_tools
+
+    _seed_registry(("claude-sonnet-4-5", False))
+    assert model_supports_tools("claude-sonnet-4-5") is False
+
+
+def test_registry_ohne_toolinfo_faellt_auf_metadata_zurueck():
+    """tool_use=None in der Registry (Provider meldet nichts) darf das Modell
+    nicht faelschlich entmachten — METADATA entscheidet."""
+    from hydrahive.llm.tool_support import model_supports_tools
+
+    _seed_registry(("abab5.5-chat", None), ("claude-sonnet-4-5", None))
+    assert model_supports_tools("abab5.5-chat") is False
+    assert model_supports_tools("claude-sonnet-4-5") is True
+
+
+def test_kalter_cache_faellt_auf_metadata_zurueck():
+    """Kein Netzwerk-Call im heissen Pfad: leerer Cache = METADATA/Default."""
+    from hydrahive.llm.tool_support import model_supports_tools
+    assert model_supports_tools("abab5.5-chat") is False
+    assert model_supports_tools("claude-sonnet-4-5") is True
+
+
+# --- 2. Das Gate im Runner --------------------------------------------------
+
+class _Recorder:
+    """Faengt die tools ab, die tatsaechlich am Provider ankommen."""
+
+    def __init__(self):
+        self.seen: list[tuple[str, list]] = []
+
+    async def stream(self, **kwargs):
+        self.seen.append((kwargs["model"], kwargs["tools"]))
+        yield {"type": "message_start"}
+        yield {
+            "type": "message_stop", "stop_reason": "end_turn",
+            "blocks": [{"type": "text", "text": "ok"}],
+            "input_tokens": 1, "output_tokens": 1,
+            "cache_creation_tokens": 0, "cache_read_tokens": 0,
+        }
+
+
+_TOOLS = [{"name": "shell_exec", "description": "x", "input_schema": {}}]
+
+
+def _drain(models, monkeypatch, rec):
+    from hydrahive.runner import _call
+    monkeypatch.setattr(_call, "stream_with_tools", rec.stream)
+
+    async def go():
+        out = []
+        async for ev in _call.call_with_stream_or_fallback(
+            models=models, system_prompt="s", messages=[{"role": "user", "content": "hi"}],
+            tools=_TOOLS, temperature=0.7, max_tokens=100,
+        ):
+            out.append(ev)
+        return out
+
+    return asyncio.run(go())
+
+
+def test_gate_entfernt_tools_bei_modell_ohne_toolsupport(monkeypatch):
+    rec = _Recorder()
+    _drain(["abab5.5-chat"], monkeypatch, rec)
+    model, tools = rec.seen[0]
+    assert model == "abab5.5-chat"
+    assert tools == [], "Modell ohne Function-Calling darf keine tool_schemas sehen"
+
+
+def test_gate_laesst_tools_bei_faehigem_modell_durch(monkeypatch):
+    rec = _Recorder()
+    _drain(["claude-sonnet-4-5"], monkeypatch, rec)
+    _, tools = rec.seen[0]
+    assert tools == _TOOLS
+
+
+def test_gate_greift_pro_modell_in_der_fallback_kette(monkeypatch):
+    """Das Gate darf nicht einmalig pro Session entschieden werden: die
+    Fallback-Kette kann auf ein Modell mit anderer Tool-Faehigkeit wechseln."""
+    from hydrahive.runner import _call
+
+    calls: list[tuple[str, list]] = []
+
+    async def failing_stream(**kwargs):
+        raise RuntimeError("stream kaputt")
+        yield  # pragma: no cover
+
+    # Primary schlaegt fehl -> Failover aufs zweite Modell. Beide Modelle
+    # muessen individuell gegatet werden.
+    async def fake_call_with_tools(**kwargs):
+        calls.append((kwargs["model"], kwargs["tools"]))
+        if kwargs["model"] == "abab5.5-chat":
+            raise TimeoutError("primary down")
+        return [{"type": "text", "text": "ok"}], "end_turn", {}
+
+    monkeypatch.setattr(_call, "stream_with_tools", failing_stream)
+    monkeypatch.setattr(_call, "call_with_tools", fake_call_with_tools)
+    monkeypatch.setattr(_call, "should_failover", lambda e: True)
+
+    async def go():
+        async for _ in _call.call_with_stream_or_fallback(
+            models=["abab5.5-chat", "claude-sonnet-4-5"], system_prompt="s",
+            messages=[{"role": "user", "content": "hi"}], tools=_TOOLS,
+            temperature=0.7, max_tokens=100,
+        ):
+            pass
+
+    asyncio.run(go())
+    assert len(calls) == 2, f"beide Modelle muessen versucht worden sein: {calls}"
+    assert calls[0] == ("abab5.5-chat", []), "tool-loses Primary: keine Tools"
+    assert calls[1] == ("claude-sonnet-4-5", _TOOLS), "faehiges Fallback: Tools bleiben"
+
+
+def test_gate_veraendert_die_uebergebene_tools_liste_nicht(monkeypatch):
+    """Kein In-Place-Mutieren: der Runner baut tool_schemas EINMAL und
+    wiederverwendet sie ueber alle Iterationen."""
+    rec = _Recorder()
+    original = list(_TOOLS)
+    _drain(["abab5.5-chat"], monkeypatch, rec)
+    assert _TOOLS == original

--- a/docs/specs/tool-gate-non-tool-models.md
+++ b/docs/specs/tool-gate-non-tool-models.md
@@ -1,0 +1,100 @@
+# Tool-Gate für Modelle ohne Function-Calling
+
+- Status: umgesetzt
+- Datum: 2026-07-27
+- Task: `380f4184`
+
+## Problem
+
+Der Runner schickt **immer** `tool_schemas` an das Modell — unabhängig davon, ob
+das Modell Function-Calling überhaupt beherrscht. Bei Modellen ohne Tool-Support
+(z.B. viele lokale Ollama-Modelle) führt das zu einem sichtbaren Fehlverhalten:
+
+1. Das Modell sieht Tool-Beschreibungen im Prompt.
+2. Es kann sie mangels Function-Calling nicht als echte Tool-Calls ausgeben und
+   *erfindet* stattdessen Tool-Aufrufe als **Text-JSON** in der Antwort.
+3. HydraHive führt dieses Text-JSON — korrekterweise — **nicht** aus.
+4. Ergebnis: rohes JSON landet stumpf im Chat, der User bekommt Müll statt Antwort.
+
+Zusätzlich kostet das unnötig Tokens: Tool-Schemas belegen bei vielen Tools
+erheblichen Platz im Kontext eines Modells, das sie gar nicht nutzen kann.
+
+## Ziel
+
+Wenn ein Modell laut Katalog `tool_use=False` hat, werden **keine** Tools an das
+Modell geschickt. Das Modell antwortet dann sauber als reiner Chat-Partner.
+
+## Entscheidungen
+
+### Wo greift das Gate?
+
+In `runner/_call.py::call_with_stream_or_fallback` — der **einzigen** Stelle, an
+der Modell und Tools zusammentreffen und die von beiden Pfaden (Streaming und
+non-streaming Fallback) durchlaufen wird.
+
+Bewusst **nicht** in `runner.py`, wo `tool_schemas` gebaut wird: dort ist das
+Modell noch gar nicht final. `primary_model` wird pro Iteration neu aufgelöst
+(Session-Override), und die Fallback-Kette kann auf ein Modell mit anderer
+Tool-Fähigkeit wechseln. Das Gate muss also **pro Modell** greifen, nicht einmal
+pro Session — sonst bekäme ein Fallback-Modell die falsche Behandlung.
+
+### Woher kommt `tool_use`?
+
+Neue SSOT-Funktion `llm/tool_support.py::model_supports_tools(model)`.
+
+Reihenfolge:
+
+1. **Registry-Cache** (`llm/registry.py::_cache`) — die kanonische Modell-Liste.
+   Sie aggregiert `catalog_for_providers()` und enthält damit auch die
+   Ollama-Modelle mitsamt der aus `/api/show` gelesenen Tool-Capability.
+2. **Statische `METADATA`** — Fallback für Cloud-Modelle (exakter Key, dann ohne
+   Provider-Prefix).
+3. **Default `True`** — unbekannte Modelle behalten Tools.
+
+Der Default ist bewusst `True` (fail-open): ein Modell fälschlich ohne Tools zu
+lassen würde einen funktionierenden Agenten stillschweigend entmachten. Der
+umgekehrte Fehler (Tools an ein Modell, das sie nicht kann) ist das bereits
+bekannte, sichtbare und harmlosere Verhalten.
+
+**Warum die Registry und nicht der Catalog-Cache?** Ollama-Modelle stehen weder
+in `METADATA` noch im Catalog-Cache: `catalog_for_providers()` behandelt Ollama
+in einem Sonderzweig, der `_cached_fetch()` — und damit `catalog._cache` —
+komplett umgeht. Ein Lookup gegen METADATA oder den Catalog-Cache hätte also
+ausgerechnet den gemeldeten Bug-Fall (lokales Ollama-Modell ohne Tools)
+verfehlt. Die Registry ist die einzige Ebene, auf der beide Welten
+zusammenlaufen.
+
+Dafür bekommt `ModelEntry` ein neues Feld `tool_use: bool | None`, das `_build()`
+aus dem Katalog-Eintrag durchreicht und `_add()` beim Deduplizieren mitführt.
+
+Der Registry-Cache wird **nur gelesen, nie gefüllt** — kein Netzwerk-Call im
+heißen Pfad des Runners. Er wird beim Start via `awarm()` im Lifespan gewärmt,
+ist also im Normalbetrieb warm. Ist er ausnahmsweise kalt, greift METADATA bzw.
+der `True`-Default. Das Gate ist damit eine Optimierung, kein harter Blocker.
+
+### Was passiert mit den Tool-Namen im System-Prompt?
+
+Nichts. Der System-Prompt bleibt unverändert. Das Gate entfernt ausschließlich
+die `tools`-Parameter am API-Call. Grund: der Prompt ist gecacht (Anthropic
+Prompt-Caching) — ihn modellabhängig zu variieren würde den Cache brechen und
+wäre teurer als der eingesparte Platz.
+
+## Umsetzung
+
+- `core/src/hydrahive/llm/tool_support.py` (neu, ~45 Zeilen)
+  - `model_supports_tools(model: str) -> bool`
+- `core/src/hydrahive/llm/registry.py`
+  - `ModelEntry.tool_use: bool | None` + Durchreichen in `_build()`/`_add()`
+- `core/src/hydrahive/runner/_call.py`
+  - `_tools_for(model, tools)` — filtert pro Modell, loggt einmal auf INFO
+  - greift im Streaming-Pfad **und** in der Fallback-Schleife
+- `core/tests/test_tool_gate_non_tool_models.py` (neu)
+
+## Verifikation
+
+- Modell mit `tool_use=False` (METADATA) → `tools=[]` am Call
+- Ollama-Modell aus der Registry ohne Tool-Capability → `tools=[]`
+- Ollama-Modell mit `capabilities: ["tools"]` → Tools bleiben
+- Unbekanntes Modell → Tools bleiben (fail-open)
+- Fallback-Kette: tool-loses Primary → `tools=[]`, fähiges Fallback behält Tools
+- Die vom Runner übergebene `tools`-Liste wird nicht in-place mutiert


### PR DESCRIPTION
## Problem

Der Runner schickte `tool_schemas` an **jedes** Modell — auch an solche, die kein Function-Calling beherrschen (typisch: lokale Ollama-Modelle). Diese Modelle können keine echten Tool-Calls emittieren und *erfinden* sie stattdessen als Text-JSON. HydraHive führt das (korrekterweise) nicht aus — das rohe JSON landete stumpf im Chat statt einer Antwort.

Nebeneffekt: Tool-Schemas belegen erheblichen Kontext bei einem Modell, das sie gar nicht nutzen kann.

## Lösung

Modelle mit `tool_use=False` bekommen keine Tools mehr und antworten sauber als Chat.

- **`llm/tool_support.py`** (neu): `model_supports_tools()` als SSOT.
  Reihenfolge: Registry (live) → statische `METADATA` → `True`.
- **`llm/registry.py`**: `ModelEntry.tool_use` durchgereicht.
- **`runner/_call.py`**: `_tools_for()` filtert pro Modell.

## Zwei Design-Entscheidungen, die nicht offensichtlich sind

**Warum die Registry und nicht `METADATA`/`catalog._cache`?**
Ollama-Modelle stehen in *keinem* von beiden: `catalog_for_providers()` behandelt Ollama in einem Sonderzweig, der `_cached_fetch()` — und damit `catalog._cache` — komplett umgeht. Ihre Tool-Capability kommt aus `/api/show` und landet nur in der Registry. Ein METADATA-Lookup hätte ausgerechnet den gemeldeten Bug-Fall verfehlt.

**Warum das Gate in `_call.py` und nicht dort, wo `tool_schemas` gebaut wird?**
In `runner.py` steht das Modell noch nicht fest: `primary_model` wird pro Iteration neu aufgelöst (Session-Override), und die Fallback-Kette kann auf ein Modell mit anderer Tool-Fähigkeit wechseln. Das Gate muss pro Modell greifen — sonst bekäme ein Fallback-Modell die falsche Behandlung. `_call.py` ist die einzige Stelle, die beide Pfade (Streaming + non-streaming Fallback) durchlaufen.

## Bewusst fail-open

Unbekannte Modelle behalten Tools. Ein Modell fälschlich zu entmachten wäre ein stiller, schwer auffindbarer Fehler; der umgekehrte Fall ist das bereits bekannte, sichtbare Verhalten.

Der System-Prompt bleibt unverändert — ihn modellabhängig zu variieren würde das Anthropic-Prompt-Caching brechen und wäre teurer als der eingesparte Platz.

## Tests

12 neue Tests, u.a. Ollama-Capability aus der Registry, Registry-Vorrang vor METADATA, fail-open bei kaltem Cache, Pro-Modell-Gating über die Fallback-Kette, keine In-Place-Mutation der Tool-Liste.

**1949 Tests gesamt grün, Ruff sauber.**

Spec: `docs/specs/tool-gate-non-tool-models.md`