### PR TITLE
fix(chat): Agent-Lauf vom Browser entkoppeln + echter Stop-Button

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -20,7 +20,10 @@ dependencies = [
     "cryptography>=41.0",
     "litellm>=1.40",
     "anthropic>=0.105",
-    "mcp>=1.0",
+    # <2 pinnen: mcp v2 ist ein Major-Rework mit Breaking Changes —
+    # streamablehttp_client → streamable_http_client umbenannt UND zieht
+    # opentelemetry rein (verletzt den No-Telemetry-Guard). v1 bleibt kompatibel.
+    "mcp>=1.0,<2",
     "httpx>=0.27",
     "Pillow>=10.0",
     "playwright>=1.44",

--- a/core/src/hydrahive/api/routes/_session_msg_helpers.py
+++ b/core/src/hydrahive/api/routes/_session_msg_helpers.py
@@ -20,10 +20,23 @@ from hydrahive.api.routes._files import (
     process_upload,
     validate_upload_sizes,
 )
-from hydrahive.api.routes._sse import to_sse
+from hydrahive.api.routes._sse import encode_event, to_sse
+from hydrahive.runner.events import Error as RunnerError
+import asyncio
+import logging
+
 from hydrahive.runner import run as runner_run
 from hydrahive.runner._run_workspace import resolve_run_context
-from hydrahive.runner.concurrency import SessionAlreadyRunning, is_running, session_run_guard
+from hydrahive.runner.concurrency import (
+    SessionAlreadyRunning,
+    is_running,
+    register_task,
+    session_run_guard,
+    unregister_task,
+)
+from hydrahive.runner.event_bus import bus as event_bus
+
+logger = logging.getLogger(__name__)
 
 # Live-Sync v1: max ein Aktivitäts-Ping pro Intervall während eines Laufs.
 _PING_INTERVAL_S = 0.5
@@ -81,33 +94,75 @@ def _upload_http_error(exc):
     return coded(status.HTTP_400_BAD_REQUEST, "upload_size_unknown")
 
 
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
 def sse_run_response(events) -> StreamingResponse:
     return StreamingResponse(
         to_sse(events),
         media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",
-        },
+        headers=_SSE_HEADERS,
     )
 
 
