### PR TITLE
fix(cockpit): F5 landet weiterhin im falschen Chat — Lade-Race behoben

### DIFF
--- a/frontend/src/features/chat/ChatPane.tsx
+++ b/frontend/src/features/chat/ChatPane.tsx
@@ -48,13 +48,15 @@ interface ChatPaneProps {
   projectId?: string | null
   showSidePanels?: boolean
   preferredAgentId?: string | null
+  /** true = der Agent wurde bewusst gewählt (nicht bloß Fallback beim Laden). */
+  agentSelectionExplicit?: boolean
   /** Von außen angeforderte Session in-place öffnen (z. B. Klick im Auswerten-Panel). */
   openSessionRequest?: string | null
   /** Wird aufgerufen, sobald openSessionRequest angewendet wurde (Parent kann zurücksetzen). */
   onSessionRequestHandled?: () => void
 }
 
-export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true, preferredAgentId = null, openSessionRequest = null, onSessionRequestHandled }: ChatPaneProps) {
+export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true, preferredAgentId = null, agentSelectionExplicit = false, openSessionRequest = null, onSessionRequestHandled }: ChatPaneProps) {
   const { t } = useTranslation("chat")
   const deepLinkApplied = useRef(false)
 
@@ -90,7 +92,7 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
         deepLinkApplied.current = true
         setActiveId(deepLinkSid)
       } else if (!activeId && !deepLinkSid && visibleSessions.length > 0) {
-        setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null)))
+        setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null), { agentExplicit: agentSelectionExplicit }))
       }
     } catch {
       // Nicht still schlucken (#211): die Sitzungsliste wäre sonst unbemerkt veraltet.
@@ -223,8 +225,8 @@ export function ChatPane({ deepLinkSid = null, projectId, showSidePanels = true,
 
   useEffect(() => {
     if (activeId || deepLinkSid || visibleSessions.length === 0) return
-    setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null)))
-  }, [activeId, deepLinkSid, visibleSessions, preferredAgentId, projectId])
+    setActiveId(pickSessionFor(visibleSessions, preferredAgentId, readStoredSession(projectId ?? null), { agentExplicit: agentSelectionExplicit }))
+  }, [activeId, deepLinkSid, visibleSessions, preferredAgentId, projectId, agentSelectionExplicit])
 
   const [pixelScope, setPixelScope] = useState<"chat" | "all">("chat")
   const { running, doneNames } = useAgentActivity(showPixelMonitor)

