### PR TITLE
fix(chat): Nachladen älterer Nachrichten hängt bei langen Sessions

### DIFF
--- a/frontend/src/features/chat/_LoadOlderSentinel.tsx
+++ b/frontend/src/features/chat/_LoadOlderSentinel.tsx
@@ -1,4 +1,5 @@
-import { Loader2 } from "lucide-react"
+import { useState } from "react"
+import { ChevronUp, Loader2 } from "lucide-react"
 import { useLoadOlder } from "./_useLoadOlder"
 
 interface Props {
@@ -9,16 +10,53 @@ interface Props {
 }
 
 /**
- * Unsichtbarer Anker oben im Thread. Scrollt er in den sichtbaren Bereich,
- * werden ältere Nachrichten nachgeladen (siehe useLoadOlder).
+ * Anker oben im Thread. Scrollt er in den sichtbaren Bereich, werden ältere
+ * Nachrichten nachgeladen (siehe useLoadOlder).
+ *
+ * Zeigt einen echten Ruhezustand: vorher stand hier dauerhaft „Ältere
+ * Nachrichten werden geladen …“, solange überhaupt noch ältere existierten —
+ * auch wenn gerade nichts lud. Das war als Dauer-Hänger missverständlich.
+ * Der Spinner erscheint jetzt nur zwischen Auslösen und Eintreffen.
+ *
+ * Zusätzlich ist der Anker klickbar: Falls der Scroll-Container nicht
+ * auflösbar ist (exotisches Layout), bleibt Nachladen so trotzdem möglich.
  */
 export function LoadOlderSentinel({ hasMore, onLoadMore, visibleCount }: Props) {
-  const sentinelRef = useLoadOlder(hasMore, onLoadMore, visibleCount)
+  // Zustand als "wofür wurde geladen" statt als boolean: sobald visibleCount
+  // sich ändert (Nachschub da) oder hasMore wegfällt, ist der Spinner
+  // automatisch vorbei — ohne setState-im-Effekt und ohne Hänger-Risiko,
+  // wenn ein Ladevorgang folgenlos bleibt.
+  const [pendingAt, setPendingAt] = useState<number | null>(null)
+  const loading = hasMore && pendingAt === visibleCount
+
+  const handleLoadMore = () => {
+    setPendingAt(visibleCount)
+    onLoadMore()
+  }
+
+  const sentinelRef = useLoadOlder(hasMore, handleLoadMore, visibleCount)
+
   if (!hasMore) return null
   return (
-    <div ref={sentinelRef} className="flex items-center justify-center py-3 text-xs text-[#8d9ab0]">
-      <Loader2 size={12} className="mr-2 animate-spin" />
-      Ältere Nachrichten werden geladen …
+    <div ref={sentinelRef} className="flex items-center justify-center py-3">
+      <button
+        type="button"
+        onClick={handleLoadMore}
+        disabled={loading}
+        className="flex items-center gap-2 rounded-[4px] px-2 py-1 text-xs text-[#8d9ab0] transition-colors hover:bg-white/[6%] hover:text-[#e8eef8] disabled:cursor-default disabled:hover:bg-transparent"
+      >
+        {loading ? (
+          <>
+            <Loader2 size={12} className="animate-spin" />
+            Ältere Nachrichten werden geladen …
+          </>
+        ) : (
+          <>
+            <ChevronUp size={12} />
+            Ältere Nachrichten laden
+          </>
+        )}
+      </button>
     </div>
   )
 }

--- a/frontend/src/features/chat/_useLoadOlder.ts
+++ b/frontend/src/features/chat/_useLoadOlder.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from "react"
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react"
 
 /** Nächsten scrollbaren Vorfahren finden (assistant-ui Viewport). */
 function getScrollParent(node: HTMLElement | null): HTMLElement | null {
@@ -19,6 +19,14 @@ function getScrollParent(node: HTMLElement | null): HTMLElement | null {
  *
  * `dep` ist die sichtbare Nachrichtenanzahl — ändert sie sich, korrigieren wir
  * die Scroll-Position um die neu oben eingefügte Höhe.
+ *
+ * WICHTIG (Bugfix): Der Scroll-Container wird LAZY beim Registrieren des
+ * Observers gesucht, nicht einmalig beim Mount. Beim ersten Render ist die
+ * Nachrichtenliste noch leer → hasMore=false → der Sentinel rendert `null` →
+ * die Ref ist leer. Ein Mount-Effekt mit leerem Dep-Array hätte dann dauerhaft
+ * `null` gecached, der Observer wäre nie registriert worden und der Thread
+ * hätte beim Hochscrollen nie nachgeladen (sichtbar als dauerhaftes
+ * „Ältere Nachrichten werden geladen …“).
  */
 export function useLoadOlder(
   hasMore: boolean,
@@ -31,27 +39,49 @@ export function useLoadOlder(
   const loadMoreRef = useRef(onLoadMore)
   loadMoreRef.current = onLoadMore
 
-  useEffect(() => {
+  /** Container bei Bedarf (neu) auflösen — Ergebnis wird gecached. */
+  const resolveScrollParent = useCallback(() => {
+    if (scrollParentRef.current?.isConnected) return scrollParentRef.current
     scrollParentRef.current = getScrollParent(sentinelRef.current)
+    return scrollParentRef.current
   }, [])
 
   useEffect(() => {
     if (!hasMore) return
     const el = sentinelRef.current
-    const root = scrollParentRef.current
-    if (!el || !root) return
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          prevScrollHeight.current = root.scrollHeight
-          loadMoreRef.current()
-        }
-      },
-      { root, threshold: 0 },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [hasMore, dep])
+    if (!el) return
+
+    let observer: IntersectionObserver | null = null
+    let raf = 0
+    let attempts = 0
+
+    // Der Viewport kann eine Runde später im DOM landen (assistant-ui rendert
+    // asynchron). Deshalb ein paar Frames lang erneut versuchen, statt still
+    // aufzugeben.
+    const attach = () => {
+      const root = resolveScrollParent()
+      if (!root) {
+        if (attempts++ < 30) raf = requestAnimationFrame(attach)
+        return
+      }
+      observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            prevScrollHeight.current = root.scrollHeight
+            loadMoreRef.current()
+          }
+        },
+        { root, threshold: 0 },
+      )
+      observer.observe(el)
+    }
+    attach()
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      observer?.disconnect()
+    }
+  }, [hasMore, dep, resolveScrollParent])
 
   useLayoutEffect(() => {
     const root = scrollParentRef.current


### PR DESCRIPTION
## Symptom

In Sessions mit >50 Nachrichten lädt der Thread beim Hochscrollen nichts nach — stattdessen steht dauerhaft **„Ältere Nachrichten werden geladen …"**. Von till im laufenden Betrieb gemeldet.

## Ursache — Race beim Mount

`useChat` startet mit `messages: []` (`useChat.ts:31`). Beim ersten Render gilt also `total = 0` → `hasMore = false` → der Sentinel macht `if (!hasMore) return null` und rendert **nichts**. `sentinelRef.current` ist `null`.

Genau in diesem Render lief der Mount-Effekt:

```ts
useEffect(() => {
  scrollParentRef.current = getScrollParent(sentinelRef.current)  // → null
}, [])   // ← leeres Dep-Array: läuft NUR EINMAL
```

Da das Dep-Array leer ist, wird der Wert **nie** neu ermittelt. Sobald die Nachrichten eintreffen und der Sentinel rendern kann, bricht der Observer-Effekt still ab:

```ts
const root = scrollParentRef.current   // immer noch null
if (!el || !root) return               // stiller Abbruch, kein Log, keine Exception
```

**Der IntersectionObserver wird nie registriert.** Deshalb bewirkt Hochscrollen nichts. Und weil der Sentinel keinen Ruhezustand hatte, stand der Spinner-Text dauerhaft da — was wie ein hängender Ladevorgang aussah.

Der stille `return` erklärt auch, warum in der Browser-Konsole **kein** HydraHive-Fehler auftauchte (till hat zweimal geprüft — nur Extension-Lärm).

**Bestand seit `3f6988f6`** ("window thread to last 50 messages"). Fällt nur bei >50 Nachrichten auf, kurze Sessions waren unauffällig.

## Fix

1. **Scroll-Container lazy auflösen** beim Registrieren des Observers statt einmalig beim Mount; Cache wird per `isConnected` invalidiert.
2. **Retry über `requestAnimationFrame`** (max. 30 Frames), falls der assistant-ui-Viewport eine Runde später im DOM landet — statt still aufzugeben.
3. **Echter Ruhezustand** im Sentinel: „Ältere Nachrichten laden"; Spinner nur zwischen Auslösen und Eintreffen.
4. **Klick-Fallback**: der Anker ist klickbar, falls der Container in einem exotischen Layout nicht auflösbar ist.

Ladezustand als `pendingAt === visibleCount` statt boolean — löst sich auch, wenn ein Ladevorgang folgenlos bleibt. Ein Dauerspinner ist damit strukturell ausgeschlossen.

## Verifikation

Mount-Reihenfolge und alle Endzustände durchgespielt (Nachschub eingetroffen / Ende erreicht / folgenloser Klick / nie geklickt) — alle korrekt.

- `tsc --noEmit` → grün
- `npm run build` → grün
- `eslint` → **0 Errors**, Warnungen **1 vorher / 1 nachher** (Bestandscode, `react-hooks/refs`)
- `check:cockpit-offline` → passed

**Noch offen:** Praxistest durch till in der langen Session (306 bzw. 1223 Nachrichten) — scrollen muss nachladen, Text darf nicht mehr dauerhaft "wird geladen" zeigen.