-async def sse_run_with_guard(session_id: str, user_content, *, extra_system: str | None = None) -> StreamingResponse:
-    """SSE-Response für runner_run MIT Session-Concurrency-Guard.
+async def _raw_with_heartbeat(frames):
+    """Reicht bereits SSE-serialisierte Frames (aus dem Event-Bus) durch und
+    fügt bei Inaktivität einen Heartbeat-Comment ein, damit Proxies/Browser die
+    Verbindung nicht schließen."""
+    it = frames.__aiter__()
+    task: asyncio.Task | None = None
+    try:
+        while True:
+            if task is None:
+                task = asyncio.ensure_future(it.__anext__())
+            done, _ = await asyncio.wait({task}, timeout=15)
+            if not done:
+                yield ": heartbeat\n\n"
+                continue
+            task = None
+            try:
+                yield done.pop().result()
+            except StopAsyncIteration:
+                break
+    finally:
+        if task is not None:
+            task.cancel()
 
-    409 wenn für die Session bereits ein Run läuft. Verhindert dass
-    bei abgerissenem SSE-Stream (Browser-Refresh, Modell-Switch, Network-Hiccup)
-    ein zweiter Run parallel angestoßen wird — siehe runner.concurrency
-    für den Hintergrund.
+
+def sse_run_response_raw(frames) -> StreamingResponse:
+    return StreamingResponse(
+        _raw_with_heartbeat(frames),
+        media_type="text/event-stream",
+        headers=_SSE_HEADERS,
+    )
+
+
+def start_run_task(session_id: str, user_content, *, extra_system: str | None = None) -> "asyncio.Task":
+    """Startet einen Agent-Run als ENTKOPPELTEN Server-Task.
+
+    Der Run hängt NICHT an der auslösenden HTTP-Verbindung — schließt der Browser
+    (oder geht der PC aus), läuft der Run serverseitig zu Ende. Über
+    concurrency.cancel(session_id) (Stop-Button → POST /stop) lässt er sich
+    jederzeit gezielt abbrechen, auch nach einem Reconnect.
+
+    Variante A: Läuft bereits ein Run für die Session → SessionAlreadyRunning
+    (kein Doppellauf, schützt lange Läufe). Der Aufrufer übersetzt das in 409.
+
+    Live-Fortschritt geht wie bisher über den broadcaster (start/activity/done);
+    die Clients laden bei Ping aus der DB nach.
     """
     if is_running(session_id):
-        raise coded(status.HTTP_409_CONFLICT, "session_already_running")
+        raise SessionAlreadyRunning(session_id)
 
-    async def _guarded_stream():
-        # Live-Sync v1: leichte Pings an alle Geräte derselben Session, damit ein
-        # passives Tab/Tablet bei Lauf-Fortschritt nachlädt. Der Sender-Stream
-        # (yield ev) bleibt davon unberührt.
+    # Frischen Event-Bus-Kanal öffnen (seq startet bei 0), BEVOR der erste
+    # Consumer (der Sende-Stream) subscribed — kein Event geht verloren.
+    event_bus.open(session_id)
+
+    async def _run() -> None:
         last_ping = 0.0
         try:
             async with session_run_guard(session_id):
@@ -117,14 +172,57 @@ async def sse_run_with_guard(session_id: str, user_content, *, extra_system: str
                 else:
                     gen = runner_run(session_id, user_content)
                 async for ev in gen:
-                    yield ev
+                    # Volles Event in den Bus (flüssiges Token-Streaming für ALLE
+                    # Consumer, auch nach Reconnect lückenlos).
+                    event_bus.publish(session_id, encode_event(ev))
                     now = time.monotonic()
                     if now - last_ping >= _PING_INTERVAL_S:
                         last_ping = now
+                        # Leichter Ping für passive Tabs (die aus der DB nachladen).
                         broadcaster.broadcast(session_id, '{"t":"activity"}')
         except SessionAlreadyRunning:
-            return  # lost the race between is_running() check and acquire
+            return  # Race verloren — anderer Task hält den Guard
+        except asyncio.CancelledError:
+            logger.info("Run gestoppt (cancel): %s", session_id)
+            event_bus.publish(session_id, encode_event(
+                RunnerError(message="Lauf gestoppt.")))
+            raise
+        except Exception:
+            logger.exception("Entkoppelter Run fehlgeschlagen: %s", session_id)
         finally:
+            unregister_task(session_id)
+            event_bus.close(session_id)
             broadcaster.broadcast(session_id, '{"t":"done"}')
 
-    return sse_run_response(_guarded_stream())
+    task = asyncio.create_task(_run())
+    register_task(session_id, task)
+    return task
+
+
+async def run_and_stream(session_id: str, user_content, *, extra_system: str | None = None) -> StreamingResponse:
+    """Startet den entkoppelten Run und gibt einen SSE-Stream zurück, der die
+    Events aus dem Event-Bus liest. Reißt DIESER Stream ab (Browser zu), läuft
+    der Run weiter — er hängt am Server-Task, nicht an der Verbindung.
+
+    409 wenn schon ein Run läuft (Variante A: kein Doppellauf)."""
+    start_run_task(session_id, user_content, extra_system=extra_system)  # wirft SessionAlreadyRunning → vom Router in 409 übersetzt
+
+    async def _events():
+        async for _seq, sse_frame in event_bus.subscribe(session_id, after_seq=0):
+            yield sse_frame  # bereits SSE-serialisiert (encode_event)
+
+    return sse_run_response_raw(_events())
+
+
+async def attach_stream(session_id: str, after_seq: int = 0) -> StreamingResponse:
+    """Zuschauer-/Reconnect-Stream: liest denselben Event-Bus ab `after_seq`.
+    Läuft kein Run, endet der Stream schnell (leerer Kanal). Für den Stop-Button
+    nach Reconnect zählt der running-Status (siehe /stop + is_running)."""
+    async def _events():
+        async for _seq, sse_frame in event_bus.subscribe(session_id, after_seq=after_seq):
+            yield sse_frame
+
+    return sse_run_response_raw(_events())
+
+
+

--- a/core/src/hydrahive/api/routes/sessions_messages.py
+++ b/core/src/hydrahive/api/routes/sessions_messages.py
@@ -15,9 +15,15 @@ from hydrahive.agents import config as agent_config
 from hydrahive.api.middleware.auth import require_admin, require_auth
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api._session_broadcast import broadcaster
-from hydrahive.api.routes._session_msg_helpers import build_user_content, sse_run_with_guard
+from hydrahive.api.routes._session_msg_helpers import (
+    attach_stream,
+    build_user_content,
+    run_and_stream,
+)
 from hydrahive.runner import run as runner_run
+from hydrahive.runner import concurrency
 from hydrahive.runner.concurrency import SessionAlreadyRunning, is_running, session_run_guard
+from hydrahive.runner.event_bus import bus as event_bus
 from hydrahive.runner.events import Error as RunnerError
 from hydrahive.api.routes._sessions_helpers import check_owner, serialize_message
 from hydrahive.agents._defaults import DEFAULT_COMPACT_THRESHOLD_PCT
@@ -96,6 +102,59 @@ async def stream_session(
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
     )
+
+
+@messages_router.get("/{session_id}/run-status")
+async def run_status(
+    session_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+) -> dict:
+    """Läuft für diese Session gerade ein Agent-Run? + aktuelle Event-Seq.
+
+    Das aktive Tab fragt das beim Laden/Reconnect ab: ist ein Run aktiv, hängt es
+    sich per /attach an den Event-Bus (lückenloses Token-Streaming) und aktiviert
+    den Stop-Button — auch wenn der Run von einem anderen Gerät gestartet wurde
+    oder der eigene Browser zwischendurch zu war.
+    """
+    s = sessions_db.get(session_id)
+    if not s:
+        raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
+    check_owner(s, *auth)
+    return {
+        "running": is_running(session_id),
+        "latest_seq": event_bus.latest_seq(session_id),
+    }
+
+
+@messages_router.get("/{session_id}/attach")
+async def attach_run(
+    session_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+    after_seq: int = 0,
+) -> StreamingResponse:
+    """Hängt sich an den laufenden Run und streamt die Events ab `after_seq`
+    lückenlos weiter (Reconnect mitten im Lauf ohne Token-Verlust)."""
+    s = sessions_db.get(session_id)
+    if not s:
+        raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
+    check_owner(s, *auth)
+    return await attach_stream(session_id, after_seq=max(0, after_seq))
+
+
+@messages_router.post("/{session_id}/stop")
+async def stop_run(
+    session_id: str,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+) -> dict:
+    """Stoppt den laufenden Agent-Run — funktioniert IMMER (auch nach Reconnect),
+    weil es den Server-Task gezielt cancelt, statt sich auf einen abgerissenen
+    SSE-Stream zu verlassen. Das ist der Stop-Button-Pfad."""
+    s = sessions_db.get(session_id)
+    if not s:
+        raise coded(status.HTTP_404_NOT_FOUND, "session_not_found")
+    check_owner(s, *auth)
+    stopped = concurrency.cancel(session_id)
+    return {"stopped": stopped}
 
 
 @messages_router.get("/{session_id}/tokens")
@@ -190,7 +249,10 @@ async def resend_message(
 
     user_content = await build_user_content(s, text, files or [])
     messages_db.delete_from(session_id, message_id)
-    return await sse_run_with_guard(session_id, user_content)
+    try:
+        return await run_and_stream(session_id, user_content)
+    except SessionAlreadyRunning:
+        raise coded(status.HTTP_409_CONFLICT, "session_already_running")
 
 
 @messages_router.post("/{session_id}/messages")
@@ -206,7 +268,10 @@ async def post_message(
     check_owner(s, *auth)
 
     user_content = await build_user_content(s, text, files or [])
-    return await sse_run_with_guard(session_id, user_content)
+    try:
+        return await run_and_stream(session_id, user_content)
+    except SessionAlreadyRunning:
+        raise coded(status.HTTP_409_CONFLICT, "session_already_running")
 
 
 class LogCmdBody(BaseModel):

--- a/core/src/hydrahive/mcp/client/http.py
+++ b/core/src/hydrahive/mcp/client/http.py
@@ -5,7 +5,16 @@ import logging
 from contextlib import AsyncExitStack
 
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+
+# mcp benannte den streamableHTTP-Client zwischen Versionen um
+# (streamablehttp_client → streamable_http_client). Beide Namen unterstützen,
+# damit der Import über mcp-Versionen hinweg funktioniert (CI-Dependency-Drift).
+try:  # ältere mcp
+    from mcp.client.streamable_http import streamablehttp_client
+except ImportError:  # neuere mcp
+    from mcp.client.streamable_http import (
+        streamable_http_client as streamablehttp_client,
+    )
 
 from hydrahive.mcp.client.base import McpTool, McpToolResult, render_tool_content
 

--- a/core/src/hydrahive/runner/concurrency.py
+++ b/core/src/hydrahive/runner/concurrency.py
@@ -36,6 +36,37 @@ class SessionAlreadyRunning(RuntimeError):
 _active: set[str] = set()
 _lock = asyncio.Lock()
 
+# Task-Registry für entkoppelte Runs: hält die asyncio.Task-Referenz je Session,
+# damit ein laufender Run gezielt gestoppt werden kann — auch wenn die
+# auslösende HTTP-Verbindung (Browser) längst weg ist.
+_tasks: dict[str, "asyncio.Task"] = {}
+
+
+def register_task(session_id: str, task: "asyncio.Task") -> None:
+    """Registriert den Run-Task einer Session (für gezieltes Stop/Cancel)."""
+    _tasks[session_id] = task
+
+
+def unregister_task(session_id: str) -> None:
+    """Entfernt den Run-Task (im finally des Runs aufrufen)."""
+    _tasks.pop(session_id, None)
+
+
+def get_task(session_id: str) -> "asyncio.Task | None":
+    return _tasks.get(session_id)
+
+
+def cancel(session_id: str) -> bool:
+    """Stoppt den laufenden Run-Task einer Session. True wenn ein Task
+    gefunden und gecancelt wurde. Der Task räumt sich selbst im finally auf
+    (unregister + Guard-Release)."""
+    task = _tasks.get(session_id)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    logger.info("Run-Task cancel() angefordert: %s", session_id)
+    return True
+
 
 @asynccontextmanager
 async def session_run_guard(session_id: str) -> AsyncIterator[None]:
@@ -54,8 +85,16 @@ async def session_run_guard(session_id: str) -> AsyncIterator[None]:
 
 
 def is_running(session_id: str) -> bool:
-    """Read-only Check (für Tests/Diagnose). Nicht race-safe — nur Snapshot."""
-    return session_id in _active
+    """Read-only Check (für Tests/Diagnose). Nicht race-safe — nur Snapshot.
+
+    Läuft = im Guard-Set ODER ein noch nicht beendeter Run-Task registriert.
+    (Der entkoppelte Task registriert sich; der Guard schützt den kritischen
+    Abschnitt — beide zusammen ergeben den Live-Status.)
+    """
+    if session_id in _active:
+        return True
+    task = _tasks.get(session_id)
+    return task is not None and not task.done()
 
 
 def active_count() -> int:

--- a/core/src/hydrahive/runner/event_bus.py
+++ b/core/src/hydrahive/runner/event_bus.py
@@ -1,0 +1,124 @@
+"""Session-Event-Bus — lückenloser Live-Event-Stream pro Session.
+
+Fundament für entkoppelte Runs mit flüssigem Token-Streaming: Der entkoppelte
+Run ist der EINZIGE Producer und publisht jedes runner-Event mit fortlaufender
+Sequenznummer (`seq`). Consumer (Sende-Stream UND Reconnect-Stream) lesen ab
+ihrem Cursor weiter — kein Token geht verloren, auch wenn ein Client mitten im
+Lauf neu verbindet.
+
+Ringpuffer je Session puffert die letzten N Events für kurze Verbindungslücken.
+Ist der Cursor rausgefallen (has_gap), lädt der Client einmalig aus der DB nach
+und steigt am aktuellen seq wieder ein.
+
+Single-Process/Single-Worker (wie das übrige Concurrency-System). Bei Multi-
+Worker müsste der Bus über einen externen Broker (Redis/PG-LISTEN) laufen.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import AsyncIterator
+
+_DEFAULT_CAPACITY = 2000
+
+
+class _SessionChannel:
+    def __init__(self, capacity: int) -> None:
+        self.seq = 0
+        self.buffer: deque[tuple[int, dict]] = deque(maxlen=capacity)
+        self.subscribers: set[asyncio.Queue] = set()
+        self.closed = False
+
+
+class SessionEventBus:
+    def __init__(self, capacity: int = _DEFAULT_CAPACITY) -> None:
+        self._capacity = capacity
+        self._channels: dict[str, _SessionChannel] = {}
+
+    def _channel(self, session_id: str) -> _SessionChannel:
+        ch = self._channels.get(session_id)
+        if ch is None:
+            ch = _SessionChannel(self._capacity)
+            self._channels[session_id] = ch
+        return ch
+
+    # ── Producer ──────────────────────────────────────────────────────────
+    def open(self, session_id: str) -> None:
+        """Startet einen frischen Kanal für einen neuen Run (seq beginnt bei 0)."""
+        self._channels[session_id] = _SessionChannel(self._capacity)
+
+    def publish(self, session_id: str, event: dict) -> int:
+        """Hängt ein Event an, vergibt die nächste seq, verteilt an Subscriber."""
+        ch = self._channel(session_id)
+        ch.seq += 1
+        item = (ch.seq, event)
+        ch.buffer.append(item)
+        for q in list(ch.subscribers):
+            try:
+                q.put_nowait(item)
+            except asyncio.QueueFull:
+                pass  # Subscriber-Queue ist großzügig; Overflow -> Gap-Recovery
+        return ch.seq
+
+    def close(self, session_id: str) -> None:
+        """Signalisiert das Run-Ende: alle Subscriber-Iteratoren enden sauber."""
+        ch = self._channels.get(session_id)
+        if ch is None:
+            return
+        ch.closed = True
+        for q in list(ch.subscribers):
+            try:
+                q.put_nowait(None)  # Sentinel = Ende
+            except asyncio.QueueFull:
+                pass
+
+    # ── Consumer ──────────────────────────────────────────────────────────
+    def latest_seq(self, session_id: str) -> int:
+        ch = self._channels.get(session_id)
+        return ch.seq if ch else 0
+
+    def has_gap(self, session_id: str, after_seq: int) -> bool:
+        """True, wenn Events nach after_seq bereits aus dem Puffer gefallen sind
+        (der Client also eine Lücke hätte und aus der DB nachladen muss)."""
+        ch = self._channels.get(session_id)
+        if ch is None:
+            return after_seq < 0
+        if after_seq >= ch.seq:
+            return False
+        oldest = ch.buffer[0][0] if ch.buffer else ch.seq + 1
+        # lückenlos vorhanden ist alles ab (oldest). Verpasst der Client etwas
+        # zwischen after_seq+1 und oldest-1, ist das ein Gap.
+        return (after_seq + 1) < oldest
+
+    async def subscribe(
+        self, session_id: str, after_seq: int = 0
+    ) -> AsyncIterator[tuple[int, dict]]:
+        """Liefert Events ab `after_seq`+1: erst die gepufferten (Backlog),
+        dann live, bis der Run schließt."""
+        ch = self._channel(session_id)
+        q: asyncio.Queue = asyncio.Queue(maxsize=10000)
+        ch.subscribers.add(q)
+        try:
+            # 1) Backlog aus dem Puffer (verpasste Events nachliefern)
+            for seq, ev in list(ch.buffer):
+                if seq > after_seq:
+                    yield seq, ev
+                    after_seq = seq
+            # Wenn der Run schon geschlossen ist und nichts Neues kommt: Ende.
+            if ch.closed and ch.seq <= after_seq:
+                return
+            # 2) Live-Events
+            while True:
+                item = await q.get()
+                if item is None:  # close-Sentinel
+                    return
+                seq, ev = item
+                if seq > after_seq:  # doppelte aus Backlog-Überlappung meiden
+                    yield seq, ev
+                    after_seq = seq
+        finally:
+            ch.subscribers.discard(q)
+
+
+# Prozessweiter Standard-Bus (ein Producer je Session, viele Consumer).
+bus = SessionEventBus()

