### PR TITLE
feat(video): E4 — SwitchHttpVideoBackend (Adapter gegen Wrapper-Vertrag)

### DIFF
--- a/core/src/hydrahive/llm/video_backends/_registry.py
+++ b/core/src/hydrahive/llm/video_backends/_registry.py
@@ -12,13 +12,15 @@ from __future__ import annotations
 from hydrahive.llm.video_backends._base import VideoBackend
 from hydrahive.llm.video_backends._comfyui import ComfyUIVideoBackend
 from hydrahive.llm.video_backends._openrouter import OpenRouterVideoBackend
+from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
 
 LOCAL_PREFIX = "local:"
 
-# Adapter-Fabriken je Backend-Typ. E4 ergänzt "switch-http".
+# Adapter-Fabriken je Backend-Typ.
 _ADAPTERS: dict[str, type] = {
     "openrouter": OpenRouterVideoBackend,
     "comfyui": ComfyUIVideoBackend,
+    "switch-http": SwitchHttpVideoBackend,
 }
 
 _openrouter_singleton = OpenRouterVideoBackend()

--- a/core/src/hydrahive/llm/video_backends/_switch_http.py
+++ b/core/src/hydrahive/llm/video_backends/_switch_http.py
@@ -1,0 +1,244 @@
+"""Switch-HTTP-Backend — spricht den node-lokalen Switch-Wrapper.
+
+Der Wrapper läuft dauerhaft und leichtgewichtig auf dem Generierungs-Node und
+kapselt dort den VRAM-Konflikt (LLM-Runtime <-> Bild-/Video-Runtime): er lädt
+die LLM-Runtime aus, startet die Generierungs-Runtime, generiert, räumt wieder
+auf. HydraHive muss sich um VRAM **nicht** kümmern.
+
+Vertrag (docs/specs/local-video-backends.md):
+
+    GET  /health           -> {"status":"ok","mode":"ollama|sd|switching"}
+    GET  /models           -> [{"id","name","category":"image|video"}]
+    POST /generate         -> {"job_id"}
+    GET  /status/{job_id}  -> {"state":"pending|running|done|error","message?"}
+    GET  /result/{job_id}  -> Bytes ODER {"url"}
+    POST /release          -> {"ok":true}   (optional)
+
+Bewusst schmal: Das interne Payload-Schema der Generierungs-Runtime kennt
+**nur** der Wrapper. Dieser Adapter kennt ausschließlich obigen Vertrag — so
+bleibt HydraHive unabhängig davon, was auf dem Node tatsächlich läuft.
+
+Anders als bei ComfyUI gibt es hier **keine** Workflow-Graphen: der Wrapper
+bietet fertige Modelle/Presets an.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+
+from hydrahive.llm.video_backends._base import (
+    JobRef,
+    JobStatus,
+    VideoModel,
+    VideoParams,
+)
+
+logger = logging.getLogger(__name__)
+
+# Ein Generate kann inkl. Runtime-Umschaltung Minuten dauern; Submit selbst
+# antwortet aber sofort mit der job_id. Nur der Result-Download braucht Luft.
+_TIMEOUT_SHORT = 20.0
+_TIMEOUT_DOWNLOAD = 300.0
+
+_VALID_STATES = {"pending", "running", "done", "error"}
+
+_EXT_BY_CONTENT_TYPE = {
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+
+def _api_base(provider: dict) -> str:
+    base = (provider.get("api_base") or "").rstrip("/")
+    if not base:
+        raise RuntimeError("Switch-Backend ohne api_base")
+    return base
+
+
+def _bare_model_id(model: str, provider_id: str) -> str:
+    """'local:muskeln2/ltx-video' -> 'ltx-video'.
+
+    Der Wrapper kennt nur seine eigenen IDs — der `local:`-Prefix ist reine
+    HydraHive-Routing-Information.
+    """
+    rest = model.split(":", 1)[1] if model.startswith("local:") else model
+    if rest.startswith(f"{provider_id}/"):
+        return rest[len(provider_id) + 1:]
+    return rest.split("/", 1)[1] if "/" in rest else rest
+
+
+def _ext_for(content_type: str, fallback: str = ".bin") -> str:
+    return _EXT_BY_CONTENT_TYPE.get(content_type.split(";")[0].strip().lower(), fallback)
+
+
+class SwitchHttpVideoBackend:
+    """Adapter gegen den Switch-Wrapper-Vertrag."""
+
+    type = "switch-http"
+
+    async def list_models(self, provider: dict) -> list[VideoModel]:
+        """Verfügbare Modelle. Leere Liste bei jedem Fehler — ein nicht
+        erreichbarer Node darf den Modell-Picker nicht sprengen."""
+        try:
+            base = _api_base(provider)
+        except RuntimeError:
+            return []
+        pid = provider.get("id", "")
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SHORT) as client:
+                resp = await client.get(f"{base}/models")
+                if resp.status_code >= 400:
+                    logger.warning("Switch-Wrapper /models Fehler %s (%s)", resp.status_code, pid)
+                    return []
+                data = resp.json()
+        except Exception as e:  # noqa: BLE001 - Picker darf nie hart fehlschlagen
+            logger.warning("Switch-Wrapper /models nicht erreichbar (%s): %s", pid, e)
+            return []
+
+        out: list[VideoModel] = []
+        for m in data or []:
+            if not isinstance(m, dict):
+                continue
+            mid = m.get("id", "")
+            if not mid:
+                continue
+            out.append(VideoModel(
+                id=f"local:{pid}/{mid}",
+                name=m.get("name") or mid,
+                category=m.get("category", "video"),
+                durations=m.get("durations") or [],
+                aspect_ratios=m.get("aspect_ratios") or [],
+                frame_images=m.get("frame_images") or [],
+            ))
+        return out
+
+    async def submit(self, provider: dict, model: str, params: VideoParams) -> JobRef:
+        base = _api_base(provider)
+        payload = {
+            "model": _bare_model_id(model, provider.get("id", "")),
+            "prompt": params.prompt,
+            "width": params.width,
+            "height": params.height,
+        }
+        # Optionale Felder nur senden wenn gesetzt — der Wrapper hat eigene Defaults.
+        if params.seed is not None:
+            payload["seed"] = params.seed
+        if params.frames is not None:
+            payload["frames"] = params.frames
+        if params.image_url:
+            payload["image_url"] = params.image_url
+
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SHORT) as client:
+                resp = await client.post(f"{base}/generate", json=payload)
+                if resp.status_code >= 400:
+                    raise RuntimeError(
+                        f"Switch-Wrapper /generate Fehler {resp.status_code}: {resp.text[:300]}")
+                data = resp.json()
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Netzwerk-Fehler beim Switch-Submit: {e}") from e
+
+        job_id = (data or {}).get("job_id") or ""
+        if not job_id:
+            raise RuntimeError(f"Keine job_id in Wrapper-Antwort: {str(data)[:200]}")
+        return JobRef(native_id=str(job_id))
+
+    async def poll(self, provider: dict, job: JobRef) -> JobStatus:
+        base = _api_base(provider)
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SHORT) as client:
+                resp = await client.get(f"{base}/status/{job.native_id}")
+                if resp.status_code >= 400:
+                    raise RuntimeError(
+                        f"Switch-Wrapper /status Fehler {resp.status_code}: {resp.text[:300]}")
+                data = resp.json() or {}
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Netzwerk-Fehler beim Switch-Poll: {e}") from e
+
+        raw_state = str(data.get("state", ""))
+        message = data.get("message")
+        if raw_state not in _VALID_STATES:
+            # Fail-safe: unbekannt heißt NIE "done" — sonst würde der Caller ein
+            # Ergebnis abholen wollen, das es gar nicht gibt.
+            logger.warning("Switch-Wrapper meldet unbekannten state %r — als running behandelt",
+                           raw_state)
+            return JobStatus(state="running", message=message, raw=data)
+        if raw_state == "error":
+            return JobStatus(state="error", error=str(message or "Wrapper-Fehler"),
+                             message=message, raw=data)
+        return JobStatus(state=raw_state, url=data.get("url"), message=message, raw=data)
+
+    async def fetch_output(self, provider: dict, job: JobRef, dest_dir: Path) -> Path:
+        """Holt das Ergebnis. Der Vertrag erlaubt beides: rohe Bytes oder {"url"}."""
+        base = _api_base(provider)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_DOWNLOAD) as client:
+                resp = await client.get(f"{base}/result/{job.native_id}")
+                if resp.status_code >= 400:
+                    raise RuntimeError(
+                        f"Switch-Wrapper /result Fehler {resp.status_code}: {resp.text[:300]}")
+                content_type = resp.headers.get("content-type", "")
+                content = resp.content
+                # Variante 2: JSON mit URL -> zweiter Hop
+                if "application/json" in content_type.lower():
+                    url = (resp.json() or {}).get("url") or ""
+                    if not url:
+                        raise RuntimeError("Wrapper-Ergebnis ohne Daten und ohne url")
+                    resp = await client.get(url)
+                    if resp.status_code >= 400:
+                        raise RuntimeError(
+                            f"Switch-Wrapper Result-URL Fehler {resp.status_code}")
+                    content_type = resp.headers.get("content-type", "")
+                    content = resp.content
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Netzwerk-Fehler beim Switch-Result: {e}") from e
+
+        if not content:
+            raise RuntimeError("Switch-Wrapper lieferte ein leeres Ergebnis")
+
+        ext = _ext_for(content_type)
+        out = dest_dir / f"{job.native_id}{ext}"
+        out.write_bytes(content)
+        return out
+
+    # --- Zusatz über das Protocol hinaus (GUI-Komfort) ----------------------
+
+    async def health(self, provider: dict) -> tuple[bool, dict]:
+        """Für „Verbindung testen": (erreichbar, {status, mode}).
+
+        Der `mode` sagt der GUI, ob der Node gerade die LLM- oder die
+        Generierungs-Runtime geladen hat bzw. gerade umschaltet.
+        """
+        try:
+            base = _api_base(provider)
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SHORT) as client:
+                resp = await client.get(f"{base}/health")
+                if resp.status_code >= 400:
+                    return False, {"error": f"HTTP {resp.status_code}"}
+                data = resp.json() or {}
+        except Exception as e:  # noqa: BLE001 - Health darf nie werfen
+            return False, {"error": str(e)}
+        return str(data.get("status", "")).lower() == "ok", data
+
+    async def release(self, provider: dict) -> bool:
+        """Bittet den Wrapper, die Generierungs-Runtime freizugeben.
+
+        Laut Vertrag optional — der Wrapper räumt nach jedem Job ohnehin selbst
+        auf. Deshalb best-effort: ein 404 ist kein Fehler, nur ein `False`.
+        """
+        try:
+            base = _api_base(provider)
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SHORT) as client:
+                resp = await client.post(f"{base}/release")
+                if resp.status_code >= 400:
+                    return False
+                return bool((resp.json() or {}).get("ok"))
+        except Exception as e:  # noqa: BLE001 - best effort
+            logger.debug("Switch-Wrapper /release nicht verfügbar: %s", e)
+            return False

--- a/core/tests/test_video_backends_switch_http.py
+++ b/core/tests/test_video_backends_switch_http.py
@@ -1,0 +1,336 @@
+"""E4: SwitchHttpVideoBackend — Adapter gegen den node-lokalen Switch-Wrapper.
+
+Der Wrapper (Muskeln2) kapselt den VRAM-Konflikt Ollama <-> sd-server. HydraHive
+spricht NUR den API-Vertrag aus docs/specs/local-video-backends.md:
+
+  GET  /health            -> {"status":"ok","mode":"ollama|sd|switching"}
+  GET  /models            -> [{"id","name","category":"image|video"}]
+  POST /generate          -> {"job_id"}
+  GET  /status/{job_id}   -> {"state":"pending|running|done|error","message?"}
+  GET  /result/{job_id}   -> binaer ODER {"url"}
+  POST /release           -> {"ok":true}   (optional)
+
+Das interne sd-server-Schema kennt NUR der Wrapper — der Adapter darf davon
+nichts wissen. Diese Tests laufen gegen einen Mock des Vertrags und blockieren
+damit nicht auf Mias echten Wrapper.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+PROVIDER = {"id": "muskeln2", "type": "switch-http", "api_base": "http://muskeln2:9700"}
+
+
+# --- Fake-HTTP gegen den Vertrag --------------------------------------------
+
+class _Resp:
+    def __init__(self, payload=None, status=200, content=b"", headers=None):
+        self._payload = payload
+        self.status_code = status
+        self.content = content
+        self.headers = headers or {}
+        self.text = str(payload or "")
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("keine JSON-Antwort")
+        return self._payload
+
+
+class _FakeClient:
+    """Minimaler httpx.AsyncClient-Ersatz. `routes` mappt (method, path) -> _Resp."""
+
+    def __init__(self, routes: dict, log: list | None = None, **kwargs):
+        self._routes = routes
+        self._log = log if log is not None else []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def _lookup(self, method: str, url: str, **kwargs):
+        path = url.split("9700", 1)[1] if "9700" in url else url
+        self._log.append((method, path, kwargs.get("json")))
+        for (m, p), resp in self._routes.items():
+            if m == method and p == path:
+                return resp
+        return _Resp({"error": "not found"}, status=404)
+
+    async def get(self, url, **kwargs):
+        return self._lookup("GET", url, **kwargs)
+
+    async def post(self, url, **kwargs):
+        return self._lookup("POST", url, **kwargs)
+
+
+def _patch_http(monkeypatch, routes: dict, log: list | None = None):
+    from hydrahive.llm.video_backends import _switch_http
+
+    def factory(*a, **kw):
+        return _FakeClient(routes, log)
+
+    monkeypatch.setattr(_switch_http.httpx, "AsyncClient", factory)
+
+
+# --- 1. Registry-Verdrahtung ------------------------------------------------
+
+def test_registry_kennt_switch_http_typ():
+    """E4 muss den Adapter in _ADAPTERS registrieren, sonst ist er unerreichbar."""
+    from hydrahive.llm.video_backends._registry import resolve_backend
+
+    cfg = {"media_backends": [PROVIDER]}
+    backend, provider = resolve_backend("local:muskeln2/realvisxl-image", cfg)
+    assert backend.type == "switch-http"
+    assert provider["api_base"] == "http://muskeln2:9700"
+
+
+def test_adapter_erfuellt_das_videobackend_protocol():
+    from hydrahive.llm.video_backends._base import VideoBackend
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    assert isinstance(SwitchHttpVideoBackend(), VideoBackend)
+
+
+# --- 2. list_models ---------------------------------------------------------
+
+def test_list_models_praefixt_ids_mit_local_provider(monkeypatch):
+    """Der Picker braucht 'local:<provider>/<model>', damit resolve_backend
+    spaeter zurueckfindet. Der Wrapper liefert nur die nackte ID."""
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/models"): _Resp([
+            {"id": "realvisxl-image", "name": "RealVisXL", "category": "image"},
+            {"id": "ltx-video", "name": "LTX Video", "category": "video"},
+        ]),
+    })
+    models = asyncio.run(SwitchHttpVideoBackend().list_models(PROVIDER))
+    assert [m.id for m in models] == ["local:muskeln2/realvisxl-image", "local:muskeln2/ltx-video"]
+    assert [m.category for m in models] == ["image", "video"]
+    assert models[0].name == "RealVisXL"
+
+
+def test_list_models_ist_bei_fehler_leer_statt_zu_werfen(monkeypatch):
+    """Ein nicht erreichbarer Node darf den Modell-Picker nicht sprengen."""
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("GET", "/models"): _Resp(status=500)})
+    assert asyncio.run(SwitchHttpVideoBackend().list_models(PROVIDER)) == []
+
+
+def test_list_models_ohne_api_base_ist_leer():
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    assert asyncio.run(SwitchHttpVideoBackend().list_models({"id": "x", "type": "switch-http"})) == []
+
+
+# --- 3. submit --------------------------------------------------------------
+
+def test_submit_schickt_vertrags_payload_und_liefert_job_id(monkeypatch):
+    from hydrahive.llm.video_backends._base import VideoParams
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    log: list = []
+    _patch_http(monkeypatch, {("POST", "/generate"): _Resp({"job_id": "job-42"})}, log)
+
+    params = VideoParams(prompt="ein fuchs", width=768, height=432, seed=123, frames=121)
+    job = asyncio.run(SwitchHttpVideoBackend().submit(
+        PROVIDER, "local:muskeln2/ltx-video", params))
+
+    assert job.native_id == "job-42"
+    _, path, payload = log[0]
+    assert path == "/generate"
+    # Modell-ID muss OHNE local:-Prefix rausgehen — der Wrapper kennt nur seine IDs
+    assert payload["model"] == "ltx-video"
+    assert payload["prompt"] == "ein fuchs"
+    assert payload["width"] == 768 and payload["height"] == 432
+    assert payload["seed"] == 123 and payload["frames"] == 121
+
+
+def test_submit_ohne_job_id_wirft(monkeypatch):
+    from hydrahive.llm.video_backends._base import VideoParams
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("POST", "/generate"): _Resp({"ok": True})})
+    with pytest.raises(RuntimeError, match="job_id"):
+        asyncio.run(SwitchHttpVideoBackend().submit(
+            PROVIDER, "local:muskeln2/x", VideoParams(prompt="p")))
+
+
+def test_submit_bei_http_fehler_wirft(monkeypatch):
+    from hydrahive.llm.video_backends._base import VideoParams
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("POST", "/generate"): _Resp({"detail": "busy"}, status=503)})
+    with pytest.raises(RuntimeError):
+        asyncio.run(SwitchHttpVideoBackend().submit(
+            PROVIDER, "local:muskeln2/x", VideoParams(prompt="p")))
+
+
+# --- 4. poll ----------------------------------------------------------------
+
+@pytest.mark.parametrize("state", ["pending", "running", "done", "error"])
+def test_poll_reicht_alle_vertrags_states_durch(monkeypatch, state):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("GET", "/status/j1"): _Resp({"state": state})})
+    st = asyncio.run(SwitchHttpVideoBackend().poll(PROVIDER, JobRef(native_id="j1")))
+    assert st.state == state
+
+
+def test_poll_uebernimmt_message_fuer_die_ui(monkeypatch):
+    """Der Switch kann Minuten dauern — die UI zeigt den Wrapper-Fortschritt."""
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/status/j1"): _Resp({"state": "running", "message": "schalte um …"}),
+    })
+    st = asyncio.run(SwitchHttpVideoBackend().poll(PROVIDER, JobRef(native_id="j1")))
+    assert st.message == "schalte um …"
+
+
+def test_poll_fuellt_error_bei_state_error(monkeypatch):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/status/j1"): _Resp({"state": "error", "message": "OOM"}),
+    })
+    st = asyncio.run(SwitchHttpVideoBackend().poll(PROVIDER, JobRef(native_id="j1")))
+    assert st.state == "error"
+    assert "OOM" in (st.error or "")
+
+
+def test_poll_bei_unbekanntem_state_ist_running_nicht_done(monkeypatch):
+    """Fail-safe: ein unbekannter State darf NIE als 'done' gelten, sonst
+    versucht der Caller ein Ergebnis zu holen, das es nicht gibt."""
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("GET", "/status/j1"): _Resp({"state": "wat"})})
+    st = asyncio.run(SwitchHttpVideoBackend().poll(PROVIDER, JobRef(native_id="j1")))
+    assert st.state == "running"
+
+
+# --- 5. fetch_output (binaer ODER url — beide Vertragsvarianten) ------------
+
+def test_fetch_output_speichert_binaerantwort(monkeypatch, tmp_path):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/result/j1"): _Resp(content=b"\x00\x01MP4",
+                                     headers={"content-type": "video/mp4"}),
+    })
+    out = asyncio.run(SwitchHttpVideoBackend().fetch_output(
+        PROVIDER, JobRef(native_id="j1"), tmp_path))
+    assert out.exists()
+    assert out.read_bytes() == b"\x00\x01MP4"
+    assert out.suffix == ".mp4"
+
+
+def test_fetch_output_erkennt_bild_an_content_type(monkeypatch, tmp_path):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/result/j1"): _Resp(content=b"\x89PNG",
+                                     headers={"content-type": "image/png"}),
+    })
+    out = asyncio.run(SwitchHttpVideoBackend().fetch_output(
+        PROVIDER, JobRef(native_id="j1"), tmp_path))
+    assert out.suffix == ".png"
+
+
+def test_fetch_output_folgt_url_variante(monkeypatch, tmp_path):
+    """Zweite Vertragsvariante: {"url": ...} statt Bytes."""
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/result/j1"): _Resp({"url": "http://muskeln2:9700/files/out.mp4"},
+                                     headers={"content-type": "application/json"}),
+        ("GET", "/files/out.mp4"): _Resp(content=b"MP4DATA",
+                                         headers={"content-type": "video/mp4"}),
+    })
+    out = asyncio.run(SwitchHttpVideoBackend().fetch_output(
+        PROVIDER, JobRef(native_id="j1"), tmp_path))
+    assert out.read_bytes() == b"MP4DATA"
+
+
+def test_fetch_output_bei_leerem_ergebnis_wirft(monkeypatch, tmp_path):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {
+        ("GET", "/result/j1"): _Resp(content=b"", headers={"content-type": "video/mp4"}),
+    })
+    with pytest.raises(RuntimeError):
+        asyncio.run(SwitchHttpVideoBackend().fetch_output(
+            PROVIDER, JobRef(native_id="j1"), tmp_path))
+
+
+def test_fetch_output_legt_zielverzeichnis_an(monkeypatch, tmp_path):
+    from hydrahive.llm.video_backends._base import JobRef
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    dest = tmp_path / "tief" / "verschachtelt"
+    _patch_http(monkeypatch, {
+        ("GET", "/result/j1"): _Resp(content=b"X", headers={"content-type": "video/mp4"}),
+    })
+    out = asyncio.run(SwitchHttpVideoBackend().fetch_output(
+        PROVIDER, JobRef(native_id="j1"), dest))
+    assert out.parent == dest
+
+
+# --- 6. health / release ----------------------------------------------------
+
+def test_health_liefert_status_und_modus(monkeypatch):
+    """'Verbindung testen' in der GUI — zeigt auch den aktuellen Wrapper-Modus."""
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("GET", "/health"): _Resp({"status": "ok", "mode": "ollama"})})
+    ok, info = asyncio.run(SwitchHttpVideoBackend().health(PROVIDER))
+    assert ok is True
+    assert info["mode"] == "ollama"
+
+
+def test_health_ist_false_wenn_node_weg(monkeypatch):
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("GET", "/health"): _Resp(status=502)})
+    ok, _ = asyncio.run(SwitchHttpVideoBackend().health(PROVIDER))
+    assert ok is False
+
+
+def test_release_ist_best_effort_und_wirft_nie(monkeypatch):
+    """/release ist laut Vertrag optional — ein 404 darf nichts kaputtmachen."""
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("POST", "/release"): _Resp(status=404)})
+    assert asyncio.run(SwitchHttpVideoBackend().release(PROVIDER)) is False
+
+
+def test_release_ok(monkeypatch):
+    from hydrahive.llm.video_backends._switch_http import SwitchHttpVideoBackend
+
+    _patch_http(monkeypatch, {("POST", "/release"): _Resp({"ok": True})})
+    assert asyncio.run(SwitchHttpVideoBackend().release(PROVIDER)) is True
+
+
+# --- 7. Isolation: kein sd-server-Wissen im Adapter -------------------------
+
+def test_adapter_kennt_keine_sd_server_internals():
+    """Vertragsgrenze: das sd-server-Payload-Schema kennt NUR der Wrapper.
+    Taucht hier ein sd-Flag auf, ist die Abstraktion undicht."""
+    src = Path(__file__).resolve().parents[1] / "src/hydrahive/llm/video_backends/_switch_http.py"
+    text = src.read_text()
+    for leak in ("--max-vram", "vae-tiling", "offload-to-cpu", "sd-server", ":8080"):
+        assert leak not in text, f"sd-server-Interna im Adapter geleakt: {leak}"

