### PR TITLE
feat(cockpit): neue Projekt-Session pro Agent starten

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -106,12 +106,21 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
     if (current && current.project_id !== projectId) setActiveId(null)
   }, [projectId, activeId, sessions])
 
-  // Externe Anforderung (z. B. Session-Klick im Auswerten-Panel) in-place öffnen.
+  // Externe Anforderung (z. B. Session-Klick im Auswerten-Panel, oder eine im
+  // Cockpit frisch erstellte Session) in-place öffnen. Ist die Session hier noch
+  // unbekannt — bei Neuanlage von außen der Normalfall — muss die Liste zuerst
+  // nachgeladen werden: sonst verwirft der Projekt-Guard oben die activeId
+  // wieder, weil sie in `sessions` nicht auffindbar ist.
   useEffect(() => {
     if (!openSessionRequest) return
+    if (!sessions.some((s) => s.id === openSessionRequest)) {
+      void loadAll()
+      return
+    }
     setActiveId(openSessionRequest)
     onSessionRequestHandled?.()
-  }, [openSessionRequest, onSessionRequestHandled])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openSessionRequest, onSessionRequestHandled, sessions])
 
   async function handleNew(agentId: string, title: string, projectId?: string) {
     if (activeSession?.project_id) await chatApi.handover(activeSession.id)
@@ -238,7 +247,12 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
     setSessions((cur) => cur.map((s) => s.id === updated.id ? updated : s))
 
   async function createPreferredSession() {
-    const agent = activeAgent ?? preferredAgent ?? agents.find((a) => !a.is_buddy) ?? agents[0]
+    // preferredAgent (im Cockpit: der links ausgewählte Projekt-Agent) hat
+    // Vorrang vor dem Agenten der zufällig offenen Session. Sonst startet der
+    // Button eine Session mit dem zuletzt benutzten Agenten statt mit dem
+    // sichtbar ausgewählten — im Projekt-Cockpit mit gemischten Sessions
+    // (Projekt-Agent + Buddy) war das reproduzierbar der falsche.
+    const agent = preferredAgent ?? activeAgent ?? agents.find((a) => !a.is_buddy) ?? agents[0]
     if (!agent) return
     setNewSessionBusy(true)
     try {

--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -29,6 +29,7 @@ import { SkillCatalogPill } from "./_SkillCatalogPill"
 import { isCommand, runChatCommand } from "./commands"
 import { ChatSearchProvider, useChatSearch } from "./ChatSearchContext"
 import { ChatSearchBar } from "./ChatSearchBar"
+import { pickSessionFor } from "./_pickSession"
 
 function ChatSearchScrollEffect() {
   const { activeMessageId } = useChatSearch()
@@ -88,7 +89,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
         deepLinkApplied.current = true
         setActiveId(deepLinkSid)
       } else if (!activeId && !deepLinkSid && visibleSessions.length > 0) {
-        setActiveId(visibleSessions[0].id)
+        setActiveId(pickSessionFor(visibleSessions, preferredAgentId))
       }
     } catch {
       // Nicht still schlucken (#211): die Sitzungsliste wäre sonst unbemerkt veraltet.
@@ -209,8 +210,8 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
 
   useEffect(() => {
     if (activeId || deepLinkSid || visibleSessions.length === 0) return
-    setActiveId(visibleSessions[0].id)
-  }, [activeId, deepLinkSid, visibleSessions])
+    setActiveId(pickSessionFor(visibleSessions, preferredAgentId))
+  }, [activeId, deepLinkSid, visibleSessions, preferredAgentId])
 
   const [pixelScope, setPixelScope] = useState<"chat" | "all">("chat")
   const { running, doneNames } = useAgentActivity(showPixelMonitor)
@@ -351,15 +352,21 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
       </ChatSearchProvider>
     </div>
   ) : (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-zinc-600">
-      <span>{t("session.select_or_new")}</span>
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-sm text-zinc-600">
+      <span>
+        {preferredAgent
+          ? `${preferredAgent.name} hat in diesem Projekt noch keine Session.`
+          : t("session.select_or_new")}
+      </span>
       <button
         type="button"
         onClick={createPreferredSession}
-        disabled={agents.length === 0}
+        disabled={agents.length === 0 || newSessionBusy}
         className="rounded-[4px] border border-cyan-400/30 bg-cyan-400/10 px-3 py-2 text-xs font-black uppercase tracking-[0.12em] text-cyan-100 hover:bg-cyan-400/20 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        Neue Projekt-Session
+        {newSessionBusy
+          ? "Wird gestartet …"
+          : preferredAgent ? `Session mit ${preferredAgent.name} starten` : "Neue Projekt-Session"}
       </button>
     </div>
   )