--- a/frontend/src/features/chat/_pickSession.ts
+++ b/frontend/src/features/chat/_pickSession.ts
@@ -22,17 +22,27 @@ export function pickSessionFor(
   sessions: Session[],
   preferredAgentId: string | null,
   rememberedId?: string | null,
+  opts?: { agentExplicit?: boolean },
 ): string | null {
   if (sessions.length === 0) return null
-  // Nach F5: die zuletzt offene Session wiederherstellen — aber nur, wenn sie
-  // noch existiert UND zum gewählten Agenten passt. Sonst würde ein
-  // Agentenwechsel die gemerkte Session fälschlich wieder aufziehen.
+
+  // Nach F5 die zuletzt offene Session wiederherstellen.
+  //
+  // Der Agent-Abgleich ist bewusst an `agentExplicit` gekoppelt: Nur wenn die
+  // Agentenwahl WIRKLICH vom Nutzer stammt, darf ein abweichender Merker
+  // verworfen werden (sonst zöge ein Agentenwechsel die alte Session wieder
+  // auf). Stammt der Agent dagegen nur aus dem Fallback — etwa weil die
+  // Preferences noch laden —, gewinnt der Merker: sonst verwirft ausgerechnet
+  // die Schutzprüfung die korrekt gemerkte Session und öffnet den Chat des
+  // Projekt-Agenten.
   if (rememberedId) {
     const remembered = sessions.find((s) => s.id === rememberedId)
-    if (remembered && (!preferredAgentId || remembered.agent_id === preferredAgentId)) {
-      return remembered.id
+    if (remembered) {
+      const agentMismatch = Boolean(preferredAgentId) && remembered.agent_id !== preferredAgentId
+      if (!agentMismatch || !opts?.agentExplicit) return remembered.id
     }
   }
+
   if (!preferredAgentId) return sessions[0].id
   const own = sessions.filter((s) => s.agent_id === preferredAgentId)
   return own.length > 0 ? own[0].id : null

--- a/frontend/src/features/cockpit/ProjectCockpitPage.tsx
+++ b/frontend/src/features/cockpit/ProjectCockpitPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
+import { Loader2 } from "lucide-react"
 import { ChatPane } from "@/features/chat/ChatPane"
 import { chatApi } from "@/features/chat/api"
 import type { AgentBrief } from "@/features/chat/types"
@@ -227,12 +228,25 @@ export function ProjectCockpitPage() {
         </aside>
 
         <main className="min-h-0 overflow-hidden rounded-[4px] border border-[#2a364b] bg-[#151c2b]">
-          {activeProjectId ? (
+          {/*
+            Erst rendern, wenn die Preferences geladen sind. Sonst mountet die
+            ChatPane mit dem noch leeren Default (selectedAgentId fällt auf den
+            Projekt-Agenten zurück), lädt Sessions für den FALSCHEN Agenten, und
+            wird beim Eintreffen der Preferences per key-Wechsel neu gemountet.
+            Genau dieses Rennen ließ nach F5 den Chat des Projekt-Agenten
+            aufgehen statt der zuletzt offenen Spezialisten-Session.
+          */}
+          {prefs.loading || loading ? (
+            <div className="flex h-full items-center justify-center text-sm text-[#8d9ab0]">
+              <Loader2 size={14} className="mr-2 animate-spin" /> Arbeitsbereich wird geladen …
+            </div>
+          ) : activeProjectId ? (
             <ChatPane
               key={`${activeProjectId}:${selectedAgentId}:${selectedAgentModel}`}
               projectId={activeProjectId}
               showSidePanels={false}
               preferredAgentId={selectedAgentId}
+              agentSelectionExplicit={Boolean(requestedAgentId)}
               openSessionRequest={openSessionRequest}
               onSessionRequestHandled={() => setOpenSessionRequest(null)}
             />


### PR DESCRIPTION
## Nachtrag zu #394

till nach dem Deploy: *„habe Update gemacht, immer noch das F5-Problem"*. Die Persistenz aus #394 war korrekt — sie wurde beim Laden nur wirkungslos.

## Ursache — zwei Ebenen

**1. Preferences laden asynchron, das Cockpit wartet nicht.**
`useUserPreferences` startet mit `DEFAULT_PREFS` und `loading=true`. Die ChatPane wird trotzdem sofort gerendert:

- **t0** – gespeicherte Agentenwahl noch leer → `selectedAgentId` fällt auf den Projekt-Agenten zurück → ChatPane mountet mit **falschem** `preferredAgentId` und lädt Sessions
- **t1** – Preferences treffen ein → `selectedAgentId` korrekt → `key` ändert sich → Remount, aber die Auswahl ist längst gelaufen

**2. Mein eigener Schutz aus #394 verwarf den richtigen Merker.**

```ts
if (remembered && (!preferredAgentId || remembered.agent_id === preferredAgentId))
```

Der Merker zeigte korrekt auf die Spezialisten-Session — aber `preferredAgentId` war zu dem Zeitpunkt noch der Projekt-Agent. Also: verworfen, Fallback auf dessen neueste Session.

Der Schutz gegen *„Agentenwechsel zieht alte Session auf"* hat damit die Wiederherstellung selbst zerstört. Das war mein Denkfehler in #394 — ich habe die Persistenz gebaut, aber nicht geprüft, **wann** sie beim Laden verfügbar ist.

## Fix

**1. Render-Reihenfolge:** Die ChatPane wird erst gerendert, wenn Preferences **und** Projekte/Agenten geladen sind (`prefs.loading || loading`). Damit stimmt `selectedAgentId` beim ersten Mount, der `key`-Wechsel entfällt, das Rennen existiert nicht mehr. Solange läuft ein dezenter Ladehinweis.

**2. Robuste Wiederherstellung:** `pickSessionFor` unterscheidet jetzt zwischen echter Nutzerwahl und Fallback (`opts.agentExplicit`). Nur eine **explizite** Wahl darf einen abweichenden Merker verwerfen. Stammt der Agent bloß aus dem Fallback, gewinnt der Merker.

Punkt 1 löst das Problem, Punkt 2 hält es auch dann, wenn das Timing anderswo einmal kippt — Gürtel und Hosenträger, nachdem ich hier schon einmal danebenlag.

## Verifikation

9 Fälle durchgespielt, alle korrekt:

| Fall | Erwartet | ✓ |
|---|---|---|
| **Race-Kernfall**: Fallback-Agent + fremder Merker | Merker gewinnt | ✓ |
| F5 mit geladenen Prefs, Agent explizit | gemerkte Session | ✓ |
| **Gegenprobe**: bewusster Klick auf anderen Agenten | Merker verworfen | ✓ |
| Merker zeigt auf gelöschte Session | Fallback auf Agent | ✓ |
| ChatPage (kein preferredAgentId) | Altverhalten unverändert | ✓ |
| Agent ohne Session + toter Merker | Leerzustand | ✓ |

- `tsc --noEmit` → grün · `npm run build` → grün · `check:cockpit-offline` → passed
- `eslint` → **0 Errors**, Warnungen **8 vorher / 8 nachher**

**Hinweis für den Test:** Nach dem Deploy einmal **Strg+Shift+R** — sonst hängt der Browser am alten Bundle.