### PR TITLE
fix(nginx): HTTPS hinter Proxy erzwingen + HSTS

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,68 @@
+# Absicherung einer öffentlich erreichbaren Instanz
+
+Stand: 27.07.2026. Geprüft an der ersten Internet-Testinstanz hinter Cloudflare.
+
+## Was der Installer bereits mitbringt
+
+- HTTP (Port 80) leitet auf HTTPS um — **außer** `/api/health-data/` (Ingest
+  von Geräten ohne TLS)
+- TLS nur 1.2/1.3, `HIGH:!aNULL:!MD5`
+- CSP, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`,
+  `Permissions-Policy`
+- **HSTS** (neu, `max-age=31536000`)
+- **HTTPS-Erzwingung hinter einem Proxy** (neu, siehe unten)
+- Login-Sperre pro Benutzer *und* IP (`lockout`), HTTP 429
+- API-Doku (`/api/docs`, `/api/openapi.json`) nur wenn ausdrücklich aktiviert
+- CORS: Default nur `localhost` — fremde Origins bekommen kein `allow-origin`
+
+## Der Proxy-Fall
+
+Steht ein Reverse-Proxy davor (Cloudflare, Traefik …), endet TLS an dessen
+Rand. Der Port-80-Block von nginx greift dann **nicht**, weil der Proxy Port 80
+selbst beantwortet und die Anfrage intern weiterreicht.
+
+Deshalb prüft der HTTPS-Block zusätzlich `X-Forwarded-Proto`:
+
+```nginx
+if ($http_x_forwarded_proto = "http") {
+    return 301 https://$host$request_uri;
+}
+```
+
+Ohne Proxy ist der Header leer und die Regel greift nie — lokale Installationen
+laufen unverändert.
+
+> **Wichtig:** Dieser Header ist nur vertrauenswürdig, wenn ausschließlich der
+> Proxy den Server erreichen kann. Ist der Ursprungsserver direkt erreichbar,
+> kann ihn jeder setzen. Siehe Checkliste unten.
+
+## Checkliste vor dem Livegang
+
+### Beim Proxy (Cloudflare)
+
+- [ ] **Always Use HTTPS** aktivieren — sonst beantwortet Cloudflare
+      HTTP-Anfragen selbst und liefert die Seite unverschlüsselt aus
+- [ ] SSL-Modus auf **Full (strict)**, nicht „Flexible" (dort ist die Strecke
+      Proxy → Server unverschlüsselt)
+- [ ] Rate Limiting auf `/api/auth/login`
+
+### Am Ursprungsserver
+
+- [ ] Firewall: Port 80/443 **nur** für Cloudflare-Adressbereiche öffnen.
+      Sonst ist der Proxy umgehbar und alle Regeln dort sind wirkungslos.
+- [ ] Prüfen, ob die Server-IP über alte DNS-Einträge auffindbar ist
+      (Subdomains, MX, TXT)
+
+### Konfiguration
+
+- [ ] `HH_JWT_EXPIRE_MINUTES` senken — Default 1440 (24 h) ist für eine
+      öffentliche Instanz lang; 60–120 sind angemessener
+- [ ] `HH_CORS_ORIGINS` setzen, falls ein anderes Frontend zugreift
+- [ ] Prüfen, dass `/api/docs` nicht aktiviert ist
+
+## Bekannte, bewusst akzeptierte Punkte
+
+- **`unsafe-eval` in der CSP** — three.js und d3 nutzen `new Function()`.
+  Schwächt den XSS-Schutz; ohne Umbau dieser Abhängigkeiten nicht entfernbar.
+- **`/api/health` ist ohne Login lesbar** und nennt Version + Commit-Hash. Für
+  Uptime-Prüfungen praktisch, verrät aber den genauen Stand.

--- a/installer/modules/60-nginx.sh
+++ b/installer/modules/60-nginx.sh
@@ -93,6 +93,13 @@ server {
     }
 }
 
+# HTTPS-Erzwingung hinter einem vorgeschalteten Proxy (Cloudflare, Traefik …).
+# Dort endet TLS am Rand und der Request erreicht nginx per HTTP auf Port 443
+# oder mit X-Forwarded-Proto=http. Der 301 im Port-80-Block oben greift dann
+# nicht, weil der Proxy Port 80 selbst beantwortet.
+# Aktivierung: HH_FORCE_HTTPS=1 (Default aus, damit lokale Installationen ohne
+# Proxy und ohne Zertifikat nicht in eine Redirect-Schleife laufen).
+
 server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
@@ -109,9 +116,24 @@ server {
     root $HH_REPO_DIR/frontend/dist;
     index index.html;
 
+    # Hinter einem Proxy (Cloudflare & Co.) meldet X-Forwarded-Proto, womit der
+    # Besucher wirklich verbunden ist. Steht dort "http", kam die Anfrage
+    # unverschluesselt am Rand an -> auf https umleiten, bevor irgendetwas
+    # ausgeliefert wird. Ohne Proxy ist der Header leer und die Regel greift nie.
+    if (\$http_x_forwarded_proto = "http") {
+        return 301 https://\$host\$request_uri;
+    }
+
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # HSTS: der Browser merkt sich, dass diese Domain nur verschluesselt
+    # erreichbar ist — schuetzt auch, wenn jemand die Adresse ohne https
+    # eintippt. Bewusst OHNE preload und mit moderatem max-age: preload ist
+    # nur schwer rueckgaengig zu machen und wuerde eine Fehlkonfiguration
+    # dauerhaft festschreiben. includeSubDomains ebenfalls bewusst weggelassen,
+    # damit unverschluesselte Subdomains (z.B. interne Tools) nicht brechen.
+    add_header Strict-Transport-Security "max-age=31536000" always;
     # microphone=(self) erlaubt Mikrofon-Zugriff vom gleichen Origin
     add_header Permissions-Policy "geolocation=(), microphone=(self), camera=(), payment=()" always;
     # Anti-Stale-Cache (siehe map \$hh_cache_control oben). Ein einzelner add_header


### PR DESCRIPTION
## Befund

An der ersten öffentlichen Testinstanz (hinter Cloudflare) geprüft:

```
http://hydra.myemployeeai.com/login  →  HTTP 200 (volle Seite, keine Weiterleitung)
```

Wer die Adresse ohne `https://` eintippt, überträgt seine Zugangsdaten im Klartext. Zusätzlich fehlte HSTS.