--- a/frontend/src/features/chat/_pickSession.ts
+++ b/frontend/src/features/chat/_pickSession.ts
@@ -1,0 +1,26 @@
+import type { Session } from "./types"
+
+/**
+ * Wählt die Session, die beim (Neu-)Laden geöffnet wird.
+ *
+ * Mit bevorzugtem Agenten (Projekt-Cockpit: der links angeklickte) gewinnt
+ * dessen NEUESTE eigene Session. Ohne diese Filterung landete jeder Klick in
+ * der neuesten Session des Projekts — bei gemischten Sessions (Projekt-Agent
+ * + Spezialisten) also immer im selben Chat, egal wen man anklickt.
+ *
+ * Hat der Agent noch keine Session, wird bewusst `null` zurückgegeben: der
+ * Chat zeigt dann den Leerzustand mit „Session mit <Agent> starten“, statt
+ * einen fremden Agenten zu öffnen.
+ *
+ * Ohne preferredAgentId bleibt das alte Verhalten (neueste Session) — die
+ * normale Chat-Seite setzt die Prop nicht und ist damit unverändert.
+ *
+ * Erwartet die Liste vorsortiert nach updated_at DESC (so liefert sie
+ * `list_for_user` in core/src/hydrahive/db/sessions.py).
+ */
+export function pickSessionFor(sessions: Session[], preferredAgentId: string | null): string | null {
+  if (sessions.length === 0) return null
+  if (!preferredAgentId) return sessions[0].id
+  const own = sessions.filter((s) => s.agent_id === preferredAgentId)
+  return own.length > 0 ? own[0].id : null
+}

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -19,6 +19,7 @@ import { ProjectServersOverlay } from "./project/ProjectServersOverlay"
 import { ProjectMountsOverlay } from "./project/ProjectMountsOverlay"
 import { ProjectInsightsOverlay, type ProjectInsightView } from "./project/ProjectInsightsOverlay"
 import { ProjectAgentsPanel } from "./project/ProjectAgentsPanel"
+import { useProjectSessionStarter } from "./project/useProjectSessionStarter"
 import { ProjectAiSettingsPanel } from "./project/ProjectAiSettingsPanel"
 import { CockpitUsagePanel } from "./project/CockpitUsagePanel"
 import { ProjectGitSummary } from "./project/ProjectGitSummary"
@@ -79,6 +80,17 @@ export function ProjectCockpitPage() {
     const known = (id: string | null) => (id && projects.some((p) => p.id === id) ? id : null)
     return known(selectedProjectId) ?? known(prefs.preferences.active_project_id) ?? projects[0]?.id ?? null
   }, [selectedProjectId, prefs.preferences.active_project_id, projects])
+
+  const sessionStarter = useProjectSessionStarter(activeProjectId)
+
+  async function startSessionWithAgent(agentId: string) {
+    if (!activeProjectId) return
+    const sessionId = await sessionStarter.start(agentId)
+    if (!sessionId) return
+    setSelectedAgentByProject((cur) => ({ ...cur, [activeProjectId]: agentId }))
+    setOpenSessionRequest(sessionId)
+    setInsightView(null)
+  }
 
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null
   const projectAgentId = activeProject?.agent_id ?? null
@@ -167,7 +179,14 @@ export function ProjectCockpitPage() {
                 setSelectedAgentByProject((cur) => ({ ...cur, [activeProjectId]: agentId }))
               }}
               onEdit={setEditingAgentId}
+              onNewSession={(agentId) => { void startSessionWithAgent(agentId) }}
+              newSessionAgentId={sessionStarter.pendingAgentId}
             />
+            {sessionStarter.error && (
+              <p className="mt-2 rounded-[4px] border border-rose-500/30 bg-rose-500/[8%] px-2 py-1.5 text-xs text-rose-200">
+                {sessionStarter.error}
+              </p>
+            )}
           </CollapsibleCockpitPanel>
 
           <CollapsibleCockpitPanel