--- a/core/tests/test_event_bus.py
+++ b/core/tests/test_event_bus.py
@@ -1,0 +1,100 @@
+"""Session-Event-Bus (chat-run-decoupled Task 2a).
+
+Lückenloser Event-Stream pro Session: der entkoppelte Run publisht Events mit
+fortlaufender seq; Consumer lesen ab ihrem Cursor weiter — auch nach Reconnect
+mitten im Lauf, ohne Token zu verlieren.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.runner.event_bus import SessionEventBus
+
+
+@pytest.mark.asyncio
+async def test_publish_assigns_increasing_seq():
+    bus = SessionEventBus(capacity=100)
+    sid = "bus-1"
+    assert bus.publish(sid, {"type": "TextDelta", "text": "a"}) == 1
+    assert bus.publish(sid, {"type": "TextDelta", "text": "b"}) == 2
+    assert bus.latest_seq(sid) == 2
+
+
+@pytest.mark.asyncio
+async def test_subscriber_gets_live_events():
+    bus = SessionEventBus(capacity=100)
+    sid = "bus-live"
+    received = []
+
+    async def consume():
+        async for seq, ev in bus.subscribe(sid, after_seq=0):
+            received.append((seq, ev["text"]))
+            if ev.get("type") == "Done":
+                break
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.01)
+    bus.publish(sid, {"type": "TextDelta", "text": "hallo"})
+    bus.publish(sid, {"type": "Done", "text": "x"})
+    await asyncio.wait_for(task, timeout=2.0)
+    assert received == [(1, "hallo"), (2, "x")]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_gets_missed_events_from_buffer():
+    """Ein Client der ab seq=1 wieder einsteigt, bekommt die verpassten 2,3,… ."""
+    bus = SessionEventBus(capacity=100)
+    sid = "bus-reconnect"
+    bus.publish(sid, {"type": "TextDelta", "text": "1"})  # seq 1
+    bus.publish(sid, {"type": "TextDelta", "text": "2"})  # seq 2
+    bus.publish(sid, {"type": "TextDelta", "text": "3"})  # seq 3
+
+    got = []
+
+    async def consume():
+        async for seq, ev in bus.subscribe(sid, after_seq=1):
+            got.append((seq, ev["text"]))
+            if seq >= 3:
+                break
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(task, timeout=2.0)
+    # bekommt 2 und 3 aus dem Puffer nachgeliefert (1 hatte er schon)
+    assert got == [(2, "2"), (3, "3")]
+
+
+@pytest.mark.asyncio
+async def test_buffer_eviction_reports_gap():
+    """Fällt der Cursor aus dem Ringpuffer, meldet subscribe einen Gap
+    (Client muss aus DB nachladen)."""
+    bus = SessionEventBus(capacity=3)
+    sid = "bus-evict"
+    for i in range(1, 6):  # seq 1..5, Puffer hält nur letzte 3 (3,4,5)
+        bus.publish(sid, {"type": "TextDelta", "text": str(i)})
+
+    # Cursor after_seq=1: 2 ist schon evicted -> Gap gemeldet
+    assert bus.has_gap(sid, after_seq=1) is True
+    # Cursor after_seq=3: 4,5 noch da -> kein Gap
+    assert bus.has_gap(sid, after_seq=3) is False
+
+
+@pytest.mark.asyncio
+async def test_close_ends_subscribers():
+    bus = SessionEventBus(capacity=100)
+    sid = "bus-close"
+    ended = asyncio.Event()
+
+    async def consume():
+        async for _seq, _ev in bus.subscribe(sid, after_seq=0):
+            pass
+        ended.set()
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.01)
+    bus.publish(sid, {"type": "TextDelta", "text": "x"})
+    bus.close(sid)  # Run zu Ende -> Subscriber-Iteratoren enden
+    await asyncio.wait_for(ended.wait(), timeout=2.0)
+    assert ended.is_set()
+    task.cancel()

--- a/core/tests/test_run_decoupled.py
+++ b/core/tests/test_run_decoupled.py
@@ -1,0 +1,91 @@
+"""Entkoppelter Run-Start (chat-run-decoupled Task 2/3).
+
+Kern: der Run läuft als eigenständiger Server-Task. Er überlebt, wenn der
+Aufrufer (HTTP-Verbindung) verschwindet, und lässt sich über cancel() stoppen.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.api.routes import _session_msg_helpers as H
+from hydrahive.runner import concurrency as C
+
+
+@pytest.mark.asyncio
+async def test_start_run_task_runs_to_completion_without_caller(monkeypatch):
+    """Der Run läuft zu Ende, auch wenn niemand den Task awaited (Browser weg)."""
+    done = asyncio.Event()
+    steps: list[str] = []
+
+    async def fake_runner(session_id, user_content, **kw):
+        steps.append("start")
+        await asyncio.sleep(0.05)
+        steps.append("mid")
+        await asyncio.sleep(0.05)
+        steps.append("end")
+        done.set()
+        return
+        yield  # macht es zum async generator
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    sid = "decoupled-1"
+    H.start_run_task(sid, "hallo")
+    # Aufrufer "verschwindet" sofort — wir awaiten den Task NICHT.
+    assert C.is_running(sid)
+    await asyncio.wait_for(done.wait(), timeout=2.0)
+    # kurz aufräumen lassen
+    await asyncio.sleep(0.02)
+    assert steps == ["start", "mid", "end"]
+    assert not C.is_running(sid)
+
+
+@pytest.mark.asyncio
+async def test_start_run_task_cancel_stops_it(monkeypatch):
+    """cancel() stoppt den laufenden Run mitten drin (Stop-Button-Fall)."""
+    started = asyncio.Event()
+
+    async def fake_runner(session_id, user_content, **kw):
+        started.set()
+        await asyncio.sleep(30)
+        return
+        yield
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    sid = "decoupled-cancel"
+    H.start_run_task(sid, "lang")
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    assert C.is_running(sid)
+
+    assert C.cancel(sid) is True
+    # Registry wird sauber freigegeben
+    for _ in range(50):
+        if not C.is_running(sid):
+            break
+        await asyncio.sleep(0.02)
+    assert not C.is_running(sid)
+
+
+@pytest.mark.asyncio
+async def test_start_run_task_second_start_blocked(monkeypatch):
+    """Variante A: zweiter Start bei laufendem Run wird abgelehnt (kein Doppellauf)."""
+    async def fake_runner(session_id, user_content, **kw):
+        await asyncio.sleep(0.3)
+        return
+        yield
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    sid = "decoupled-double"
+    H.start_run_task(sid, "erst")
+    assert C.is_running(sid)
+    with pytest.raises(H.SessionAlreadyRunning):
+        H.start_run_task(sid, "zweit")
+    C.cancel(sid)
+    for _ in range(50):
+        if not C.is_running(sid):
+            break
+        await asyncio.sleep(0.02)

