### PR TITLE
fix(llm): provider-fremde Blocks nicht an Anthropic/MiniMax senden

### DIFF
--- a/core/src/hydrahive/runner/_anthropic_payload.py
+++ b/core/src/hydrahive/runner/_anthropic_payload.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 from hydrahive.llm import client as llm_client
+from hydrahive.runner._anthropic_sanitize import strip_foreign_blocks
 
 
 def cache_control(ttl: str) -> dict:
@@ -119,9 +120,14 @@ def build_anthropic_kwargs(
     if volatile_system:
         system_blocks.append({"type": "text", "text": volatile_system})
 
+    # Provider-fremde Blocks (z.B. codex_reasoning aus einer vorher über Codex
+    # gelaufenen Session) VOR dem Cache-Breakpoint entfernen — sonst landet der
+    # Breakpoint womöglich auf einem Block, den wir gleich wegwerfen.
+    clean_messages = strip_foreign_blocks(messages)
+
     kwargs: dict[str, Any] = {
         "model": model,
-        "messages": with_cache_breakpoint(messages, ttl=cache_ttl),
+        "messages": with_cache_breakpoint(clean_messages, ttl=cache_ttl),
         "temperature": temperature,
         "max_tokens": max_tokens,
     }
@@ -150,7 +156,8 @@ def build_minimax_kwargs(
         base_url=llm_client.MINIMAX_BASE_URL, api_key=api_key, timeout=300.0,
         default_headers={"Authorization": f"Bearer {api_key}"},
     )
-    messages, tools = strip_minimax_cache_control(messages, tools)
+    # Gleiches Format wie Anthropic → dieselben fremden Blocks müssen raus.
+    messages, tools = strip_minimax_cache_control(strip_foreign_blocks(messages), tools)
     kwargs: dict[str, Any] = {
         "model": model, "messages": messages,
         "temperature": temperature, "max_tokens": max_tokens,

--- a/core/src/hydrahive/runner/_anthropic_sanitize.py
+++ b/core/src/hydrahive/runner/_anthropic_sanitize.py
@@ -1,0 +1,101 @@
+"""Provider-fremde Content-Blocks aus Anthropic-Messages entfernen.
+
+Hintergrund: Sessions können das Modell wechseln. Läuft eine Session zuerst
+über den Codex-Provider und danach über Anthropic, liegen in der History
+Blocks vom Typ ``codex_reasoning`` (opaker Provider-State, siehe
+_codex_provider.py). Anthropic kennt diesen Typ nicht und lehnt die komplette
+Anfrage ab::
+
+    400 invalid_request_error — messages.2.content.0: Input tag
+    'codex_reasoning' found using 'type' does not match any of the expected
+    tags: 'text', 'thinking', 'tool_use', 'tool_result', …
+
+Der Codex-Pfad übersetzt seine eigenen Blocks korrekt zurück
+(_codex_convert.py) und der LiteLLM-Pfad verwirft sie beim Mapping auf das
+OpenAI-Format. Nur der Anthropic-Pfad reichte sie ungefiltert durch.
+
+Gefiltert wird beim SENDEN, nicht beim Speichern: die Blocks bleiben in der
+DB erhalten (Codex braucht sie für Reasoning-Kontinuität), sie werden nur
+nicht an Anthropic geschickt. Dadurch heilen auch bestehende Sessions sofort.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Block-Typen, die die Anthropic Messages-API in `messages[].content`
+# akzeptiert. Alles andere ist Provider-State fremder Backends und muss raus.
+# Quelle: Fehlermeldung der API (Liste der "expected tags").
+ANTHROPIC_BLOCK_TYPES = frozenset({
+    "bash_code_execution_tool_result",
+    "code_execution_tool_result",
+    "connector_text",
+    "container_upload",
+    "document",
+    "image",
+    "mid_conv_system",
+    "redacted_thinking",
+    "search_result",
+    "server_tool_use",
+    "text",
+    "text_editor_code_execution_tool_result",
+    "thinking",
+    "tool_result",
+    "tool_search_tool_result",
+    "tool_use",
+    "web_fetch_tool_result",
+    "web_search_tool_result",
+})
+
+
+def strip_foreign_blocks(messages: list[dict]) -> list[dict]:
+    """Entfernt Blocks, die Anthropic nicht kennt.
+
+    Fällt eine Message dadurch komplett leer, wird sie ganz weggelassen —
+    Anthropic lehnt leere ``content``-Listen ebenso mit 400 ab. In der DB
+    existiert dieser Fall real (Assistant-Turn, der nur aus einem
+    ``codex_reasoning``-Block besteht), deshalb ist das kein Theoriefall.
+
+    String-Content (alte API-Form) bleibt unangetastet.
+    """
+    out: list[dict] = []
+    dropped_types: set[str] = set()
+    dropped_messages = 0
+
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            out.append(msg)
+            continue
+
+        kept: list = []
+        for block in content:
+            if not isinstance(block, dict):
+                kept.append(block)
+                continue
+            btype = block.get("type")
+            if btype in ANTHROPIC_BLOCK_TYPES:
+                kept.append(block)
+            else:
+                dropped_types.add(str(btype))
+
+        if kept:
+            out.append({**msg, "content": kept})
+        elif content:
+            # Message ist durch das Filtern leer geworden → weglassen statt
+            # mit content=[] zu senden (sonst erneut 400).
+            dropped_messages += 1
+        else:
+            # War schon vorher leer — unverändert durchreichen, damit wir
+            # bestehendes Verhalten nicht still ändern.
+            out.append(msg)
+
+    if dropped_types:
+        logger.info(
+            "Anthropic-Payload: %d provider-fremde Block-Typen entfernt (%s)%s",
+            len(dropped_types),
+            ", ".join(sorted(dropped_types)),
+            f"; {dropped_messages} leer gewordene Message(s) weggelassen" if dropped_messages else "",
+        )
+    return out

--- a/core/tests/test_anthropic_strip_foreign_blocks.py
+++ b/core/tests/test_anthropic_strip_foreign_blocks.py
@@ -1,0 +1,119 @@
+"""Provider-fremde Blocks dürfen nicht an Anthropic/MiniMax gehen.
+
+Regression: Wechselte eine Session vom Codex-Provider auf Claude, gingen
+``codex_reasoning``-Blocks aus der History ungefiltert mit und Anthropic
+lehnte JEDEN weiteren Turn mit HTTP 400 ab ("Input tag 'codex_reasoning'
+… does not match any of the expected tags"). Betraf reale Sessions —
+Fehler in errors_log am 20.07., 24.07., 26.07. und 30.07.2026.
+"""
+from __future__ import annotations
+
+from hydrahive.runner._anthropic_payload import (
+    build_anthropic_kwargs,
+    build_minimax_kwargs,
+)
+from hydrahive.runner._anthropic_sanitize import strip_foreign_blocks
+
+_CODEX = {"type": "codex_reasoning", "encrypted_content": "opaque", "model": "openai-codex/gpt-5.6-sol"}
+
+
+def _types(messages: list[dict]) -> list[str]:
+    return [b.get("type") for m in messages for b in m["content"] if isinstance(b, dict)]
+
+
+def test_codex_reasoning_wird_entfernt():
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [_CODEX, {"type": "text", "text": "antwort"}]},
+    ]
+    out = strip_foreign_blocks(msgs)
+    assert "codex_reasoning" not in _types(out)
+    # Der legitime Text-Block bleibt erhalten
+    assert {"type": "text", "text": "antwort"} in out[1]["content"]
+
+
+def test_erlaubte_bloecke_bleiben_unveraendert():
+    msgs = [
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "t"},
+            {"type": "thinking", "thinking": "…", "signature": "s"},
+            {"type": "tool_use", "id": "1", "name": "n", "input": {}},
+        ]},
+        {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "1", "content": "ok"}]},
+    ]
+    assert strip_foreign_blocks(msgs) == msgs
+
+
+def test_leer_gewordene_message_wird_weggelassen():
+    """Realer DB-Fall: Assistant-Turn, der NUR aus codex_reasoning besteht.
+
+    Naiv gefiltert bliebe content=[] übrig — das lehnt Anthropic ebenfalls
+    mit 400 ab. Die Message muss deshalb ganz verschwinden.
+    """
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [_CODEX]},
+        {"role": "user", "content": [{"type": "text", "text": "weiter"}]},
+    ]
+    out = strip_foreign_blocks(msgs)
+    assert len(out) == 2
+    assert all(m["content"] for m in out), "keine Message darf leeren content haben"
+    assert [m["role"] for m in out] == ["user", "user"]
+
+
+def test_string_content_bleibt_unangetastet():
+    msgs = [{"role": "user", "content": "alte API-Form"}]
+    assert strip_foreign_blocks(msgs) == msgs
+
+
+def test_vorher_schon_leere_message_bleibt():
+    """Kein stiller Verhaltenswechsel für bereits leere Messages."""
+    msgs = [{"role": "user", "content": []}]
+    assert strip_foreign_blocks(msgs) == msgs
+
+
+def test_build_anthropic_kwargs_sendet_keine_fremden_bloecke():
+    """End-to-End: der 400er darf gar nicht erst entstehen können."""
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [_CODEX, {"type": "text", "text": "a"}]},
+        {"role": "user", "content": [{"type": "text", "text": "und jetzt claude"}]},
+    ]
+    _client, kwargs = build_anthropic_kwargs(
+        key="sk-plain", model="claude-opus-5", system_prompt="SYS",
+        volatile_system=None, summary_system=None, cache_ttl="1h",
+        messages=msgs, tools=[], temperature=1.0, max_tokens=100,
+        reasoning_effort=None,
+    )
+    assert "codex_reasoning" not in _types(kwargs["messages"])
+
+
+def test_build_minimax_kwargs_sendet_keine_fremden_bloecke():
+    """MiniMax spricht dasselbe Format — gleiche Filterung nötig."""
+    msgs = [
+        {"role": "assistant", "content": [_CODEX, {"type": "text", "text": "a"}]},
+    ]
+    _client, kwargs = build_minimax_kwargs(
+        api_key="k", model="MiniMax-M2", system_prompt="SYS",
+        volatile_system=None, summary_system=None,
+        messages=msgs, tools=[], temperature=1.0, max_tokens=100,
+        reasoning_effort=None,
+    )
+    assert "codex_reasoning" not in _types(kwargs["messages"])
+
+
+def test_cache_breakpoint_landet_auf_erlaubtem_block():
+    """Der Breakpoint darf nicht auf einem Block sitzen, der entfernt wird."""
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "a"}, _CODEX]},
+    ]
+    _client, kwargs = build_anthropic_kwargs(
+        key="sk-plain", model="claude-opus-5", system_prompt="SYS",
+        volatile_system=None, summary_system=None, cache_ttl="5m",
+        messages=msgs, tools=[], temperature=1.0, max_tokens=100,
+        reasoning_effort=None,
+    )
+    last_block = kwargs["messages"][-1]["content"][-1]
+    assert last_block["type"] == "text"
+    assert "cache_control" in last_block


### PR DESCRIPTION
## Symptom

Von till gemeldet: *„ich bekomme in den Projekt-Agenten LLM-Fehler, egal was ich einstelle"*.

Wechselte eine Session vom Codex-Provider auf ein Claude-Modell, brach **jeder** weitere Turn ab:

```
400 invalid_request_error — messages.2.content.0: Input tag 'codex_reasoning'
found using 'type' does not match any of the expected tags: 'text', 'thinking',
'tool_use', 'tool_result', …
```

## Ursache

`_codex_provider.py:156` speichert opaken Provider-State als Block vom Typ `codex_reasoning` — nötig für Reasoning-Kontinuität und Prompt-Cache-Effizienz.

- Der **Codex-Pfad** übersetzt ihn korrekt zurück (`_codex_convert.py:92`) ✓
- Der **LiteLLM-Pfad** verwirft ihn beim OpenAI-Mapping ✓
- Der **Anthropic-Pfad** reichte ihn ungefiltert durch ✗ — `with_cache_breakpoint` kopiert die Messages 1:1

Weil die Blocks **dauerhaft in der History** liegen, half kein Modellwechsel: die Session blieb kaputt. Das erklärt das „egal was ich einstelle".

**Umfang:** 248 Sessions / 7.212 Nachrichten in der DB. Fehler in `errors_log` am 20.07., 24.07., 26.07. und 30.07.2026 — alle `source=runner.llm_call`, alle beim Wechsel auf ein Claude-Modell.

## Fix

`_anthropic_sanitize.strip_foreign_blocks` filtert **beim Senden** gegen die Positivliste der von Anthropic akzeptierten Block-Typen. In der DB bleiben die Blocks erhalten (Codex braucht sie) — dadurch **heilen bestehende Sessions sofort, ohne Migration**.

Drei Details, die nicht offensichtlich sind:

1. **Leer gefallene Messages werden ganz weggelassen.** Ein naiver Filter hätte `content=[]` hinterlassen — das lehnt Anthropic ebenfalls mit 400 ab, der Bug wäre nur durch einen anderen ersetzt worden. Der Fall ist **real**: eine Assistant-Nachricht in der DB (`019f7525-477f…`) besteht ausschließlich aus einem `codex_reasoning`-Block.
2. **Bereits vorher leere Messages bleiben unverändert** — kein stiller Verhaltenswechsel. (Altbestand separat als Task erfasst.)
3. **Gefiltert wird VOR `with_cache_breakpoint`**, sonst könnte der Cache-Breakpoint auf einem Block landen, der danach entfernt wird.

**MiniMax ist mitgefixt** — spricht dasselbe Format und hatte dieselbe Lücke.

## Verifikation

- **8 neue Tests**, alle grün
- **Rot-Grün belegt**: mit deaktiviertem Fix schlagen genau die 3 End-to-End-Tests fehl, mit Fix alle grün
- **Volle Suite: 2028 passed**, keine Regression
- `ruff` sauber, keine zirkulären Imports, beide Dateien < 200 Zeilen
- **Gegen echte Daten geprüft**: Session `019fb1d0` (die heute früh mit 400 abbrach) — 6 `codex_reasoning`-Blocks vorher, **0 nachher**