--- a/docs/specs/local-video-backends.md
+++ b/docs/specs/local-video-backends.md
@@ -263,13 +263,17 @@ der Wrapper intern nutzt; HydraHive muss es NICHT kennen.
 
 ## Umsetzungs-Etappen (jede mit Tests, klein & mergebar)
 
-- **E1**: `media_backends`-Config + `VideoBackend`-Protocol + OpenRouter refactored
-  dahinter (kein Verhaltensänderung, reine Struktur). Registry mischt Quellen.
-- **E2**: `ComfyUIVideoBackend` (submit/poll/view + ffmpeg) + Workflow-Template-Modell.
-- **E3**: GUI — Media-Backend-Verwaltung + „Verbindung testen" + Workflow-Upload/Mapping.
-- **E4**: `SwitchHttpVideoBackend` (Adapter gegen den Wrapper-API-Vertrag) +
-  GUI-Preset. Voraussetzung: Kunde/Mia stellt den node-lokalen Wrapper bereit,
-  der den API-Vertrag erfüllt. HydraHive-Adapter ist gegen Mock testbar.
+- **E1** ✅ (PR #375): `media_backends`-Config + `VideoBackend`-Protocol + OpenRouter
+  refactored dahinter (keine Verhaltensänderung, reine Struktur).
+- **E2** ✅ (PR #376): `ComfyUIVideoBackend` (submit/poll/view + ffmpeg) +
+  Workflow-Template-Modell.
+- **E3** ✅ (PR #377): GUI — Media-Backend-Verwaltung + „Verbindung testen" +
+  Workflow-Upload/Mapping.
+- **E4** ✅: `SwitchHttpVideoBackend` (Adapter gegen den Wrapper-API-Vertrag),
+  in `_ADAPTERS` registriert. Gegen einen Mock des Vertrags getestet (25 Tests),
+  blockiert also **nicht** auf Mias Wrapper. GUI-Preset + Test-Endpoint waren
+  bereits aus E3 vorhanden. Offen bleibt nur der Live-Test gegen den echten
+  Wrapper (→ E6).
 - **E5**: Video-Dialog: gruppiertes Dropdown + lokale Metadaten/Limits.
 - **E6**: Doku (`docs/local-video-backends.md`) + Live-Test beim Kunden.
 


### PR DESCRIPTION
Vierter Adaptertyp hinter dem `VideoBackend`-Protocol. Schließt E4 der Roadmap aus `docs/specs/local-video-backends.md`.

## Was

Der Adapter spricht den node-lokalen **Switch-Wrapper**, der auf dem Generierungs-Node den VRAM-Konflikt zwischen LLM-Runtime und Bild-/Video-Runtime kapselt: Runtime umschalten → generieren → aufräumen. HydraHive muss sich um VRAM nicht kümmern.

- `_switch_http.py` — `list_models` / `submit` / `poll` / `fetch_output` + `health` / `release`
- `_registry.py` — `"switch-http"` in `_ADAPTERS` registriert

## Vertragsgrenze bewusst hart gezogen

Der Adapter kennt **ausschließlich** den in der Spec definierten Wrapper-Vertrag (`/health`, `/models`, `/generate`, `/status/{id}`, `/result/{id}`, `/release`). Das interne Payload-Schema der Generierungs-Runtime kennt nur der Wrapper — ein Test wacht explizit darüber, dass keine Runtime-Interna (VRAM-Flags, Ports, Binary-Namen) in den Adapter lecken. So bleibt HydraHive unabhängig davon, was auf dem Node tatsächlich läuft.

## Details, die nicht offensichtlich sind

- **Modell-IDs**: gehen *ohne* `local:`-Prefix an den Wrapper (der kennt nur seine eigenen IDs), kommen aber präfixt zurück, damit `resolve_backend` später zurückfindet.
- **`fetch_output`** beherrscht beide Vertragsvarianten: rohe Bytes *und* `{"url"}` mit zweitem Hop. Dateiendung kommt aus dem Content-Type.
- **Unbekannter `state` gilt nie als `done`** (fail-safe). Sonst würde der Caller ein Ergebnis abholen wollen, das es gar nicht gibt.
- **`list_models` / `health` / `release` werfen nie**: ein offline Node darf weder den Modell-Picker sprengen noch einen laufenden Job scheitern lassen. `/release` ist laut Vertrag optional — ein 404 ist kein Fehler.

## Blockiert nicht auf den externen Wrapper

Alle 25 Tests laufen gegen einen **Mock des Vertrags**. Der Adapter ist damit fertig und mergebar, bevor Mias Wrapper steht — der Live-Test gegen die echte Hardware gehört zu E6.

GUI-Preset (`Switch-Wrapper`-Option) und Test-Endpoint (`/api/media-backends/test` → `/health`) waren bereits aus E3 vorhanden; der Modell-Picker geht generisch über `_backend_for_type` und ist damit automatisch verdrahtet.

## Tests

25 neue Tests: Registry-Verdrahtung, Protocol-Konformität, ID-Präfixung, Payload-Vertrag, alle vier Job-States, Message-Durchreichung für die UI, beide Result-Varianten, Verzeichnis-Anlage, Health/Release-Verhalten, Leak-Test der Vertragsgrenze.

**1962 Tests gesamt grün, Ruff sauber.**