### PR TITLE
feat(projects): Member-Rechte Read/Write/Admin (#75)

### DIFF
--- a/core/src/hydrahive/agents/_workspace_links.py
+++ b/core/src/hydrahive/agents/_workspace_links.py
@@ -86,7 +86,8 @@ def sync_links_for_project(project_id: str) -> None:
     cfg = project_config.get(project_id)
     users: set[str] = set()
     if cfg:
-        users.update(cfg.get("members", []))
+        from hydrahive.projects import _members_model
+        users.update(_members_model.usernames(cfg))
         if cfg.get("created_by"):
             users.add(cfg["created_by"])
     # Für robustes Cleanup auch alle Owner mit existierendem Master-Workspace

--- a/core/src/hydrahive/api/routes/_git_helpers.py
+++ b/core/src/hydrahive/api/routes/_git_helpers.py
@@ -31,10 +31,11 @@ class GitCommit(BaseModel):
 
 
 def project_or_404(project_id: str, username: str, role: str) -> dict:
+    from hydrahive.projects import _members_model
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    if role != "admin" and username not in p.get("members", []) and p.get("created_by") != username:
+    if role != "admin" and not _members_model.is_member(p, username):
         raise coded(status.HTTP_403_FORBIDDEN, "project_no_access")
     return p
 

--- a/core/src/hydrahive/api/routes/_project_route_helpers.py
+++ b/core/src/hydrahive/api/routes/_project_route_helpers.py
@@ -6,12 +6,19 @@ from fastapi import status
 from pydantic import BaseModel, Field
 
 from hydrahive.api.middleware.errors import coded
+from hydrahive.projects import _members_model
+
+
+class MemberEntry(BaseModel):
+    username: str = Field(..., min_length=1)
+    role: str = Field("write", pattern="^(read|write|admin)$")
 
 
 class ProjectCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
     description: str = ""
-    members: list[str] = []
+    # Akzeptiert Legacy (list[str]) und neues Format (list[{username, role}]).
+    members: list[str | MemberEntry] = []
     llm_model: str
     init_git: bool = False
 
@@ -20,14 +27,20 @@ class ProjectUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     status: str | None = None
-    members: list[str] | None = None
+    members: list[str | MemberEntry] | None = None
     allowed_specialists: list[str] | None = None
 
 
-def check_project_access(project: dict, username: str, role: str) -> None:
+def check_project_access(
+    project: dict, username: str, role: str, required: str = "read"
+) -> None:
+    """Setzt Projekt-Rollen durch. System-Admins (Auth-role) dürfen alles.
+
+    ``required`` ist die Mindest-Projektrolle (read < write < admin).
+    """
     if role == "admin":
         return
-    if username in project.get("members", []) or project.get("created_by") == username:
+    if _members_model.has_at_least(_members_model.role_of(project, username), required):
         return
     raise coded(status.HTTP_403_FORBIDDEN, "project_no_access")
 

--- a/core/src/hydrahive/api/routes/_server_route_helpers.py
+++ b/core/src/hydrahive/api/routes/_server_route_helpers.py
@@ -21,7 +21,8 @@ def project_or_404(project_id: str, username: str, role: str) -> dict:
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    if role != "admin" and username not in p.get("members", []) and p.get("created_by") != username:
+    from hydrahive.projects import _members_model
+    if role != "admin" and not _members_model.is_member(p, username):
         raise coded(status.HTTP_403_FORBIDDEN, "project_no_access")
     return p
 

--- a/core/src/hydrahive/api/routes/butler.py
+++ b/core/src/hydrahive/api/routes/butler.py
@@ -155,7 +155,8 @@ def _project_flows(project: dict, project_id: str) -> list[Flow]:
     (created_by + members), explizit auf DIESES Projekt gescopt und enabled
     sind. So kann ein Außenstehender weder fremde Flows triggern noch über ein
     gefälschtes scope_id auf ein fremdes Projekt feuern."""
-    authorized = {project.get("created_by"), *project.get("members", [])}
+    from hydrahive.projects import _members_model
+    authorized = {project.get("created_by"), *_members_model.usernames(project)}
     authorized.discard(None)
     selected: list[Flow] = []
     for owner in authorized:

--- a/core/src/hydrahive/api/routes/projects.py
+++ b/core/src/hydrahive/api/routes/projects.py
@@ -4,6 +4,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
 
+from pydantic import BaseModel, Field
+
 from hydrahive.api.middleware.auth import require_admin, require_auth
 from hydrahive.api.middleware.errors import coded
 from hydrahive.api.routes._project_route_helpers import (
@@ -15,6 +17,19 @@ from hydrahive.projects import members as project_members
 
 router = APIRouter(prefix="/api/projects", tags=["projects"])
 _check_access = check_project_access
+
+
+class MemberRoleBody(BaseModel):
+    role: str = Field("write", pattern="^(read|write|admin)$")
+
+
+def _require_project_admin(project_id: str, auth: tuple[str, str]) -> dict:
+    """Member-Verwaltung: System-Admin ODER Projekt-admin (created_by/role admin)."""
+    p = project_config.get(project_id)
+    if not p:
+        raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
+    check_project_access(p, *auth, required="admin")
+    return p
 
 
 @router.get("")
@@ -31,11 +46,12 @@ def create_project(
     auth: Annotated[tuple[str, str], Depends(require_admin)],
 ) -> dict:
     creator, _ = auth
+    members = [m if isinstance(m, str) else m.model_dump() for m in req.members]
     try:
         return project_config.create(
             name=req.name,
             description=req.description,
-            members=req.members,
+            members=members,
             llm_model=req.llm_model,
             created_by=creator,
             init_git=req.init_git,
@@ -85,15 +101,38 @@ def delete_project(project_id: str) -> None:
 def add_member(
     project_id: str,
     username: str,
-    auth: Annotated[tuple[str, str], Depends(require_admin)],
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+    body: MemberRoleBody | None = None,
 ) -> dict:
+    _require_project_admin(project_id, auth)
+    role = (body.role if body else None) or project_members.DEFAULT_ROLE
     try:
-        result = project_members.add(project_id, username)
+        result = project_members.add(project_id, username, role)
     except KeyError:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
     except ProjectValidationError as e:
         raise coded(status.HTTP_400_BAD_REQUEST, "validation_error", message=str(e))
-    project_audit.log(project_id, auth[0], "member_added", target=username)
+    project_audit.log(project_id, auth[0], "member_added", target=username,
+                      details={"role": role})
+    return result
+
+
+@router.patch("/{project_id}/members/{username}")
+def set_member_role(
+    project_id: str,
+    username: str,
+    body: MemberRoleBody,
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
+) -> dict:
+    _require_project_admin(project_id, auth)
+    try:
+        result = project_members.set_role(project_id, username, body.role)
+    except KeyError:
+        raise coded(status.HTTP_404_NOT_FOUND, "member_not_found")
+    except ProjectValidationError as e:
+        raise coded(status.HTTP_400_BAD_REQUEST, "validation_error", message=str(e))
+    project_audit.log(project_id, auth[0], "member_role_changed", target=username,
+                      details={"role": body.role})
     return result
 
 
@@ -101,8 +140,9 @@ def add_member(
 def remove_member(
     project_id: str,
     username: str,
-    auth: Annotated[tuple[str, str], Depends(require_admin)],
+    auth: Annotated[tuple[str, str], Depends(require_auth)],
 ) -> dict:
+    _require_project_admin(project_id, auth)
     try:
         result = project_members.remove(project_id, username)
     except KeyError:

--- a/core/src/hydrahive/api/routes/projects_files_write.py
+++ b/core/src/hydrahive/api/routes/projects_files_write.py
@@ -34,7 +34,7 @@ def write_file(
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    check_project_access(p, *auth)
+    check_project_access(p, *auth, required="write")
 
     workspace = workspace_path(project_id)
     target = safe_workspace_path(workspace, body.path)
@@ -65,7 +65,7 @@ async def upload_file(
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    check_project_access(p, *auth)
+    check_project_access(p, *auth, required="write")
 
     name = (file.filename or "upload").strip()
     if not name or "/" in name or "\\" in name:
@@ -94,7 +94,7 @@ def delete_file(
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    check_project_access(p, *auth)
+    check_project_access(p, *auth, required="write")
 
     workspace = workspace_path(project_id)
     target = safe_workspace_path(workspace, path)

--- a/core/src/hydrahive/api/routes/projects_samba.py
+++ b/core/src/hydrahive/api/routes/projects_samba.py
@@ -24,7 +24,8 @@ def _project_or_404(project_id: str, username: str, role: str) -> dict:
     p = project_config.get(project_id)
     if not p:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    if role != "admin" and username not in p.get("members", []) and p.get("created_by") != username:
+    from hydrahive.projects import _members_model
+    if role != "admin" and not _members_model.is_member(p, username):
         raise coded(status.HTTP_403_FORBIDDEN, "project_no_access")
     return p
 

--- a/core/src/hydrahive/api/routes/sessions.py
+++ b/core/src/hydrahive/api/routes/sessions.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, status
 from hydrahive.agents import config as agent_config
 from hydrahive.api.middleware.auth import require_auth
 from hydrahive.api.middleware.errors import coded
+from hydrahive.api.routes._project_route_helpers import check_project_access
 from hydrahive.projects import config as project_config
 from hydrahive.api.routes._sessions_helpers import (
     SessionCreate,
@@ -113,15 +114,11 @@ def update_session(
 
 
 def _assert_project_access(project_id: str, username: str, role: str) -> None:
-    """Verhindert, dass eine Session an ein fremdes Projekt geheftet wird."""
+    """Eine Session an ein Projekt heften ist schreibend -> Rolle write nötig."""
     proj = project_config.get(project_id)
     if not proj:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    members = set(proj.get("members", []))
-    if proj.get("created_by"):
-        members.add(proj["created_by"])
-    if role != "admin" and username not in members:
-        raise coded(status.HTTP_403_FORBIDDEN, "project_no_access")
+    check_project_access(proj, username, role, required="write")
 
 
 @router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/core/src/hydrahive/api/routes/skills.py
+++ b/core/src/hydrahive/api/routes/skills.py
@@ -35,18 +35,18 @@ def _check_project_access(project_id: str | None, username: str, role: str) -> N
     Schließt das Tor, das durch 'project' in SkillScope sonst offenstünde."""
     from hydrahive.projects import config as project_config
 
+    from hydrahive.api.routes._project_route_helpers import check_project_access
+
     if not project_id:
         raise coded(status.HTTP_400_BAD_REQUEST, "skill_owner_required")
     proj = project_config.get(project_id)
     if not proj:
         raise coded(status.HTTP_404_NOT_FOUND, "project_not_found")
-    if role == "admin" or proj.get("owner") == username:
-        return
-    members = proj.get("members") or []
-    names = {m if isinstance(m, str) else (m or {}).get("username") for m in members}
-    if username in names:
-        return
-    raise coded(status.HTTP_403_FORBIDDEN, "skill_no_access")
+    # Skills anlegen/ändern/löschen ist schreibend -> Rolle write.
+    try:
+        check_project_access(proj, username, role, required="write")
+    except Exception:
+        raise coded(status.HTTP_403_FORBIDDEN, "skill_no_access")
 
 
 @router.get("")

--- a/core/src/hydrahive/projects/_config_io.py
+++ b/core/src/hydrahive/projects/_config_io.py
@@ -5,6 +5,7 @@ import json
 import logging
 from pathlib import Path
 
+from hydrahive.projects import _members_model
 from hydrahive.projects._paths import config_path, projects_root
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,8 @@ def _normalize(cfg: dict) -> dict:
     cfg.setdefault("status", "active")
     cfg.setdefault("description", "")
     cfg.setdefault("members", [])
+    # Legacy list[str] -> list[{username, role}] transparent beim Lesen.
+    cfg["members"] = _members_model.normalize_members(cfg.get("members"))
     cfg.setdefault("git_initialized", False)
     cfg.setdefault("git_token", "")
     cfg.setdefault("git_repos", {})
@@ -58,5 +61,4 @@ def list_all() -> list[dict]:
 
 
 def list_for_user(username: str) -> list[dict]:
-    return [p for p in list_all()
-            if username in p.get("members", []) or p.get("created_by") == username]
+    return [p for p in list_all() if _members_model.is_member(p, username)]

--- a/core/src/hydrahive/projects/_members_model.py
+++ b/core/src/hydrahive/projects/_members_model.py
@@ -1,0 +1,76 @@
+"""Einzige maßgebliche Abstraktion über die Projekt-Member-Struktur.
+
+Das Feld ``project["members"]`` ist eine ``list[{username, role}]``.
+NIEMAND außerhalb dieses Moduls greift direkt auf die Struktur zu — alle
+Membership-/Rollen-Fragen laufen über ``role_of`` / ``usernames`` /
+``has_at_least``. So bleibt das Speicherformat an genau einer Stelle gekapselt.
+
+``created_by`` ist implizit ``admin`` (auch wenn er nicht in ``members`` steht).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+ROLES = ("read", "write", "admin")
+DEFAULT_ROLE = "write"
+ROLE_RANK = {"read": 1, "write": 2, "admin": 3}
+
+
+def normalize_members(raw: Any) -> list[dict[str, str]]:
+    """Bringt beliebige (auch Legacy-)Member-Listen ins kanonische Format.
+
+    - ``["till", "bibs"]``            -> beide als ``write``
+    - ``[{"username": "x", "role": "read"}]`` -> unverändert (validiert)
+    - gemischte Listen                -> vereinheitlicht
+    Unbekannte Rollen fallen auf ``DEFAULT_ROLE`` zurück. Duplikate (gleicher
+    username) werden zusammengeführt (letzter Eintrag gewinnt).
+    """
+    if not isinstance(raw, list):
+        return []
+    by_name: dict[str, str] = {}
+    for entry in raw:
+        if isinstance(entry, str):
+            name, role = entry, DEFAULT_ROLE
+        elif isinstance(entry, dict):
+            name = entry.get("username") or ""
+            role = entry.get("role") or DEFAULT_ROLE
+        else:
+            continue
+        if not name:
+            continue
+        if role not in ROLE_RANK:
+            role = DEFAULT_ROLE
+        by_name[name] = role
+    return [{"username": n, "role": r} for n, r in by_name.items()]
+
+
+def usernames(project: dict) -> list[str]:
+    """Reine Namensliste der Members (ohne ``created_by``)."""
+    return [m["username"] for m in normalize_members(project.get("members"))]
+
+
+def role_of(project: dict, username: str) -> str | None:
+    """Effektive Rolle eines Users im Projekt, oder ``None`` wenn kein Zugriff.
+
+    ``created_by`` zählt immer als ``admin``.
+    """
+    if not username:
+        return None
+    if project.get("created_by") == username:
+        return "admin"
+    for m in normalize_members(project.get("members")):
+        if m["username"] == username:
+            return m["role"]
+    return None
+
+
+def has_at_least(role: str | None, required: str) -> bool:
+    """True, wenn ``role`` mindestens ``required`` erfüllt (read<write<admin)."""
+    if role is None:
+        return False
+    return ROLE_RANK.get(role, 0) >= ROLE_RANK.get(required, 99)
+
+
+def is_member(project: dict, username: str) -> bool:
+    """True, wenn der User Zugriff hat (irgendeine Rolle oder created_by)."""
+    return role_of(project, username) is not None

--- a/core/src/hydrahive/projects/_validation.py
+++ b/core/src/hydrahive/projects/_validation.py
@@ -32,8 +32,25 @@ def validate_member(username: str) -> None:
         raise ProjectValidationError(f"User '{username}' existiert nicht")
 
 
-def validate_members(members: list[str]) -> None:
+_VALID_ROLES = {"read", "write", "admin"}
+
+
+def validate_role(role: str) -> None:
+    if role not in _VALID_ROLES:
+        raise ProjectValidationError(
+            f"Ungültige Rolle: '{role}' (erlaubt: {', '.join(sorted(_VALID_ROLES))})"
+        )
+
+
+def validate_members(members: list) -> None:
+    """Akzeptiert Legacy (list[str]) und neues Format (list[{username, role}])."""
     if not isinstance(members, list):
         raise ProjectValidationError("members muss eine Liste sein")
     for m in members:
-        validate_member(m)
+        if isinstance(m, str):
+            validate_member(m)
+        elif isinstance(m, dict):
+            validate_member(m.get("username") or "")
+            validate_role(m.get("role") or "write")
+        else:
+            raise ProjectValidationError("Member muss str oder {username, role} sein")

--- a/core/src/hydrahive/projects/config.py
+++ b/core/src/hydrahive/projects/config.py
@@ -8,6 +8,7 @@ from typing import Any
 from hydrahive.agents import config as agent_config
 from hydrahive.db._utils import now_iso, uuid7
 from hydrahive.projects import _validation
+from hydrahive.projects import _members_model
 from hydrahive.projects._config_io import (
     _normalize, _save_atomic, get, list_all, list_for_user,
 )
@@ -36,6 +37,7 @@ def create(
     _validation.validate_name(name)
     members = members or []
     _validation.validate_members(members)
+    members = _members_model.normalize_members(members)
 
     project_id = uuid7()
     cfg: dict[str, Any] = {
@@ -116,7 +118,7 @@ def delete(project_id: str) -> bool:
     from hydrahive.smbmounts import db as mounts_db
     from hydrahive.smbmounts import mounter as smb_mounter
     from hydrahive.agents._workspace_links import sync_links_for_user
-    affected_users = set(cfg.get("members", []))
+    affected_users = set(_members_model.usernames(cfg))
     if cfg.get("created_by"):
         affected_users.add(cfg["created_by"])
     vms_db.clear_project_assignments(project_id)

--- a/core/src/hydrahive/projects/members.py
+++ b/core/src/hydrahive/projects/members.py
@@ -1,20 +1,39 @@
-"""Member-Management für Projekte. Admin-only auf Route-Ebene."""
+"""Member-Management für Projekte. Admin-Rechte werden auf Route-Ebene geprüft.
+
+Members sind ``list[{username, role}]`` — Struktur-Zugriff läuft über
+``_members_model``. ``created_by`` ist implizit admin und steht nicht in der
+Liste.
+"""
 from __future__ import annotations
 
 from hydrahive.db._utils import now_iso
 from hydrahive.projects import _validation
+from hydrahive.projects import _members_model
 from hydrahive.projects._paths import config_path
 from hydrahive.projects.config import _save_atomic, get
 
+DEFAULT_ROLE = _members_model.DEFAULT_ROLE
 
-def add(project_id: str, username: str) -> dict:
+
+def _entry(cfg: dict, username: str) -> dict | None:
+    for m in cfg["members"]:
+        if m["username"] == username:
+            return m
+    return None
+
+
+def add(project_id: str, username: str, role: str = DEFAULT_ROLE) -> dict:
     _validation.validate_member(username)
+    _validation.validate_role(role)
     cfg = get(project_id)
     if not cfg:
         raise KeyError(f"Projekt '{project_id}' nicht gefunden")
-    if username in cfg["members"]:
-        return cfg
-    cfg["members"].append(username)
+    existing = _entry(cfg, username)
+    if existing:
+        # Idempotent: bereits Member -> ggf. Rolle aktualisieren.
+        existing["role"] = role
+    else:
+        cfg["members"].append({"username": username, "role": role})
     cfg["updated_at"] = now_iso()
     _save_atomic(config_path(project_id), cfg)
     from hydrahive.agents._workspace_links import sync_links_for_user
@@ -22,13 +41,28 @@ def add(project_id: str, username: str) -> dict:
     return cfg
 
 
+def set_role(project_id: str, username: str, role: str) -> dict:
+    _validation.validate_role(role)
+    cfg = get(project_id)
+    if not cfg:
+        raise KeyError(f"Projekt '{project_id}' nicht gefunden")
+    entry = _entry(cfg, username)
+    if not entry:
+        raise KeyError(f"'{username}' ist kein Member von '{project_id}'")
+    entry["role"] = role
+    cfg["updated_at"] = now_iso()
+    _save_atomic(config_path(project_id), cfg)
+    return cfg
+
+
 def remove(project_id: str, username: str) -> dict:
     cfg = get(project_id)
     if not cfg:
         raise KeyError(f"Projekt '{project_id}' nicht gefunden")
-    if username not in cfg["members"]:
+    entry = _entry(cfg, username)
+    if not entry:
         return cfg
-    cfg["members"].remove(username)
+    cfg["members"].remove(entry)
     cfg["updated_at"] = now_iso()
     _save_atomic(config_path(project_id), cfg)
     from hydrahive.agents._workspace_links import sync_links_for_user

--- a/core/tests/test_project_member_roles_routes.py
+++ b/core/tests/test_project_member_roles_routes.py
@@ -1,0 +1,97 @@
+"""End-to-End: Member-Rollen-Enforcement über die Projekt-Routen.
+
+Nutzt echte Projekt-Persistenz (kein Mock) — deckt Migration, Rollen-Setzen
+und Enforcement ab. testuser = role 'user', admin = role 'admin'.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _create_project(client, admin_headers, members=None) -> str:
+    body = {"name": "Rollen-Projekt", "llm_model": "test/model"}
+    if members is not None:
+        body["members"] = members
+    r = client.post("/api/projects", headers=admin_headers, json=body)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+class TestMemberRolePersistence:
+    def test_create_normalizes_legacy_str_members(self, client, admin_headers):
+        pid = _create_project(client, admin_headers, members=["testuser"])
+        r = client.get(f"/api/projects/{pid}", headers=admin_headers)
+        assert r.json()["members"] == [{"username": "testuser", "role": "write"}]
+
+    def test_add_member_with_role(self, client, admin_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.post(f"/api/projects/{pid}/members/testuser",
+                        headers=admin_headers, json={"role": "read"})
+        assert r.status_code == 200
+        assert {"username": "testuser", "role": "read"} in r.json()["members"]
+
+    def test_add_member_default_role_write(self, client, admin_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.post(f"/api/projects/{pid}/members/testuser", headers=admin_headers)
+        assert r.status_code == 200
+        assert {"username": "testuser", "role": "write"} in r.json()["members"]
+
+    def test_set_member_role(self, client, admin_headers):
+        pid = _create_project(client, admin_headers, members=["testuser"])
+        r = client.patch(f"/api/projects/{pid}/members/testuser",
+                         headers=admin_headers, json={"role": "admin"})
+        assert r.status_code == 200
+        assert {"username": "testuser", "role": "admin"} in r.json()["members"]
+
+    def test_set_role_unknown_member_404(self, client, admin_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.patch(f"/api/projects/{pid}/members/ghost",
+                         headers=admin_headers, json={"role": "read"})
+        assert r.status_code == 404
+
+    def test_invalid_role_rejected(self, client, admin_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.post(f"/api/projects/{pid}/members/testuser",
+                        headers=admin_headers, json={"role": "superuser"})
+        assert r.status_code == 422  # pydantic pattern
+
+
+class TestMemberManagementAuth:
+    def test_project_admin_member_can_manage(self, client, admin_headers, auth_headers):
+        # testuser als Projekt-admin -> darf weitere Members hinzufügen.
+        pid = _create_project(client, admin_headers,
+                              members=[{"username": "testuser", "role": "admin"}])
+        r = client.post(f"/api/projects/{pid}/members/admin",
+                        headers=auth_headers, json={"role": "read"})
+        assert r.status_code == 200
+
+    def test_write_member_cannot_manage(self, client, admin_headers, auth_headers):
+        pid = _create_project(client, admin_headers,
+                              members=[{"username": "testuser", "role": "write"}])
+        r = client.post(f"/api/projects/{pid}/members/admin",
+                        headers=auth_headers, json={"role": "read"})
+        assert r.status_code == 403
+
+    def test_read_member_cannot_manage(self, client, admin_headers, auth_headers):
+        pid = _create_project(client, admin_headers,
+                              members=[{"username": "testuser", "role": "read"}])
+        r = client.post(f"/api/projects/{pid}/members/admin", headers=auth_headers)
+        assert r.status_code == 403
+
+    def test_non_member_cannot_manage(self, client, admin_headers, auth_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.post(f"/api/projects/{pid}/members/admin", headers=auth_headers)
+        assert r.status_code == 403
+
+
+class TestReadVsWriteEnforcement:
+    def test_read_member_can_view_project(self, client, admin_headers, auth_headers):
+        pid = _create_project(client, admin_headers,
+                              members=[{"username": "testuser", "role": "read"}])
+        r = client.get(f"/api/projects/{pid}", headers=auth_headers)
+        assert r.status_code == 200
+
+    def test_non_member_cannot_view_project(self, client, admin_headers, auth_headers):
+        pid = _create_project(client, admin_headers)
+        r = client.get(f"/api/projects/{pid}", headers=auth_headers)
+        assert r.status_code == 403

--- a/core/tests/test_project_members_model.py
+++ b/core/tests/test_project_members_model.py
@@ -1,0 +1,88 @@
+"""Tests für die Member-Rollen-Abstraktion (projects/_members_model.py)."""
+from __future__ import annotations
+
+from hydrahive.projects import _members_model as mm
+
+
+class TestNormalize:
+    def test_legacy_str_list_becomes_write(self):
+        out = mm.normalize_members(["till", "bibs"])
+        assert out == [
+            {"username": "till", "role": "write"},
+            {"username": "bibs", "role": "write"},
+        ]
+
+    def test_dict_list_preserved(self):
+        raw = [{"username": "till", "role": "read"}]
+        assert mm.normalize_members(raw) == [{"username": "till", "role": "read"}]
+
+    def test_mixed_list(self):
+        raw = ["till", {"username": "bibs", "role": "admin"}]
+        out = mm.normalize_members(raw)
+        assert {"username": "till", "role": "write"} in out
+        assert {"username": "bibs", "role": "admin"} in out
+
+    def test_unknown_role_falls_back(self):
+        raw = [{"username": "x", "role": "superuser"}]
+        assert mm.normalize_members(raw) == [{"username": "x", "role": "write"}]
+
+    def test_duplicate_last_wins(self):
+        raw = [{"username": "x", "role": "read"}, {"username": "x", "role": "admin"}]
+        assert mm.normalize_members(raw) == [{"username": "x", "role": "admin"}]
+
+    def test_garbage_ignored(self):
+        assert mm.normalize_members(None) == []
+        assert mm.normalize_members("nope") == []
+        assert mm.normalize_members([123, {"role": "read"}, {"username": ""}]) == []
+
+
+class TestRoleOf:
+    def test_created_by_is_admin(self):
+        p = {"created_by": "boss", "members": []}
+        assert mm.role_of(p, "boss") == "admin"
+
+    def test_member_role(self):
+        p = {"created_by": "boss", "members": [{"username": "j", "role": "read"}]}
+        assert mm.role_of(p, "j") == "read"
+
+    def test_legacy_member_is_write(self):
+        p = {"created_by": "boss", "members": ["j"]}
+        assert mm.role_of(p, "j") == "write"
+
+    def test_non_member_none(self):
+        p = {"created_by": "boss", "members": []}
+        assert mm.role_of(p, "stranger") is None
+
+    def test_empty_username_none(self):
+        assert mm.role_of({"created_by": "boss"}, "") is None
+
+
+class TestHasAtLeast:
+    def test_ranking(self):
+        assert mm.has_at_least("admin", "read")
+        assert mm.has_at_least("admin", "write")
+        assert mm.has_at_least("admin", "admin")
+        assert mm.has_at_least("write", "read")
+        assert mm.has_at_least("write", "write")
+        assert not mm.has_at_least("write", "admin")
+        assert mm.has_at_least("read", "read")
+        assert not mm.has_at_least("read", "write")
+        assert not mm.has_at_least("read", "admin")
+
+    def test_none_never_qualifies(self):
+        assert not mm.has_at_least(None, "read")
+
+
+class TestUsernamesAndIsMember:
+    def test_usernames_from_dicts(self):
+        p = {"members": [{"username": "a", "role": "read"}, {"username": "b", "role": "admin"}]}
+        assert mm.usernames(p) == ["a", "b"]
+
+    def test_usernames_from_legacy(self):
+        assert mm.usernames({"members": ["a", "b"]}) == ["a", "b"]
+
+    def test_is_member(self):
+        p = {"created_by": "boss", "members": [{"username": "a", "role": "read"}]}
+        assert mm.is_member(p, "a")
+        assert mm.is_member(p, "boss")
+        assert not mm.is_member(p, "x")

--- a/core/tests/test_skills_project_route.py
+++ b/core/tests/test_skills_project_route.py
@@ -7,7 +7,20 @@ from __future__ import annotations
 
 def test_non_member_cannot_write_project_skill(client, auth_headers, monkeypatch):
     from hydrahive.projects import config as pc
-    monkeypatch.setattr(pc, "get", lambda pid: {"id": pid, "owner": "someone_else", "members": []})
+    monkeypatch.setattr(pc, "get", lambda pid: {"id": pid, "created_by": "someone_else", "members": []})
+    r = client.post("/api/skills/project?owner=proj-x", headers=auth_headers, json={
+        "name": "x", "description": "d", "when_to_use": "w", "body": "b",
+    })
+    assert r.status_code == 403
+
+
+def test_read_member_cannot_write_project_skill(client, auth_headers, monkeypatch):
+    from hydrahive.projects import config as pc
+    # testuser ist nur read-Member -> darf keine Skills schreiben.
+    monkeypatch.setattr(pc, "get", lambda pid: {
+        "id": pid, "created_by": "boss",
+        "members": [{"username": "testuser", "role": "read"}],
+    })
     r = client.post("/api/skills/project?owner=proj-x", headers=auth_headers, json={
         "name": "x", "description": "d", "when_to_use": "w", "body": "b",
     })
@@ -16,9 +29,21 @@ def test_non_member_cannot_write_project_skill(client, auth_headers, monkeypatch
 
 def test_member_can_write_project_skill(client, auth_headers, monkeypatch):
     from hydrahive.projects import config as pc
-    # auth_headers == testuser; als Owner zugelassen
-    monkeypatch.setattr(pc, "get", lambda pid: {"id": pid, "owner": "testuser", "members": []})
+    # auth_headers == testuser; created_by == Owner -> implizit admin, darf schreiben.
+    monkeypatch.setattr(pc, "get", lambda pid: {"id": pid, "created_by": "testuser", "members": []})
     r = client.post("/api/skills/project?owner=proj-x", headers=auth_headers, json={
         "name": "shared", "description": "d", "when_to_use": "w", "body": "b",
+    })
+    assert r.status_code == 201
+
+
+def test_write_member_can_write_project_skill(client, auth_headers, monkeypatch):
+    from hydrahive.projects import config as pc
+    monkeypatch.setattr(pc, "get", lambda pid: {
+        "id": pid, "created_by": "boss",
+        "members": [{"username": "testuser", "role": "write"}],
+    })
+    r = client.post("/api/skills/project?owner=proj-x", headers=auth_headers, json={
+        "name": "shared2", "description": "d", "when_to_use": "w", "body": "b",
     })
     assert r.status_code == 201

--- a/docs/specs/project-member-roles.md
+++ b/docs/specs/project-member-roles.md
@@ -1,0 +1,87 @@
+# Spec: Projekt-Member-Rechte (Read / Write / Admin)
+
+**Issue:** #75 · **Branch:** `feat/project-member-roles` · **Stand:** 2026-07-29
+
+## Was
+Projekt-Mitgliedschaft wird von binär (`members: list[str]`) auf rollenbasiert
+umgestellt: jeder Member hat eine Rolle `read | write | admin`. Die Rollen
+werden serverseitig pro Operation durchgesetzt.
+
+## Warum
+Bei mehreren Personen pro Projekt braucht man Abstufung: ein Junior darf
+Sessions öffnen/mitlesen, aber nicht Settings ändern oder Members verwalten.
+
+## Datenmodell (die eine maßgebliche Quelle)
+`config.json` → `members: list[{username: str, role: 'read'|'write'|'admin'}]`
+
+- Bleibt im File (konsistent mit allen anderen Projekt-Feldern), **keine** DB.
+- `created_by` ist implizit **admin** (steht nicht zwingend in `members`).
+- Default-Rolle beim Hinzufügen: `write`.
+
+### Backward-Compat (verbindlich)
+`_normalize()` migriert beim **Lesen** transparent:
+- `members: ["till", "bibs"]` → `[{"username":"till","role":"write"}, {"username":"bibs","role":"write"}]`
+- gemischte Listen (teils str, teils dict) werden ebenfalls normalisiert.
+- Alte Configs werden dadurch beim nächsten Save automatisch aufs neue Format
+  gehoben — kein separater Migrationslauf nötig.
+
+## Abstraktionsschicht (Kern der „sauberen" Lösung)
+Neues Modul `projects/_members_model.py` (oder Funktionen in bestehendem
+`members.py`) mit:
+
+- `role_of(project: dict, username: str) -> str | None`
+  - `created_by` → `"admin"`
+  - sonst Rolle aus `members`, oder `None` wenn kein Member
+- `usernames(project: dict) -> list[str]` — reine Namensliste (ersetzt alle
+  bisherigen `p.get("members", [])`-Iterationen)
+- `ROLE_RANK = {"read":1, "write":2, "admin":3}` + `has_at_least(role, required)`
+
+**Regel:** Niemand außer diesem Modul greift direkt auf die members-Struktur zu.
+Alle ~10 heutigen `username in members`-Stellen rufen `usernames()` bzw.
+`role_of()` auf.
+
+## Enforcement
+`check_project_access(project, username, role, required='read')` in
+`_project_route_helpers.py`:
+- System-Admin (`role == "admin"` aus Auth) → immer erlaubt
+- sonst: `has_at_least(role_of(project, username), required)`
+- kein Zugriff → `403 project_no_access`
+
+### Rollen-Matrix (Default; beim Review kippbar)
+| Operation | benötigt |
+|---|---|
+| Projekt sehen, Dateien lesen, Session öffnen/mitlesen, Read-Tools | read |
+| Session starten, Workspace/Dateien schreiben, Skills anlegen | write |
+| Members verwalten, Settings ändern, Projekt löschen | admin |
+
+## Betroffene Stellen (alle auf Abstraktion umstellen)
+- `projects/_config_io.py` — `_normalize` (Migration), `list_for_user` (via `usernames`)
+- `projects/config.py` — `create`, `update` (validate), `delete` (affected_users via `usernames`)
+- `projects/members.py` — `add(project, username, role='write')`, `remove`, neu `set_role`
+- `projects/_validation.py` — `validate_members` akzeptiert dict-Form + Rolle
+- `api/routes/_project_route_helpers.py` — `check_project_access(required=...)`, Pydantic-Modelle
+- `api/routes/projects.py` — Member-Routen (add mit role, set_role-Endpoint)
+- `api/routes/sessions.py` — `_assert_project_access` (start→write, open→read)
+- `api/routes/projects_files*.py` — read→read, write→write
+- `api/routes/skills.py` — `_check_project_access` (write für Anlegen)
+- `api/routes/butler.py`, `_git_helpers.py`, `projects_samba.py`,
+  `_server_route_helpers.py` — via `usernames()`
+- `tools/list_projects.py` — `members` weiterhin ausgeben (Namen + Rolle)
+- `agents/_workspace_links.py` — `usernames()` statt direktem members-Zugriff
+
+## Frontend
+- `frontend/src/features/projects/…` — Member-Liste zeigt Rolle, Rollen-Dropdown
+  (nur für admin/created_by editierbar), Hinzufügen mit Rollenwahl.
+- API-Typen anpassen (`members: {username, role}[]`).
+
+## Akzeptanzkriterien
+1. Alte Config (`members: list[str]`) lädt fehlerfrei, alle Member als `write`.
+2. `read`-Member kann Session **öffnen/mitlesen**, aber **nicht starten** (403).
+3. `read`/`write`-Member kann **keine** Members verwalten/Settings ändern (403).
+4. `admin`-Member + `created_by` können Members verwalten.
+5. System-Admin darf weiterhin alles.
+6. Kein direkter members-Struktur-Zugriff außerhalb `_members_model` (grep-Check).
+7. pytest grün (inkl. neuer Rollen-Tests), ruff grün, tsc/eslint grün.
+
+## Nicht in v1
+- Rollenvererbung, Custom-Rollen, per-Tool-Granularität, DB-Auslagerung.

--- a/frontend/src/features/projects/MemberManager.tsx
+++ b/frontend/src/features/projects/MemberManager.tsx
@@ -2,11 +2,19 @@ import { useEffect, useState } from "react"
 import { Plus, X } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { projectsApi, usersApi } from "./api"
-import type { Project } from "./types"
+import type { Project, ProjectRole } from "./types"
 
 interface Props {
   project: Project
   onChange: (p: Project) => void
+}
+
+const ROLES: ProjectRole[] = ["read", "write", "admin"]
+
+const ROLE_STYLE: Record<ProjectRole, string> = {
+  read: "bg-sky-500/[8%] border-sky-500/20 text-sky-200",
+  write: "bg-violet-500/[8%] border-violet-500/20 text-violet-200",
+  admin: "bg-amber-500/[8%] border-amber-500/20 text-amber-200",
 }
 
 export function MemberManager({ project, onChange }: Props) {
@@ -14,6 +22,7 @@ export function MemberManager({ project, onChange }: Props) {
   const { t: tCommon } = useTranslation("common")
   const [available, setAvailable] = useState<string[]>([])
   const [adding, setAdding] = useState("")
+  const [addRole, setAddRole] = useState<ProjectRole>("write")
 
   useEffect(() => {
     usersApi.list().then((users) => setAvailable(users.map((u) => u.username))).catch(() => {})
@@ -22,9 +31,19 @@ export function MemberManager({ project, onChange }: Props) {
   async function add() {
     if (!adding) return
     try {
-      const updated = await projectsApi.addMember(project.id, adding)
+      const updated = await projectsApi.addMember(project.id, adding, addRole)
       onChange(updated)
       setAdding("")
+      setAddRole("write")
+    } catch (e) {
+      alert(e instanceof Error ? e.message : tCommon("status.error"))
+    }
+  }
+
+  async function changeRole(username: string, role: ProjectRole) {
+    try {
+      const updated = await projectsApi.setMemberRole(project.id, username, role)
+      onChange(updated)
     } catch (e) {
       alert(e instanceof Error ? e.message : tCommon("status.error"))
     }
@@ -36,27 +55,41 @@ export function MemberManager({ project, onChange }: Props) {
     onChange(updated)
   }
 
-  const candidates = available.filter((u) => !project.members.includes(u))
+  const memberNames = project.members.map((m) => m.username)
+  const candidates = available.filter((u) => !memberNames.includes(u))
+
+  function roleLabel(role: ProjectRole) {
+    return t(`members.roles.${role}`, { defaultValue: role })
+  }
 
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-col gap-1.5">
         {project.members.length === 0 && (
           <p className="text-xs text-zinc-600">{t("members.no_members")}</p>
         )}
         {project.members.map((m) => (
-          <span
-            key={m}
-            className="inline-flex items-center gap-1.5 pl-2.5 pr-1 py-1 rounded-md bg-violet-500/[8%] border border-violet-500/20 text-xs text-violet-200"
+          <div
+            key={m.username}
+            className={`inline-flex items-center gap-2 pl-2.5 pr-1 py-1 rounded-md border text-xs ${ROLE_STYLE[m.role]}`}
           >
-            {m}
+            <span className="font-medium">{m.username}</span>
+            <select
+              value={m.role}
+              onChange={(e) => changeRole(m.username, e.target.value as ProjectRole)}
+              className="ml-auto px-1.5 py-0.5 rounded bg-zinc-900/60 border border-white/10 text-[11px] text-zinc-200"
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r}>{roleLabel(r)}</option>
+              ))}
+            </select>
             <button
-              onClick={() => remove(m)}
+              onClick={() => remove(m.username)}
               className="p-0.5 rounded hover:bg-rose-500/20 hover:text-rose-300 transition-colors"
             >
               <X size={11} />
             </button>
-          </span>
+          </div>
         ))}
       </div>
       {candidates.length > 0 && (
@@ -68,6 +101,15 @@ export function MemberManager({ project, onChange }: Props) {
           >
             <option value="">{t("members.select_user")}</option>
             {candidates.map((u) => <option key={u} value={u}>{u}</option>)}
+          </select>
+          <select
+            value={addRole}
+            onChange={(e) => setAddRole(e.target.value as ProjectRole)}
+            className="px-2 py-2 rounded-lg bg-zinc-900 border border-white/[8%] text-sm text-zinc-200"
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>{roleLabel(r)}</option>
+            ))}
           </select>
           <button
             onClick={add}

--- a/frontend/src/features/projects/api.ts
+++ b/frontend/src/features/projects/api.ts
@@ -1,5 +1,5 @@
 import { api } from "@/shared/api-client"
-import type { Project, ProjectAuditEntry, ProjectCreate, ProjectGiteaStatus, ProjectGitRepo, ProjectServer, ProjectStats, ProjectSession, ServerKind, SmbMount, SmbMountCreate } from "./types"
+import type { Project, ProjectAuditEntry, ProjectCreate, ProjectGiteaStatus, ProjectGitRepo, ProjectRole, ProjectServer, ProjectStats, ProjectSession, ServerKind, SmbMount, SmbMountCreate } from "./types"
 
 export const projectsApi = {
   list: () => api.get<Project[]>("/projects"),
@@ -29,8 +29,10 @@ export const projectsApi = {
   deleteFile: (id: string, path: string) =>
     api.delete<{ ok: boolean }>(`/projects/${id}/files?path=${encodeURIComponent(path)}`),
   delete: (id: string) => api.delete<void>(`/projects/${id}`),
-  addMember: (id: string, username: string) =>
-    api.post<Project>(`/projects/${id}/members/${username}`, {}),
+  addMember: (id: string, username: string, role: ProjectRole = "write") =>
+    api.post<Project>(`/projects/${id}/members/${username}`, { role }),
+  setMemberRole: (id: string, username: string, role: ProjectRole) =>
+    api.patch<Project>(`/projects/${id}/members/${username}`, { role }),
   removeMember: (id: string, username: string) =>
     api.delete<Project>(`/projects/${id}/members/${username}`),
   getAgent: (id: string) => api.get<{ id: string; name: string; llm_model: string }>(`/projects/${id}/agent`),

--- a/frontend/src/features/projects/types.ts
+++ b/frontend/src/features/projects/types.ts
@@ -1,3 +1,10 @@
+export type ProjectRole = "read" | "write" | "admin"
+
+export interface ProjectMember {
+  username: string
+  role: ProjectRole
+}
+
 export interface Project {
   id: string
   name: string
@@ -8,7 +15,7 @@ export interface Project {
   allowed_plugins: string[]
   allowed_specialists: string[]
   llm_api_key: string
-  members: string[]
+  members: ProjectMember[]
   agent_id: string
   status: "active" | "paused" | "archived"
   created_at: string
@@ -20,7 +27,7 @@ export interface Project {
 export interface ProjectCreate {
   name: string
   description: string
-  members: string[]
+  members: (string | ProjectMember)[]
   llm_model: string
   init_git: boolean
 }
@@ -131,5 +138,6 @@ export type ProjectAuditAction =
   | "project_updated"
   | "member_added"
   | "member_removed"
+  | "member_role_changed"
   | "server_assigned"
   | "server_unassigned"

--- a/frontend/src/i18n/locales/de/projects.json
+++ b/frontend/src/i18n/locales/de/projects.json
@@ -25,7 +25,12 @@
   "members": {
     "no_members": "Keine Members",
     "remove_confirm": "'{{username}}' aus Projekt entfernen?",
-    "select_user": "User auswählen…"
+    "select_user": "User auswählen…",
+    "roles": {
+      "read": "Lesen",
+      "write": "Schreiben",
+      "admin": "Admin"
+    }
   },
   "tabs": {
     "overview": "Übersicht",

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -25,7 +25,12 @@
   "members": {
     "no_members": "No members",
     "remove_confirm": "Remove '{{username}}' from project?",
-    "select_user": "Select user…"
+    "select_user": "Select user…",
+    "roles": {
+      "read": "Read",
+      "write": "Write",
+      "admin": "Admin"
+    }
   },
   "tabs": {
     "overview": "Overview",


### PR DESCRIPTION
Schließt #75.

## Was
Projekt-Mitgliedschaft wird von binär (drin/draußen) auf rollenbasiert umgestellt: jeder Member hat `read | write | admin`, serverseitig pro Operation durchgesetzt.

## Datenmodell (die eine maßgebliche Quelle)
`members: list[str]` → `members: list[{username, role}]` im File (konsistent mit allen anderen Projekt-Feldern, **keine** DB).
- `created_by` ist implizit **admin**.
- **Backward-Compat:** `_normalize()` migriert alte `list[str]` transparent beim Lesen (→ Rolle `write`). Kein separater Migrationslauf nötig.

## Saubere Abstraktion (der eigentliche Kern)
Neues Modul `projects/_members_model.py` mit `role_of` / `usernames` / `has_at_least` — **die einzige Stelle** mit direktem Struktur-Zugriff. Alle bisherigen ~10 `username in members`-Checks (sessions, skills, butler, git, samba, server, workspace-links, list_projects) rufen jetzt die Abstraktion. Ein späterer Wechsel auf DB wäre dadurch ein Einzeiler in diesem Modul.

## Enforcement
`check_project_access(project, username, role, required='read')` als zentraler Punkt.

| Operation | benötigt |
|---|---|
| Projekt sehen, Session öffnen/mitlesen | read |
| Session starten, Workspace schreiben, Skills anlegen | write |
| Members/Settings verwalten, löschen | admin |

Member-Verwaltung: von System-`require_admin` auf **Projekt-admin** umgestellt. Neu: `PATCH /projects/{id}/members/{username}` (set_role); `POST` nimmt optional `{role}`.

## Frontend
`ProjectMember`-Typ, Rollen-Dropdown im `MemberManager`, `setMemberRole`-API, i18n de/en.

## Tests / Checks
- 16 Modell-Unit-Tests (`test_project_members_model.py`)
- 12 Route-E2E-Tests inkl. read/write/admin-Enforcement-Matrix (`test_project_member_roles_routes.py`)
- Regression: 193 passed im projects/members/skill/git/samba/butler-Bereich, 74 session-Tests grün
- ruff / tsc / eslint clean

## Bewusste v1-Grenze
`update_project` (Projekt-Settings wie name/status) bleibt vorerst System-`require_admin`. Delegation an Projekt-admins ist ein eigener Scope (welche Felder darf ein Projekt-admin ändern?) und in der Spec als „nicht in v1" vermerkt.

Spec: `docs/specs/project-member-roles.md`