--- a/core/tests/test_run_stream_integration.py
+++ b/core/tests/test_run_stream_integration.py
@@ -1,0 +1,103 @@
+"""Integration: entkoppelter Run + lückenloses Streaming über den Event-Bus.
+
+Beweist: (1) der Sende-Stream bekommt alle Events flüssig, (2) reißt er ab,
+läuft der Run weiter, (3) ein Reconnect-Stream bekommt die verpassten Events
+lückenlos nachgeliefert, (4) Stop cancelt den Run.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.api.routes import _session_msg_helpers as H
+from hydrahive.runner import concurrency as C
+from hydrahive.runner.event_bus import bus
+from hydrahive.runner.events import Done, TextDelta
+
+
+async def _drain(response, limit=None):
+    """Sammelt die SSE-Frames aus einer StreamingResponse."""
+    frames = []
+    async for chunk in response.body_iterator:
+        frames.append(chunk)
+        if limit and len(frames) >= limit:
+            break
+    return frames
+
+
+@pytest.mark.asyncio
+async def test_sender_stream_gets_all_events(monkeypatch):
+    async def fake_runner(session_id, user_content, **kw):
+        yield TextDelta(text="Hal")
+        await asyncio.sleep(0.01)
+        yield TextDelta(text="lo")
+        yield Done(message_id="m1", iterations=1)
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    resp = await H.run_and_stream("int-1", "hi")
+    frames = await _drain(resp)
+    joined = "".join(frames)
+    assert "Hal" in joined and "lo" in joined
+    assert "event: done" in joined
+    # Run ist danach beendet
+    for _ in range(50):
+        if not C.is_running("int-1"):
+            break
+        await asyncio.sleep(0.02)
+    assert not C.is_running("int-1")
+
+
+@pytest.mark.asyncio
+async def test_run_survives_sender_disconnect_and_reconnect_is_gapless(monkeypatch):
+    gate = asyncio.Event()
+
+    async def fake_runner(session_id, user_content, **kw):
+        yield TextDelta(text="A")   # seq 1
+        yield TextDelta(text="B")   # seq 2
+        await gate.wait()           # hält den Run offen
+        yield TextDelta(text="C")   # seq 3
+        yield Done(message_id="m1", iterations=1)  # seq 4
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    # Sender startet, liest die ersten 2 Events, dann "Browser zu" (Stream weg)
+    resp = await H.run_and_stream("int-2", "hi")
+    first = await _drain(resp, limit=2)
+    assert "A" in "".join(first) and "B" in "".join(first)
+    await resp.body_iterator.aclose()  # Verbindung abgerissen
+
+    # Run läuft weiter (Task lebt)
+    assert C.is_running("int-2")
+
+    # Reconnect ab seq=2 → bekommt C und Done lückenlos
+    gate.set()
+    reconnect = await H.attach_stream("int-2", after_seq=2)
+    frames = await _drain(reconnect)
+    joined = "".join(frames)
+    assert "C" in joined
+    assert "event: done" in joined
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_running(monkeypatch):
+    started = asyncio.Event()
+
+    async def fake_runner(session_id, user_content, **kw):
+        started.set()
+        yield TextDelta(text="x")
+        await asyncio.sleep(30)
+
+    monkeypatch.setattr(H, "runner_run", fake_runner)
+
+    H.start_run_task("int-stop", "hi")
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    assert C.is_running("int-stop")
+    assert C.cancel("int-stop") is True
+    for _ in range(50):
+        if not C.is_running("int-stop"):
+            break
+        await asyncio.sleep(0.02)
+    assert not C.is_running("int-stop")
+    bus.close("int-stop")

--- a/core/tests/test_run_task_registry.py
+++ b/core/tests/test_run_task_registry.py
@@ -1,0 +1,69 @@
+"""Task-Registry für entkoppelte Runs (chat-run-decoupled Task 1).
+
+Der Run läuft als eigenständiger asyncio.Task, den man gezielt stoppen kann —
+auch wenn die auslösende HTTP-Verbindung längst weg ist.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hydrahive.runner import concurrency as C
+
+
+@pytest.mark.asyncio
+async def test_register_and_get_task():
+    sid = "reg-1"
+    task = asyncio.current_task()
+    C.register_task(sid, task)
+    try:
+        assert C.get_task(sid) is task
+        assert C.is_running(sid)  # registrierter Task = läuft
+    finally:
+        C.unregister_task(sid)
+    assert C.get_task(sid) is None
+    assert not C.is_running(sid)
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_running_task():
+    sid = "reg-cancel"
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def long_run():
+        C.register_task(sid, asyncio.current_task())
+        started.set()
+        try:
+            await asyncio.sleep(30)  # simuliert langen Lauf
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        finally:
+            C.unregister_task(sid)
+
+    task = asyncio.create_task(long_run())
+    await started.wait()
+    assert C.is_running(sid)
+
+    # Stop-Button: cancel über die Registry (nicht über die Verbindung)
+    assert C.cancel(sid) is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+    assert not C.is_running(sid)
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown_returns_false():
+    assert C.cancel("nie-gestartet") is False
+
+
+@pytest.mark.asyncio
+async def test_is_running_reflects_registry_or_guard():
+    """is_running muss sowohl den Guard (Set) als auch die Task-Registry sehen."""
+    sid = "reg-both"
+    async with C.session_run_guard(sid):
+        assert C.is_running(sid)
+    assert not C.is_running(sid)