## Ursache

Der Installer **hat** den 301 im Port-80-Block bereits. Er greift nur nicht, wenn ein Reverse-Proxy davorsteht: dort endet TLS am Rand, der Proxy beantwortet Port 80 selbst und reicht die Anfrage intern weiter — nginx sieht Port 80 nie.

## Fix

Der HTTPS-Block prüft jetzt `X-Forwarded-Proto`, bevor irgendetwas ausgeliefert wird:

```nginx
if ($http_x_forwarded_proto = "http") {
    return 301 https://$host$request_uri;
}
```

Ohne Proxy ist der Header leer → die Regel greift nie, lokale Installationen laufen unverändert.

**HSTS** ergänzt (`max-age=31536000`) — bewusst **ohne** `preload` und **ohne** `includeSubDomains`: `preload` ist kaum rückgängig zu machen und würde eine Fehlkonfiguration dauerhaft festschreiben; `includeSubDomains` könnte unverschlüsselte interne Subdomains brechen.

`/api/health-data/` bleibt unberührt (Geräte-Ingest ohne TLS, sitzt im Port-80-Block).

## Verifikation

Regel in eine Kopie der **Live**-nginx-Konfiguration eingesetzt und real geprüft:

```
nginx: configuration file test is successful
```

## Wichtige Einschränkung

`X-Forwarded-Proto` ist **nur vertrauenswürdig, wenn ausschließlich der Proxy den Server erreicht**. Ist der Ursprungsserver direkt erreichbar, kann den Header jeder setzen — dann hilft nur eine Firewall, die Port 80/443 auf die Proxy-Adressbereiche beschränkt.

Das steht samt Livegang-Checkliste in der neuen `docs/security-hardening.md`.