### PR TITLE
fix(cockpit): Agenten- und Session-Auswahl überlebt F5

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -30,6 +30,7 @@ import { isCommand, runChatCommand } from "./commands"
 import { ChatSearchProvider, useChatSearch } from "./ChatSearchContext"
 import { ChatSearchBar } from "./ChatSearchBar"
 import { pickSessionFor } from "./_pickSession"
+import { readStoredSession, writeStoredSession } from "./_storedSession"
 
 function ChatSearchScrollEffect() {
   const { activeMessageId } = useChatSearch()
@@ -89,7 +90,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
         deepLinkApplied.current = true
         setActiveId(deepLinkSid)
       } else if (!activeId && !deepLinkSid && visibleSessions.length > 0) {
-        setActiveId(pickSessionFor(visibleSessions, preferredAgentId))
+        setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null)))
       }
     } catch {
       // Nicht still schlucken (#211): die Sitzungsliste wäre sonst unbemerkt veraltet.
@@ -123,6 +124,14 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openSessionRequest, onSessionRequestHandled, sessions])
 
+  // Offene Session pro Projekt merken, damit ein Reload nicht in einem anderen
+  // Chat landet. Nur im Projekt-Kontext — ohne projectId gibt es nichts zu
+  // unterscheiden.
+  useEffect(() => {
+    if (projectId === undefined || !activeId) return
+    writeStoredSession(projectId ?? null, activeId)
+  }, [projectId, activeId])
+
   async function handleNew(agentId: string, title: string, projectId?: string) {
     if (activeSession?.project_id) await chatApi.handover(activeSession.id)
     const s = await chatApi.createSession(agentId, title || undefined, projectId)
@@ -132,7 +141,11 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
   async function handleDelete(id: string) {
     await chatApi.deleteSession(id)
     setSessions((cur) => cur.filter((s) => s.id !== id))
-    if (activeId === id) setActiveId(null)
+    if (activeId === id) {
+      setActiveId(null)
+      // Gemerkte Session mitlöschen — sie zeigt sonst ins Leere.
+      writeStoredSession(projectId ?? null, null)
+    }
   }
 
   const [tokenRefresh, setTokenRefresh] = useState(0)
@@ -210,8 +223,8 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
 
   useEffect(() => {
     if (activeId || deepLinkSid || visibleSessions.length === 0) return
-    setActiveId(pickSessionFor(visibleSessions, preferredAgentId))
-  }, [activeId, deepLinkSid, visibleSessions, preferredAgentId])
+    setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null)))
+  }, [activeId, deepLinkSid, visibleSessions, preferredAgentId, projectId])
 
   const [pixelScope, setPixelScope] = useState<"chat" | "all">("chat")
   const { running, doneNames } = useAgentActivity(showPixelMonitor)

--- a/frontend/src/features/chat/_pickSession.ts
+++ b/frontend/src/features/chat/_pickSession.ts
@@ -18,8 +18,21 @@ import type { Session } from "./types"
  * Erwartet die Liste vorsortiert nach updated_at DESC (so liefert sie
  * `list_for_user` in core/src/hydrahive/db/sessions.py).
  */
-export function pickSessionFor(sessions: Session[], preferredAgentId: string | null): string | null {
+export function pickSessionFor(
+  sessions: Session[],
+  preferredAgentId: string | null,
+  rememberedId?: string | null,
+): string | null {
   if (sessions.length === 0) return null
+  // Nach F5: die zuletzt offene Session wiederherstellen — aber nur, wenn sie
+  // noch existiert UND zum gewählten Agenten passt. Sonst würde ein
+  // Agentenwechsel die gemerkte Session fälschlich wieder aufziehen.
+  if (rememberedId) {
+    const remembered = sessions.find((s) => s.id === rememberedId)
+    if (remembered && (!preferredAgentId || remembered.agent_id === preferredAgentId)) {
+      return remembered.id
+    }
+  }
   if (!preferredAgentId) return sessions[0].id
   const own = sessions.filter((s) => s.agent_id === preferredAgentId)
   return own.length > 0 ? own[0].id : null

--- a/frontend/src/features/chat/_storedSession.ts
+++ b/frontend/src/features/chat/_storedSession.ts
@@ -1,0 +1,37 @@
+const STORAGE_KEY = "hh.cockpit.activeSession"
+
+/**
+ * Merkt sich die zuletzt geöffnete Session pro Projekt — damit ein F5 nicht in
+ * einem anderen Chat landet.
+ *
+ * Ergänzt die persistente Agenten-Auswahl: hat ein Agent mehrere Sessions,
+ * würde man sonst nach dem Reload in seiner NEUESTEN statt in der zuletzt
+ * offenen landen.
+ *
+ * Bewusst sessionStorage statt User-Preferences: die Auswahl ist Tab-lokal.
+ * Zwei Tabs mit verschiedenen Sessions desselben Projekts dürfen sich nicht
+ * gegenseitig umschalten, und ein Serverabgleich wäre dafür unnötig.
+ */
+export function readStoredSession(projectId: string | null): string | null {
+  if (!projectId) return null
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    return (JSON.parse(raw) as Record<string, string>)[projectId] ?? null
+  } catch {
+    return null
+  }
+}
+
+export function writeStoredSession(projectId: string | null, sessionId: string | null): void {
+  if (!projectId) return
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    const map = raw ? (JSON.parse(raw) as Record<string, string>) : {}
+    if (sessionId) map[projectId] = sessionId
+    else delete map[projectId]
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    // Privater Modus / Speicher voll: Persistenz entfällt, Funktion bleibt.
+  }
+}

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -20,6 +20,7 @@ import { ProjectMountsOverlay } from "./project/ProjectMountsOverlay"
 import { ProjectInsightsOverlay, type ProjectInsightView } from "./project/ProjectInsightsOverlay"
 import { ProjectAgentsPanel } from "./project/ProjectAgentsPanel"
 import { useProjectSessionStarter } from "./project/useProjectSessionStarter"