--- a/docs/specs/chat-run-decoupled.md
+++ b/docs/specs/chat-run-decoupled.md
@@ -1,0 +1,104 @@
+# Plan: Agent-Lauf vom Browser entkoppeln (+ echter Stop)
+
+## Ziel
+
+Ein Agent-Lauf läuft serverseitig weiter, egal ob der Browser offen ist. Nach
+dem Wiederverbinden kann der User den laufenden Lauf **stoppen** (nicht nur
+zuschauen). PC aus / Browser zu → der Lauf läuft zu Ende.
+
+## Problem (verifiziert)
+
+`_session_msg_helpers.sse_run_with_guard()` konsumiert `runner_run()` **im
+SSE-Generator** (`async for ev in gen: yield ev`). Reißt die HTTP-Verbindung
+(Browser zu, PC aus, TCP-Timeout), bricht Starlette den Generator ab
+(`GeneratorExit`/`CancelledError`) → der Run stirbt mitten drin.
+
+Frontend: „Stop" = `AbortController.abort()` auf genau diese fetch-Verbindung
+(useChat.ts:39). Nach Reconnect ist die Verbindung weg → Stop wirkt nicht mehr.
+
+Das Concurrency-Modul kennt nur ein in-memory `set[str]` aktiver Session-IDs —
+**keine Task-Referenz**, also kein gezieltes Canceln möglich.
+
+## UX-Anforderung (till): flüssiges Token-Streaming MUSS erhalten bleiben
+
+Kein „Antwort erscheint in Schüben". Deshalb NICHT der ping+reload-Weg, sondern
+ein lückenloser **Event-Bus pro Session** (Ringpuffer mit Sequenznummer):
+- Der entkoppelte Run ist der EINZIGE Producer und schreibt JEDES runner-Event
+  (TextDelta, ToolUse, Done, …) mit fortlaufender `seq` in den Bus.
+- Consumer (Sender-Stream UND Reconnect-Stream) lesen ab ihrem `seq`-Cursor
+  weiter — kein Token geht verloren, auch bei Reconnect mitten im Lauf.
+- Ringpuffer (z.B. letzte 2000 Events/Session) puffert für kurze Verbindungs-
+  lücken; ist der Cursor rausgefallen, lädt der Client einmalig aus der DB nach
+  und springt auf den aktuellen seq.
+
+## Lösung (Muster existiert: `inject_message` nutzt `background_tasks.add_task`)
+
+1. **Run als entkoppelter Server-Task**: `post_message`/`resend` starten den
+   Runner als eigenständigen `asyncio.Task` (nicht im SSE-Generator). Der Task
+   konsumiert `runner_run` bis zum Ende und schreibt wie gehabt in die DB +
+   broadcastet Live-Pings. Verbindungsabbruch berührt ihn nicht.
+2. **Task-Registry** (`runner/concurrency.py` erweitern): beim Start Task-Handle
+   registrieren, `cancel(session_id)` bricht ihn ab, `finally` räumt auf.
+3. **SSE nur noch Zuschauer**: `post_message` startet den Task und gibt sofort
+   den `stream_session`-SSE zurück (Live-Sync). Der Stream liest nur mit; sein
+   Abbruch killt den Run nicht mehr.
+4. **Echter Stop-Endpunkt**: `POST /sessions/{id}/stop` → `cancel(session_id)`.
+   Der Stop-Button ruft diesen Endpunkt statt die Verbindung zu kappen.
+5. **Frontend**: `busy`/Stop-Zustand aus dem Server ableiten (Session-Status
+   `running`), damit der Stop-Button auch nach Reconnect aktiv ist. `cancel`
+   ruft `POST /stop` statt `AbortController.abort()`.
+
+## Dateien
+
+Backend:
+- `core/src/hydrahive/runner/concurrency.py` — Task-Registry: `register_task`,
+  `cancel`, `get_task`; `session_run_guard` optional mit Task-Handle.
+- `core/src/hydrahive/api/routes/_session_msg_helpers.py` — neue
+  `start_run_task()` (entkoppelt) statt `sse_run_with_guard` im Stream.
+- `core/src/hydrahive/api/routes/sessions_messages.py` — `post_message`/`resend`
+  starten Task + geben SSE zurück; neuer `POST /{id}/stop`; `stream_session`
+  liefert initial `is_running`.
+- `core/tests/test_run_decoupled.py` — Run überlebt „Verbindungsabbruch", Stop
+  cancelt, kein Doppelstart.
+
+Frontend:
+- `frontend/src/features/chat/useChat.ts` — `cancel` ruft `POST /stop`; Run-Start
+  entkoppelt (Response nicht mehr lebensnotwendig fürs Weiterlaufen); busy aus
+  Server-Status beim Laden/Reconnect.
+- `frontend/src/features/chat/api.ts` — `stopRun(sessionId)`.
+
+## Implementierungsreihenfolge (TDD)
+
+### Task 1: Task-Registry in concurrency.py
+- [ ] Test: `register_task`/`get_task`/`cancel` — cancel bricht laufenden Task ab,
+      `is_running` false nach Ende.
+- [ ] Implementieren: `_tasks: dict[str, asyncio.Task]`; `cancel()` → `task.cancel()`.
+- [ ] Guard erweitert: registriert den aktuellen Task, `finally` deregistriert.
+
+### Task 2: Entkoppelter Run-Start
+- [ ] Test: `start_run_task()` startet Run als Task; nach „Abbruch des
+      Aufrufers" läuft der Task weiter bis Done (DB bekommt finale Assistant-Msg).
+- [ ] Implementieren: `start_run_task(session_id, user_content)` →
+      `asyncio.create_task(_run())`, registriert in Registry, 409 bei is_running.
+
+### Task 3: post_message/resend entkoppeln + Stop-Endpunkt
+- [ ] Test: `POST /messages` → Task läuft, Response-Abbruch killt Run NICHT.
+- [ ] Test: `POST /{id}/stop` → Run wird gecancelt (is_running false, DB konsistent).
+- [ ] Implementieren: post_message ruft start_run_task, gibt stream_session-SSE
+      zurück; `POST /{id}/stop` → cancel; stream_session initial `{"t":"running",...}`.
+
+### Task 4: Frontend Stop + Reconnect-Status
+- [ ] `stopRun()` in api.ts; `cancel` in useChat ruft es.
+- [ ] busy nach Laden/Reconnect aus Session-Status (running) — Stop-Button aktiv.
+- [ ] tsc + eslint grün.
+
+## Akzeptanzkriterien
+- [ ] Aufgabe starten, Browser schließen, 10+ min → Run läuft weiter & wird fertig.
+- [ ] Reconnect während Lauf → Stop-Button aktiv, Stop wirkt.
+- [ ] Kein Doppelstart (409 bleibt), Concurrency-Guard intakt.
+- [ ] Bestehende Chat-Tests grün, keine Regression im normalen Senden/Streamen.
+
+## Nicht in diesem Plan
+- Multi-Worker/DB-basierter Run-Status (bleibt in-memory, Single-Worker — wie heute).
+- Persistente Wiederaufnahme nach Server-Neustart (Run überlebt Prozess-Restart NICHT).
+- Voice-Bridge (nutzt eigenen Pfad, nicht betroffen).