--- a/frontend/src/features/cockpit/project/ProjectAgentsPanel.tsx
+++ b/frontend/src/features/cockpit/project/ProjectAgentsPanel.tsx
@@ -1,4 +1,4 @@
-import { Pencil } from "lucide-react"
+import { Loader2, Pencil, SquarePen } from "lucide-react"
 import type { AgentBrief } from "@/features/chat/types"
 
 interface Props {
@@ -8,9 +8,13 @@ interface Props {
   selectedAgentId?: string | null
   onSelect: (agentId: string) => void
   onEdit?: (agentId: string) => void
+  /** Startet eine neue Projekt-Session mit GENAU diesem Agenten (inkl. Übergabe). */
+  onNewSession?: (agentId: string) => void
+  /** Agent-ID, für die gerade eine Session erstellt wird (Übergabe läuft). */
+  newSessionAgentId?: string | null
 }
 
-export function ProjectAgentsPanel({ agents, projectAgentId, specialistAgentIds = [], selectedAgentId, onSelect, onEdit }: Props) {
+export function ProjectAgentsPanel({ agents, projectAgentId, specialistAgentIds = [], selectedAgentId, onSelect, onEdit, onNewSession, newSessionAgentId = null }: Props) {
   const teamIds = [projectAgentId, ...specialistAgentIds].filter((id): id is string => Boolean(id))
   const shown = [...new Set(teamIds)]
     .map((id) => agents.find((agent) => agent.id === id))
@@ -23,6 +27,10 @@ export function ProjectAgentsPanel({ agents, projectAgentId, specialistAgentIds 
       {shown.map((agent) => {
         const selected = agent.id === selectedAgentId
         const isLead = agent.id === projectAgentId
+        // Während einer laufenden Übergabe alle Aktionen sperren — sonst
+        // entstehen bei Doppelklick zwei Sessions bzw. zwei Handover-Läufe.
+        const busy = newSessionAgentId !== null
+        const busyHere = newSessionAgentId === agent.id
         return (
           <div
             key={agent.id}
@@ -33,7 +41,8 @@ export function ProjectAgentsPanel({ agents, projectAgentId, specialistAgentIds 
           >
             <button
               onClick={() => onSelect(agent.id)}
-              className={["min-w-0 flex-1 px-1.5 py-1 text-left text-sm font-semibold leading-none", selected ? "text-[#69d7ff]" : "text-[#e8eef8]"].join(" ")}
+              disabled={busy}
+              className={["min-w-0 flex-1 px-1.5 py-1 text-left text-sm font-semibold leading-none disabled:cursor-not-allowed", selected ? "text-[#69d7ff]" : "text-[#e8eef8]"].join(" ")}
             >
               <span className="flex items-center gap-1.5">
                 <span className="truncate">{agent.name}</span>
@@ -43,10 +52,21 @@ export function ProjectAgentsPanel({ agents, projectAgentId, specialistAgentIds 
               </span>
               <span className="mt-1 block truncate font-mono text-[10px] font-normal text-[#8d9ab0]">{agent.llm_model || "Kein Modell zugewiesen"}</span>
             </button>
+            {onNewSession ? (
+              <button
+                onClick={() => onNewSession(agent.id)}
+                disabled={busy}
+                className="rounded-[4px] p-1.5 text-[#8d9ab0] transition-colors hover:bg-white/[8%] hover:text-[#69d7ff] disabled:cursor-not-allowed disabled:opacity-40"
+                title={`Neue Session mit ${agent.name} starten (bisherige Session wird übergeben)`}
+              >
+                {busyHere ? <Loader2 size={13} className="animate-spin" /> : <SquarePen size={13} />}
+              </button>
+            ) : null}
             {onEdit ? (
               <button
                 onClick={() => onEdit(agent.id)}
-                className="rounded-[4px] p-1.5 text-[#8d9ab0] hover:bg-white/[8%] hover:text-[#e8eef8]"
+                disabled={busy}
+                className="rounded-[4px] p-1.5 text-[#8d9ab0] hover:bg-white/[8%] hover:text-[#e8eef8] disabled:cursor-not-allowed disabled:opacity-40"
                 title={`${isLead ? "Projekt-Agent" : "Spezialist"} bearbeiten`}
               >
                 <Pencil size={13} />

--- a/frontend/src/features/cockpit/project/useProjectSessionStarter.ts
+++ b/frontend/src/features/cockpit/project/useProjectSessionStarter.ts
@@ -1,0 +1,41 @@
+import { useState } from "react"
+import { chatApi } from "@/features/chat/api"
+
+/**
+ * Startet eine neue Projekt-Session mit einem EXPLIZIT gewählten Agenten.
+ *
+ * Abgrenzung zum „Neuer Chat"-Button im Chat-Header: der nimmt den Agenten der
+ * gerade offenen Session. Hier wählt der Nutzer den Agenten bewusst im
+ * Projekt-Team-Panel — diese Wahl darf nicht überschrieben werden.
+ *
+ * Vor dem Anlegen wird die laufende Projekt-Session übergeben (handover), damit
+ * der Kontext nicht verloren geht. Serverseitig ist handover ohne Projekt ein
+ * No-Op, deshalb ist der Aufruf gefahrlos.
+ */
+export function useProjectSessionStarter(projectId: string | null) {
+  const [pendingAgentId, setPendingAgentId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function start(agentId: string): Promise<string | null> {
+    // Guard gegen Doppelklick: sonst zwei Sessions + zwei Handover-Läufe.
+    if (!projectId || pendingAgentId) return null
+    setPendingAgentId(agentId)
+    setError(null)
+    try {
+      const sessions = await chatApi.listSessions()
+      const current = sessions
+        .filter((s) => s.project_id === projectId)
+        .sort((a, b) => b.created_at.localeCompare(a.created_at))[0]
+      if (current) await chatApi.handover(current.id)
+      const created = await chatApi.createSession(agentId, undefined, projectId)
+      return created.id
+    } catch {
+      setError("Neue Session konnte nicht gestartet werden.")
+      return null
+    } finally {
+      setPendingAgentId(null)
+    }
+  }
+
+  return { start, pendingAgentId, error, clearError: () => setError(null) }
+}


### PR DESCRIPTION
## Problem

Im Projekt-Cockpit gab es keine Möglichkeit, gezielt eine neue Session mit einem **bestimmten** Projekt-Agenten zu starten.

Der vorhandene "Neuer Chat"-Button im Chat-Header wählt den Agenten so:
```ts
const agent = activeAgent ?? preferredAgent ?? …
```
`activeAgent` stammt aus der *gerade offenen Session* und gewinnt. Liegen im Projekt Sessions mehrerer Agenten (Projekt-Agent + Buddy), startet der Button daher mit dem zuletzt benutzten statt mit dem links ausgewählten Agenten. Im Agenten-Panel selbst gab es nur *Auswählen* und *Bearbeiten*.

## Lösung

**1. Button pro Agent im Team-Panel** — startet eine neue Projekt-Session mit genau diesem Agenten. Während der Übergabe sind alle Listen-Aktionen gesperrt (Doppelklick-Schutz: sonst zwei Sessions + zwei Handover-Läufe), der Spinner läuft nur beim betroffenen Agenten.

**2. `useProjectSessionStarter`** — Handover der laufenden Projekt-Session, dann `createSession` mit explizitem Agenten. Als Hook ausgelagert, damit `ProjectCockpitPage` nicht weiter wächst (Regel: ~200 Zeilen).

**3. `ChatPane`: `openSessionRequest` lädt nach.** Wichtig — ohne das öffnet die neue Session nicht: `setActiveId` wird gesetzt, aber die Session steckt noch nicht in `sessions`, und der Projekt-Guard (`ChatPane.tsx:105`) setzt `activeId` sofort wieder auf `null`. Jetzt wird bei unbekannter Session erst `loadAll()` ausgeführt.

**4. `preferredAgent` hat Vorrang** in `createPreferredSession`, damit auch der Header-Button dem ausgewählten Agenten folgt.

### Kontext bleibt erhalten
Die bisherige Session wird per `handover` übergeben (bewusste Entscheidung — Kontext geht nicht verloren). Serverseitig ist `handover` ohne Projekt ein No-Op.

## Regressionsrisiko

Gering und klar abgegrenzt: `preferredAgentId` wird **ausschließlich** vom Cockpit gesetzt. `ChatPage.tsx` übergibt es nicht → `preferredAgent` ist dort `null` → Verhalten der normalen Chat-Seite unverändert.

## Verifikation

- `tsc --noEmit` → grün
- `eslint` → **0 Errors**; Warnungen vorher 9 / nachher 9 (unverändert, Bestandscode)
- `npm run build` → grün
- `npm run check:cockpit-offline` → "Cockpit offline-first guard passed"

**Noch offen:** visueller Test im laufenden Cockpit durch till — Button sichtbar, richtiger Agent, Session öffnet rechts.
