### PR TITLE
fix(test): Tests laufen gegen das Repo statt gegen /opt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,21 @@ erzwingt das.
 
 ```bash
 cd core
-/home/<user>/hydrahive2/.venv/bin/python -m pytest          # alle 243 Tests, ~5s
-/home/<user>/hydrahive2/.venv/bin/python -m ruff check src tests
+python -m pytest                    # ganze Suite
+python -m ruff check src tests
 ```
 
 Pytest, Ruff, mypy-Linting sind in `core/pyproject.toml` als Dev-Dependencies.
+
+**Immer aus `core/` heraus starten.** Die pytest-Option `pythonpath = ["src"]`
+ist relativ zur rootdir und sorgt dafür, dass die Tests gegen den Code **dieses
+Repos** laufen. Ohne sie gewinnt eine anderswo installierte hydrahive-Version
+(z.B. der editable-Install unter `/opt/hydrahive2` auf dem Server) — man testet
+dann unbemerkt den alten Produktionsstand, und neue Module werfen
+`ModuleNotFoundError`, obwohl die Datei direkt daneben liegt.
+
+`tests/test_pytest_uses_repo_source.py` wacht darüber und schlägt fehl, sobald
+wieder eine Fremdinstallation importiert wird.
 
 **Frontend:**
 ```bash

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -41,6 +41,15 @@ dependencies = [
 # vorhandenen @pytest.mark.asyncio bleiben gültig). Ohne pytest-asyncio wurden
 # alle async-Tests (TTS/wyoming/generate_music) als Fehler übersprungen.
 asyncio_mode = "auto"
+# pythonpath: Tests laufen IMMER gegen das Repo (core/src), nie gegen eine
+# anderswo installierte hydrahive-Version.
+#
+# Hintergrund: Auf dem Server liegt ein editable-Install, dessen .pth-Datei
+# /opt/hydrahive2/core/src fest in sys.path einträgt. Ohne diesen Eintrag hier
+# gewinnt der Produktionsstand — man testet dann unbemerkt den ALTEN Code, und
+# neue Module aus dem Arbeitsverzeichnis werfen ModuleNotFoundError.
+# Relativ zur rootdir (= core/), gilt für lokale Läufe und CI gleichermaßen.
+pythonpath = ["src"]
 
 [project.scripts]
 hydrahive = "hydrahive.api.main:run"

--- a/core/tests/test_pytest_uses_repo_source.py
+++ b/core/tests/test_pytest_uses_repo_source.py
@@ -1,0 +1,29 @@
+"""Wacht darüber, dass Tests gegen das REPO laufen — nie gegen /opt.
+
+Hintergrund: Auf dem Server liegt ein editable-Install, dessen .pth-Datei
+`/opt/hydrahive2/core/src` fest in sys.path einträgt. Ohne `pythonpath = ["src"]`
+in der pytest-Config gewinnt dieser Produktionsstand: man testet dann unbemerkt
+den ALTEN Code, und neue Module aus dem Arbeitsverzeichnis werfen
+ModuleNotFoundError — obwohl die Datei direkt daneben liegt.
+
+Dieser Test schlägt fehl, sobald jemand die pythonpath-Option entfernt oder die
+Test-Umgebung so verbiegt, dass wieder eine Fremdinstallation importiert wird.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_hydrahive_wird_aus_diesem_repo_importiert():
+    import hydrahive
+
+    imported = Path(hydrahive.__file__).resolve()
+    expected_src = (Path(__file__).resolve().parents[1] / "src").resolve()
+
+    assert imported.is_relative_to(expected_src), (
+        f"Tests laufen gegen eine FREMDE hydrahive-Installation:\n"
+        f"  importiert: {imported}\n"
+        f"  erwartet unter: {expected_src}\n"
+        f"Ursache ist meist eine fehlende `pythonpath = [\"src\"]`-Option in "
+        f"core/pyproject.toml ([tool.pytest.ini_options])."
+    )


### PR DESCRIPTION
## Problem

Auf dem Server liegt ein editable-Install, dessen `.pth`-Datei `/opt/hydrahive2/core/src` **fest in `sys.path`** einträgt. pytest legt nur das Test-Verzeichnis davor, nie `core/src` — dadurch gewann der Produktionsstand.

Folge: man testete unbemerkt den **alten Code**. Neue Module aus dem Arbeitsverzeichnis warfen `ModuleNotFoundError`, obwohl die Datei direkt daneben lag. Das ist besonders tückisch, weil bestehende Tests dabei fröhlich grün bleiben — nur eben gegen den falschen Code.

Im CI war das bereits umschifft (`PYTHONPATH=src` im Workflow), lokal aber nicht. Wer den Trick nicht kannte, testete am Repo vorbei.

## Fix

- **`core/pyproject.toml`**: `pythonpath = ["src"]` in `[tool.pytest.ini_options]`. Relativ zur rootdir — gilt für lokale Läufe und CI gleichermaßen, ohne dass man etwas exportieren muss.
- **`tests/test_pytest_uses_repo_source.py`**: Wächter, der fehlschlägt sobald wieder eine Fremdinstallation importiert wird. Beidseitig verifiziert — grün mit der Option, rot mit `-o pythonpath=`.
- **`CONTRIBUTING.md`**: Testbefehl ohne venv-Pfad-Krücke, plus Erklärung warum aus `core/` heraus gestartet werden muss.

`PYTHONPATH=src` im CI-Workflow bleibt bewusst stehen: jetzt redundant, aber schadlos und robust, falls jemand mit abweichender rootdir aufruft.

## Verifikation

Vorher/nachher am Import-Pfad nachgewiesen:

| | importiert aus |
|---|---|
| ohne Option | `/opt/hydrahive2/core/src/hydrahive` ❌ |
| mit Option | `<repo>/core/src/hydrahive` ✅ |

**1975 Tests grün — erstmals ohne manuelles `PYTHONPATH`.** Ruff sauber.