--- a/frontend/src/features/chat/api.ts
+++ b/frontend/src/features/chat/api.ts
@@ -40,6 +40,13 @@ export const chatApi = {
   }>(`/sessions/${id}/tokens`),
   toolConfirm: (sessionId: string, callId: string, decision: "approve" | "deny") =>
     api.post<{ resolved: boolean }>(`/sessions/${sessionId}/tool-confirm/${callId}`, { decision }),
+  /** Stoppt den laufenden Agent-Run serverseitig — funktioniert immer, auch nach
+   *  Reconnect (cancelt den Server-Task, nicht die Verbindung). */
+  stopRun: (sessionId: string) =>
+    api.post<{ stopped: boolean }>(`/sessions/${sessionId}/stop`, {}),
+  /** Läuft für die Session gerade ein Run? + aktuelle Event-Seq (für Reconnect). */
+  runStatus: (sessionId: string) =>
+    api.get<{ running: boolean; latest_seq: number }>(`/sessions/${sessionId}/run-status`),
 }
 
 /** Stream a user message through SSE and yield runner events as they arrive. */
@@ -87,6 +94,35 @@ export async function* sendMessage(
     const frames = buffer.split("\n\n")
     buffer = frames.pop() ?? ""
 
+    for (const frame of frames) {
+      const event = parseSseFrame(frame)
+      if (event) yield event
+    }
+  }
+}
+
+/** Hängt sich an einen bereits laufenden Run und streamt dessen Events ab
+ *  `afterSeq` lückenlos weiter (Reconnect mitten im Lauf ohne Token-Verlust). */
+export async function* attachRun(
+  sessionId: string,
+  afterSeq: number,
+  signal?: AbortSignal,
+): AsyncIterable<RunnerEvent> {
+  const token = useAuthStore.getState().token
+  const res = await fetch(
+    `/api/sessions/${sessionId}/attach?after_seq=${afterSeq}`,
+    { headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}) }, signal },
+  )
+  if (!res.ok || !res.body) return
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const frames = buffer.split("\n\n")
+    buffer = frames.pop() ?? ""
     for (const frame of frames) {
       const event = parseSseFrame(frame)
       if (event) yield event

--- a/frontend/src/features/chat/useChat.ts
+++ b/frontend/src/features/chat/useChat.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { chatApi, sendMessage, subscribeSession } from "./api"
+import { attachRun, chatApi, sendMessage, subscribeSession } from "./api"
 import { applyStreamEvent, flushPendingLive } from "./_chatStream"
 import type { ContentBlock, Message } from "./types"
 
@@ -36,9 +36,12 @@ export function useChat(sessionId: string | null) {
   const [state, setState] = useState<ChatState>(EMPTY_STATE)
   const abortRef = useRef<AbortController | null>(null)
 
+  // Stop: cancelt den Server-Task (funktioniert IMMER, auch nach Reconnect),
+  // danach das lokale Zuhören beenden. Kein Verlass mehr auf Verbindungsabbruch.
   const cancel = useCallback(() => {
+    if (sessionId) { void chatApi.stopRun(sessionId).catch(() => {}) }
     abortRef.current?.abort(); abortRef.current = null
-  }, [])
+  }, [sessionId])
 
   const reload = useCallback(async () => {
     if (!sessionId) { setState(EMPTY_STATE); return }
@@ -135,6 +138,37 @@ export function useChat(sessionId: string | null) {
     void subscribeSession(sessionId, onPing, controller.signal)
     return () => { controller.abort(); if (timer) clearTimeout(timer) }
   }, [sessionId])
+
+  // Reconnect-in-Lauf: Beim Öffnen einer Session prüfen, ob dort schon ein Run
+  // läuft (von diesem oder einem anderen Gerät). Wenn ja: an den Event-Bus
+  // anhängen → live weiterschauen (flüssig) + Stop-Button aktiv. Der eigene
+  // Sende-Stream (busy schon true) übernimmt selbst, daher hier nur wenn NICHT busy.
+  useEffect(() => {
+    if (!sessionId) return
+    const controller = new AbortController()
+    let cancelled = false
+    ;(async () => {
+      try {
+        const st = await chatApi.runStatus(sessionId)
+        if (cancelled || !st.running || busyRef.current) return
+        setState((s) => ({ ...s, busy: true }))
+        abortRef.current = controller
+        const blocks: ContentBlock[] = []
+        for await (const ev of attachRun(sessionId, st.latest_seq, controller.signal)) {
+          const result = applyStreamEvent(ev as Record<string, unknown>, blocks, setState)
+          if (result === "error") break
+          if (result === "done") { await reload(); break }
+        }
+      } catch {
+        /* Run schon vorbei / Abbruch — reload holt den Endstand */
+        if (!cancelled) await reload()
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null
+        if (!cancelled) setState((s) => ({ ...s, busy: false }))
+      }
+    })()
+    return () => { cancelled = true; controller.abort() }
+  }, [sessionId, reload])
 
   return { ...state, send, cancel, reload, confirmTool }
 }