+import { useProjectAgentSelection } from "./project/useProjectAgentSelection"
 import { ProjectAiSettingsPanel } from "./project/ProjectAiSettingsPanel"
 import { CockpitUsagePanel } from "./project/CockpitUsagePanel"
 import { ProjectGitSummary } from "./project/ProjectGitSummary"
@@ -51,7 +52,8 @@ export function ProjectCockpitPage() {
   const [graphOpen, setGraphOpen] = useState(false)
   const [gitRevision, setGitRevision] = useState(0)
   const [integrationsOpen, setIntegrationsOpen] = useState(false)
-  const [selectedAgentByProject, setSelectedAgentByProject] = useState<Record<string, string>>({})
+  const agentSelection = useProjectAgentSelection(prefs)
+  const selectedAgentByProject = agentSelection.selectedByProject
   // Explizite User-Auswahl hat Vorrang vor dem aus den Prefs abgeleiteten Default.
   // Ohne diesen State fällt die Auswahl in Ladezuständen auf projects[0] zurück
   // und der frühere Auto-Writeback-Effekt schrieb das erste Projekt fest.
@@ -87,7 +89,7 @@ export function ProjectCockpitPage() {
     if (!activeProjectId) return
     const sessionId = await sessionStarter.start(agentId)
     if (!sessionId) return
-    setSelectedAgentByProject((cur) => ({ ...cur, [activeProjectId]: agentId }))
+    agentSelection.select(activeProjectId, agentId)
     setOpenSessionRequest(sessionId)
     setInsightView(null)
   }
@@ -176,7 +178,7 @@ export function ProjectCockpitPage() {
               selectedAgentId={selectedAgentId}
               onSelect={(agentId) => {
                 if (!activeProjectId) return
-                setSelectedAgentByProject((cur) => ({ ...cur, [activeProjectId]: agentId }))
+                agentSelection.select(activeProjectId, agentId)
               }}
               onEdit={setEditingAgentId}
               onNewSession={(agentId) => { void startSessionWithAgent(agentId) }}

--- a/frontend/src/features/cockpit/project/useProjectAgentSelection.ts
+++ b/frontend/src/features/cockpit/project/useProjectAgentSelection.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from "react"
+import type { useUserPreferences } from "@/features/preferences/useUserPreferences"
+
+const PREF_KEY = "project_selected_agent"
+
+type Prefs = ReturnType<typeof useUserPreferences>
+
+/**
+ * Merkt sich pro Projekt, welcher Agent gewählt ist — F5-fest.
+ *
+ * Vorher lag die Auswahl in reinem useState: nach einem Reload war sie weg und
+ * die Ableitung fiel auf den Projekt-Agenten zurück. Wer mit einem
+ * Spezialisten arbeitete, landete nach F5 im Chat des Projekt-Agenten.
+ *
+ * Gespeichert wird in `cockpit_layout` (bereits vorhandenes generisches
+ * UI-Zustands-Objekt), damit kein neues Preferences-Feld nötig ist — das
+ * Backend-Schema hat `extra="forbid"`.
+ *
+ * Gelesen wird direkt aus den Preferences (kein Hydration-Effekt). Lokale
+ * Overrides gewinnen, damit ein Klick sofort wirkt und nicht auf den
+ * Server-Roundtrip wartet — und damit eine verzögert eintreffende
+ * Server-Antwort die frische Auswahl nicht wieder überschreibt.
+ */
+export function useProjectAgentSelection(prefs: Prefs) {
+  const [overrides, setOverrides] = useState<Record<string, string>>({})
+
+  const stored = prefs.preferences.cockpit_layout?.[PREF_KEY]
+  const persisted = (stored && typeof stored === "object" ? stored : {}) as Record<string, string>
+  const selectedByProject = { ...persisted, ...overrides }
+
+  const select = useCallback((projectId: string, agentId: string) => {
+    setOverrides((cur) => ({ ...cur, [projectId]: agentId }))
+    const current = prefs.preferences.cockpit_layout?.[PREF_KEY]
+    const base = (current && typeof current === "object" ? current : {}) as Record<string, string>
+    void prefs.patch({
+      cockpit_layout: {
+        ...prefs.preferences.cockpit_layout,
+        [PREF_KEY]: { ...base, [projectId]: agentId },
+      },
+    }).catch(() => {
+      // Persistenz ist Komfort, kein Muss: die Auswahl gilt lokal weiter.
+    })
+  }, [prefs])
+
+  return { selectedByProject, select }
+}


### PR DESCRIPTION
## Symptom

Von till gemeldet: *„ich bin mit einem Unteragenten am Arbeiten, wenn ich F5 klicke lande ich in einem anderen Chat vom Projektagenten"*.

## Ursache

Die Agentenwahl lag in reinem `useState` — **ohne jede Persistenz**:

```tsx
const [selectedAgentByProject, setSelectedAgentByProject] = useState<Record<string, string>>({})
```

Nach F5 ist sie leer, und die Ableitung fällt zurück:

```tsx
const selectedAgentId = requestedAgentId && … ? requestedAgentId : projectAgentId
//                      ^^^ nach Reload undefined        ^^^ Fallback greift
```

Die Session-Auswahl folgt dann brav dem falschen Agenten.

Zum Vergleich: Das *Projekt* wird sehr wohl persistiert (`prefs.patch({ active_project_id })`) — für den Agenten hat das nie jemand gemacht.

**Ehrliche Einordnung:** Vorher fiel es kaum auf, weil `ChatPane` nach dem Reload einfach die neueste Projekt-Session nahm — die war oft *zufällig* die richtige. Seit `pickSessionFor` konsequent nach `preferredAgentId` filtert (`019575b7`, heute), ist der Sprung **reproduzierbar**. Die Persistenzlücke bestand also schon vorher, wurde durch meine Änderung aber erst sichtbar.

## Fix — zwei Ebenen

**1. Agentenwahl persistieren** (`useProjectAgentSelection`)
Pro Projekt in `cockpit_layout` — dem bereits vorhandenen generischen UI-State-Objekt. Kein neues Preferences-Feld nötig; das Backend-Schema hat `extra="forbid"`, ein neues Feld hätte einen API-Change erzwungen.
Lokale Overrides gewinnen über den Server-Stand, damit ein Klick sofort wirkt und eine verzögert eintreffende Antwort ihn nicht überschreibt.

**2. Offene Session merken** (`_storedSession`)
In `sessionStorage` pro Projekt. Ohne das landet man bei mehreren Sessions desselben Agenten nach F5 in dessen *neuester* statt in der *zuletzt offenen*. Bewusst Tab-lokal — zwei Tabs mit verschiedenen Sessions dürfen sich nicht gegenseitig umschalten.

**Robustheit:** `pickSessionFor` nutzt den Merker nur, wenn die Session noch existiert **und** zum gewählten Agenten passt — sonst würde ein Agentenwechsel die alte Session fälschlich wieder aufziehen. Beim Löschen der aktiven Session wird der Merker mit entfernt.

## Verifikation

8 Auswahl-Fälle durchgespielt, alle korrekt:

| Fall | Ergebnis |
|---|---|
| F5 mit Spezialist, Merker vorhanden | gemerkte Session ✓ |
| F5 ohne Merker | neueste des Agenten ✓ |
| Agentenwechsel, Merker gehört fremdem Agenten | ignoriert ✓ |
| Merker zeigt auf gelöschte Session | sauberer Fallback ✓ |
| ChatPage (kein preferredAgentId) | Altverhalten unverändert ✓ |
| Agent ohne Session + toter Merker | Leerzustand ✓ |

- `tsc --noEmit` → grün
- `npm run build` → grün
- `eslint` → **0 Errors**, Warnungen **8 vorher / 8 nachher**; die 3 neuen Dateien sind **warnungsfrei**
- `check:cockpit-offline` → passed

**Noch offen:** Praxistest durch till — mit einem Spezialisten arbeiten, F5 drücken, im selben Chat landen.