### PR DESCRIPTION
## Bug (till gemeldet)
1. Aufgabe laufen lassen + Browser/PC schließen → Lauf hört Minuten später auf, morgens **nicht fertig**.
2. Laufenden Chat, Browser zu + wieder rein → man ist nur **Zuschauer, kein Stop möglich**.

## Ursache (Code verifiziert)
Der Agent-Run lief **im SSE-Stream-Generator** (`sse_run_with_guard` → `async for ev in runner_run: yield ev`). Reißt die HTTP-Verbindung, bricht Starlette den Generator ab (`GeneratorExit`) → Run stirbt. „Stop" im Frontend war `AbortController.abort()` auf genau diese Verbindung → nach Reconnect wirkungslos.

## Fix (flüssiges Token-Streaming bleibt erhalten — ausdrückliche Anforderung)
- **`runner/event_bus.py`** (neu): lückenloser Event-Bus pro Session (Ringpuffer + `seq`-Cursor). Der entkoppelte Run publisht jedes Event; Consumer lesen ab ihrem `seq` weiter → **Reconnect mitten im Lauf ohne Token-Verlust**. Fällt der Cursor aus dem Puffer (`has_gap`), lädt der Client einmal aus der DB nach.
- **`runner/concurrency.py`**: Task-Registry (`register`/`get`/`cancel`). `cancel()` stoppt den Server-Task gezielt.
- **`start_run_task()`**: Run als entkoppelter `asyncio.Task` (Muster von `inject_message`). Überlebt Verbindungsabbruch. **Variante A**: zweiter Start bei laufendem Run → 409 (kein Doppellauf, schützt lange Läufe).
- **Routen**: `post_message`/`resend` → `run_and_stream`; neu `GET /run-status`, `GET /attach?after_seq`, `POST /stop`.
- **Frontend** `useChat`: `cancel` ruft `POST /stop` (funktioniert **immer**, auch nach Reconnect); beim Öffnen prüft `run-status` und hängt sich per `attachRun` an einen laufenden Run (Stop-Button aktiv, live weiterschauen).
- toter `sse_run_with_guard` entfernt.

## Verifikation
- **57 Tests grün** (12 neu: Task-Registry, Event-Bus inkl. Gap-Recovery, entkoppelter Run, **Reconnect-lückenlos-Integration**, Stop), keine Regression.
- Ruff + `tsc -b` + eslint grün.

## Bewusst nicht enthalten
- Multi-Worker (bleibt Single-Worker in-memory, wie das übrige Concurrency-System).
- Run überlebt **keinen Server-Neustart** — nur Verbindungsabbrüche (Browser/PC). Für „PC nachts aus" ist genau das die Anforderung.

Behebt Task a83a07c5. Spec: `docs/specs/chat-run-decoupled.md`.
